### PR TITLE
🐛 On product page, custom CTA on external links (beginning with http*…

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -149,6 +149,7 @@
 							href={link.href}
 							class=" {data.notResponsive ? '' : 'hidden lg:inline'}"
 							data-sveltekit-preload-data="off"
+							target={link.href.startsWith('http') ? '_blank' : '_self'}
 						>
 							{link.label}
 						</a>

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -534,6 +534,7 @@
 								)
 									? 'break-all'
 									: ''} "
+								target={cta.href.startsWith('http') ? '_blank' : '_self'}
 							>
 								{cta.label}
 							</a>
@@ -545,6 +546,7 @@
 								)
 									? 'break-all'
 									: ''} "
+								target={cta.href.startsWith('http') ? '_blank' : '_self'}
 							>
 								{cta.label}
 							</a>


### PR DESCRIPTION
…) should open in another window #1530