### PR TITLE
👷 Add jobs to deploy to luxogood

### DIFF
--- a/.github/workflows/deploy-lxg.yml
+++ b/.github/workflows/deploy-lxg.yml
@@ -1,0 +1,41 @@
+name: deploy
+
+# push is not triggered by the sync-lxg job, so we need to trigger this manually
+# on:
+#   push:
+#     branches:
+#       - main
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-bootik:
+    runs-on: ubuntu-latest
+    environment:
+      name: lxg
+      url: ${{ vars.DEPLOY_URL }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.3.1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: |
+          pnpm install --frozen-lockfile
+          echo $DOT_ENV > .env.local
+          pnpm build
+        env:
+          DOT_ENV: ${{ vars.DOT_ENV }}
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ vars.SSH_KNOWN_HOSTS }}
+      - name: Deploy
+        run: |
+          zip -r build.zip build
+          scp build.zip ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }}:beBOP/build.zip
+          ssh ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "hostnamectl && git lfs install && cd beBOP && git remote prune origin && git fetch && git checkout $GITHUB_SHA && pnpm install && unzip -o build.zip && pm2 reload bebop"

--- a/.github/workflows/sync-lxg.yml
+++ b/.github/workflows/sync-lxg.yml
@@ -1,0 +1,12 @@
+name: sync-lxg
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync-lxg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Force-push to lxg branch, which can then be deployed
+      - run: git push --force origin HEAD:lxg


### PR DESCRIPTION
Currently two jobs to deploy to lxg due to security concerns:

- run the "sync-lxg" job manually
- run the "deploy-lxg" job manually then, on the lxg branch

Could be improved by spending more time probably but good enough at the moment