### PR TITLE
display the really currency + amount cashed-in #1090

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.svelte
@@ -340,7 +340,7 @@
 										: payment.method === 'card'
 										? payment.transactions?.[0].transaction_code
 										: payment.method === 'bitcoin'
-										? payment.transactions?.[0].txid
+										? payment.transactions?.[0].id ?? ''
 										: payment.detail || ''}</td
 								>
 


### PR DESCRIPTION
On "Payment Detail", we display currency + amout, but in case of bitcoin / lighting (or fiat depending of the shop settings), display the really currency + amount cashed-in #1090
