### PR TITLE
🐛 Error page redirects on less

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@iconify-json/ant-design": "^1.1.5",
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/adapter-node": "^1.2.3",
-		"@sveltejs/kit": "^1.5.0",
+		"@sveltejs/kit": "^1.15.4",
 		"@tailwindcss/forms": "^0.5.3",
 		"@tailwindcss/typography": "^0.5.9",
 		"@types/busboy": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ devDependencies:
     specifier: ^1.2.3
     version: 1.2.3(@sveltejs/kit@1.15.4)
   '@sveltejs/kit':
-    specifier: ^1.5.0
+    specifier: ^1.15.4
     version: 1.15.4(svelte@3.58.0)(vite@4.2.1)
   '@tailwindcss/forms':
     specifier: ^0.5.3

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -102,7 +102,11 @@ export const handle = (async ({ event, resolve }) => {
 
 	const response = await resolve(event);
 
-	if (response.status >= 500 && response.headers.get('Content-Type')?.includes('text/html')) {
+	if (
+		response.status >= 500 &&
+		(!event.locals.status || event.locals.status >= 500) &&
+		response.headers.get('Content-Type')?.includes('text/html')
+	) {
 		const errorPages = await collections.cmsPages.countDocuments({
 			_id: 'error'
 		});


### PR DESCRIPTION
Now 422 errors will probably show up instead of redirecting to /error, which is very annoying