### PR TITLE
🐛 Fix VAT rate display on cart/checkout

### DIFF
--- a/src/routes/(app)/cart/+page.svelte
+++ b/src/routes/(app)/cart/+page.svelte
@@ -221,7 +221,9 @@
 				{#if country}
 					<CartVat
 						vatAmount={priceInfo.partialVat}
-						vatRate={priceInfo.digitalVatRate || priceInfo.physicalVatRate}
+						vatRate={priceInfo.partialDigitalVat
+							? priceInfo.digitalVatRate
+							: priceInfo.physicalVatRate}
 						vatSingleCountry={priceInfo.singleVatCountry}
 						vatCountry={country}
 						vatCurrency={priceInfo.currency}

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -593,11 +593,13 @@
 					{#if country}
 						<OrderVat
 							vatAmount={priceInfo.partialVat}
-							vatRate={priceInfo.digitalVatRate || priceInfo.physicalVatRate}
+							vatRate={priceInfo.partialDigitalVat
+								? priceInfo.digitalVatRate
+								: priceInfo.physicalVatRate}
 							vatSingleCountry={priceInfo.singleVatCountry}
 							vatCountry={country}
 							vatCurrency={priceInfo.currency}
-							isDigital={isDigital || priceInfo.isPhysicalVatExempted}
+							isDigital={priceInfo.partialPhysicalVat === 0}
 						></OrderVat>
 					{/if}
 				{/if}


### PR DESCRIPTION
In the case where:

- There is only one product
- It's a physical product

The digital VAT rate is shown (correct vat amount) in checkout / cart

This PR fixes that