### PR TITLE
When duplicating a product, empty the 'alias' field #1039

### DIFF
--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -233,7 +233,7 @@
 				name="alias"
 				placeholder="alias"
 				step="any"
-				value={product.alias?.[1] ?? ''}
+				value={duplicateFromId ? '' : product.alias?.[1] ?? ''}
 			/>
 		</label>
 		<div class="gap-4 flex flex-col md:flex-row">


### PR DESCRIPTION
When duplicating a product, empty the 'alias' field #1039