### PR TITLE
product mainCTA i18n issue

### DIFF
--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -414,7 +414,7 @@
 									disabled={loading}
 									class="btn body-cta body-mainCTA"
 								>
-									{verb}
+									{t(`product.cta.${verb}`)}
 								</button>
 							{/if}
 						{:else}


### PR DESCRIPTION
To fix this :
![image](https://github.com/B2Bitcoin/beBOP/assets/50206014/57f81e2b-44c4-42db-8749-d6f94c58eec0)
{verb} was used instead of translation key related to {verb}