### PR TITLE
Change swiss VAT after law evolution

### DIFF
--- a/src/lib/types/Country.ts
+++ b/src/lib/types/Country.ts
@@ -455,7 +455,7 @@ export const VAT_RATES = {
 	SD: 17,
 	SR: 10,
 	SE: 25,
-	CH: 7.7,
+	CH: 8.1,
 	TW: 5,
 	TJ: 18,
 	TZ: 18,


### PR DESCRIPTION
Law change, Swiss full VAT rate goes to 7.7% to 8.1%