### PR TITLE
✨ Remove plausible from admin pages

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,7 +31,12 @@
 		></script>
 	{/if}
 	{#if data.plausibleScriptUrl}
-		<script defer data-domain={$page.url.host} src={data.plausibleScriptUrl}>
+		<script
+			defer
+			data-domain={$page.url.host}
+			src={data.plausibleScriptUrl.replace(/\.js$/, 'exclusion.js')}
+			data-exclude="/admin/*, /admin-*"
+		>
 		</script>
 	{/if}
 </svelte:head>


### PR DESCRIPTION
Fix https://github.com/B2Bitcoin/beBOP/issues/872 , doc: https://plausible.io/docs/excluding-pages

It will work for default admin prefix, not sure it works with custom admin prefix (it's annoying to do without exposing the admin prefix, but I can try something if it doesn't currently work)