### PR TITLE
'Show only if Add to cart / Order button aren't available' is not dis…

### DIFF
--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -457,7 +457,7 @@
 							<a href={cta.href} class="btn body-cta body-secondaryCTA">
 								{cta.label}
 							</a>
-						{:else if !canBuy || amountAvailable <= 0}
+						{:else if !canBuy || amountAvailable <= 0 || (data.cartMaxSeparateItems && data.cart?.length === data.cartMaxSeparateItems)}
 							<a href={cta.href} class="btn body-cta body-secondaryCTA">
 								{cta.label}
 							</a>


### PR DESCRIPTION
🐛 Product custom CTA with option "Show only if Add to cart / Order button aren't available" is not display if buttons aren't display because cart maximum lines is reached #1082