### PR TITLE
✨ Use bity's API for estimating fees

### DIFF
--- a/src/lib/types/bity.ts
+++ b/src/lib/types/bity.ts
@@ -1,0 +1,56 @@
+import type { Currency } from '$lib/types/Currency';
+
+export type BityAmount = {
+	currency: Currency;
+	amount: string;
+};
+
+export type BityPaymentMethod = 'bank_account' | 'online_instant_payment' | 'crypto_address';
+
+export type BityEstimate = {
+	input: BityAmount & {
+		object_information_optional: boolean;
+		type: BityPaymentMethod;
+		minimum_amount: string;
+	};
+	output: {
+		type: BityPaymentMethod;
+	} & BityAmount;
+	price_breakdown: {
+		customer_trading_fee: BityAmount;
+		output_transaction_cost: BityAmount;
+		'non-verified_fee': BityAmount;
+	};
+};
+
+export async function bityEstimate(params: {
+	from: Currency;
+	to: Currency;
+	amount: number;
+	paymentMethod?: BityPaymentMethod;
+}): Promise<BityEstimate> {
+	const response = await fetch('https://exchange.api.bity.com/v2/orders/estimate', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			input: {
+				currency: params.from,
+				amount: String(params.amount),
+				type: params.paymentMethod
+			},
+			output: {
+				currency: params.to
+			}
+		})
+	});
+
+	if (!response.ok) {
+		throw new Error(await response.text());
+	}
+
+	const jsonResp: BityEstimate = await response.json();
+
+	return jsonResp;
+}


### PR DESCRIPTION
@Tirodem note that cash-in & cash-out fees for now include the "non-verified" fee.

Later when bity id is defined it'll be removed (typically the 1.2% cashout fee becomes 0.8%)