### PR TITLE
On a non BTC currency, when price in sat is not null and is < 0.01 in…

### DIFF
--- a/src/lib/components/PriceTag.svelte
+++ b/src/lib/components/PriceTag.svelte
@@ -5,7 +5,6 @@
 	import IconBitcoin from './icons/IconBitcoin.svelte';
 	import IconSatoshi from './icons/IconSatoshi.svelte';
 	import type { LayoutData } from '../../routes/(app)/$types';
-	import { toSatoshis } from '$lib/utils/toSatoshis';
 
 	export let amount: number;
 	export let currency: Currency;


### PR DESCRIPTION
On a non BTC currency, when price in sat is not null and is < 0.01 in target currency, display "< 0.01" instead of "0" #338