### PR TITLE
Pos second price pwyw

### DIFF
--- a/src/routes/(app)/pos/session/+page.svelte
+++ b/src/routes/(app)/pos/session/+page.svelte
@@ -135,10 +135,7 @@
 							>
 							<PriceTag
 								class="text-base text-gray-600 truncate"
-								amount={(item.quantity *
-									item.product.price.amount *
-									(item.depositPercentage ?? 100)) /
-									100}
+								amount={(item.quantity * price.amount * (item.depositPercentage ?? 100)) / 100}
 								currency={price.currency}
 								secondary
 							/>


### PR DESCRIPTION
On POS session page, when you pay a PWYW higher than initial price and you display a 2nd currency, the 2nd currency is not the PWYW real price, but the initial one #1037