### PR TITLE
🦋 Reorder, duplicate and remove product variations on the admin product page

### DIFF
--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -235,20 +235,27 @@
 			}
 
 			const seen = new Set<string>();
-			for (const [i, value] of variationLabelsValues.entries()) {
-				const key = JSON.stringify(
-					`${variationLabelsNames[i] || product.variations?.[i].name}, ${
-						value || product.variations?.[i].value
-					}`
-				).toLowerCase();
+			const duplicateIndex = Array.from({
+				length: Math.max(product.variations?.length || 0, variationLabelsValues.length)
+			}).findIndex((_, i) => {
+				const name = product.variations?.[i]?.name || variationLabelsNames[i];
+				const value = product.variations?.[i]?.value || variationLabelsValues[i] || '';
 
-				if (seen.has(key)) {
-					variationInput[i].setCustomValidity(`Duplicate variations found ${key}`);
-					variationInput[i].reportValidity();
-					event.preventDefault();
-					return;
+				if (!name || !value) {
+					return false;
 				}
+
+				const key = `${name},${value}`.toLowerCase();
+				const isDuplicate = seen.has(key);
 				seen.add(key);
+				return isDuplicate;
+			});
+
+			if (duplicateIndex !== -1) {
+				variationInput[duplicateIndex]?.setCustomValidity('Duplicate variation found');
+				variationInput[duplicateIndex]?.reportValidity();
+				event.preventDefault();
+				return;
 			}
 			if (!duplicateFromId && isNew) {
 				if (!files) {
@@ -369,6 +376,10 @@
 		product.standalone = true;
 	}
 
+	$: if (product.hasVariations) {
+		product.standalone = true;
+	}
+
 	$: if (product.free) {
 		allowDeposit = false;
 	}
@@ -385,12 +396,92 @@
 			event.preventDefault();
 		}
 	}
+	/**
+	 * Temporary storage for NEW variations being entered in empty form rows.
+	 *
+	 * Data flow:
+	 * 1. User enters data in empty row → stored in these arrays (ephemeral UI state)
+	 * 2. User clicks ➕ button → moved to `product.variations` (persistent state)
+	 * 3. User clicks Update button → saved to database via FormData
+	 *
+	 * These arrays are NOT stored in the database - they only hold input for unsaved rows.
+	 *
+	 * @see product.variationLabels - Permanent storage for variation metadata (names/translations)
+	 * @see product.variations - Permanent storage for active variations with price differences
+	 */
 	let variationLabelsNames: string[] = [];
 	let variationLabelsValues: string[] = [];
+
 	function isNumber(value: string) {
 		return !isNaN(Number(value)) && value.trim() !== '';
 	}
+
+	/**
+	 * Moves a variation up or down in the list by swapping positions.
+	 *
+	 * Used by 🔺 (move up) and 🔻 (move down) buttons on saved variations.
+	 *
+	 * @param fromIndex - Current position of the variation (0-based)
+	 * @param toIndex - Target position to move to (0-based)
+	 */
+	function moveVariation(fromIndex: number, toIndex: number): void {
+		if (product.variations) {
+			if (
+				fromIndex < 0 ||
+				toIndex < 0 ||
+				fromIndex >= product.variations.length ||
+				toIndex >= product.variations.length
+			) {
+				return;
+			}
+			const newVariations = [...product.variations];
+			const [movedItem] = newVariations.splice(fromIndex, 1);
+			newVariations.splice(toIndex, 0, movedItem);
+			product.variations = newVariations;
+		}
+	}
+	/**
+	 * Duplicates a variation by creating a copy immediately after the original.
+	 *
+	 * Called when user clicks ➕ button on a variation row.
+	 * Generates a unique ID via generateId and copies the original label.
+	 *
+	 * @param index - Position of the original variation
+	 * @param variation - Variation data (name, value, price)
+	 */
+	function duplicateVariation(
+		index: number,
+		variation: { name: string; value: string; price?: number }
+	) {
+		const newValueId = generateId(variation.name, true);
+
+		product.variations?.splice(index + 1, 0, {
+			name: variation.name,
+			value: newValueId,
+			price: variation.price ?? 0
+		});
+
+		if (product.variationLabels?.values?.[variation.name]) {
+			product.variationLabels.values[variation.name][newValueId] =
+				product.variationLabels.values[variation.name][variation.value] || variation.value;
+		}
+
+		variationLines++;
+	}
 	$: variationLabelsToUpdate = product.variationLabels || { names: {}, values: {} };
+
+	/**
+	 * Deletes a variation from the product.
+	 *
+	 * Called when user clicks ➖ button on a saved variation row.
+	 * Removes the variation from both `product.variations` array and
+	 * `product.variationLabels` metadata.
+	 *
+	 * If all values for a category are deleted, also removes the category itself.
+	 *
+	 * @param key - Category ID (e.g., "size", "color")
+	 * @param valueKey - Value ID (e.g., "small", "red")
+	 */
 	function deleteVariationLabel(key: string, valueKey: string) {
 		variationLabelsToUpdate = {
 			...variationLabelsToUpdate,
@@ -964,10 +1055,36 @@
 								{#if variation.name && variation.value}
 									<button
 										type="button"
+										class="px-2 py-2 hover:bg-green-50 rounded-md"
+										on:click={() => duplicateVariation(i, variation)}
+										title="Duplicate variation"
+									>
+										➕
+									</button>
+									<button
+										type="button"
 										class="px-3 py-2 text-red-600 hover:bg-red-50 rounded-md"
 										on:click={() => deleteVariationLabel(variation.name, variation.value)}
 									>
 										🗑️
+									</button>
+									<button
+										type="button"
+										class="px-2 py-2 hover:bg-gray-100 rounded-md"
+										class:opacity-50={i === 0}
+										disabled={i === 0}
+										on:click={() => moveVariation(i, i - 1)}
+									>
+										🔺
+									</button>
+									<button
+										type="button"
+										class="px-2 py-2 hover:bg-gray-100 rounded-md"
+										class:opacity-50={i === (product.variations?.length ?? 1) - 1}
+										disabled={i === (product.variations?.length ?? 1) - 1}
+										on:click={() => moveVariation(i, i + 1)}
+									>
+										🔻
 									</button>
 								{/if}
 							</div>

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -684,6 +684,17 @@ export const migrations = [
 		}
 	},
 	{
+		_id: new ObjectId('684af38a6fbd314f44a84f88'),
+		name: 'Set standalone for products with hasVariations',
+		run: async (session: ClientSession) => {
+			await collections.products.updateMany(
+				{ hasVariations: true, standalone: { $ne: true } },
+				{ $set: { standalone: true } },
+				{ session }
+			);
+		}
+	},
+	{
 		_id: new ObjectId('68e52126bf9841f187344d14'),
 		name: 'Create default PoS payment subtype: Cash',
 		run: async (session: ClientSession) => {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -168,10 +168,13 @@ export const actions: Actions = {
 			...variation,
 			price: Math.max(parsePriceAmount(variation.price, parsed.priceCurrency), 0)
 		}));
+		const validVariations = variationsParsedPrice.filter(
+			(variation) => variation.name && variation.value
+		);
 		const amountInCarts = await amountOfStockReserved(params.id);
 		const cleanedVariationLabels = cleanVariationLabels(parsed.variationLabels);
 		const hasVariations =
-			parsed.standalone && Object.entries(cleanedVariationLabels?.names || []).length !== 0;
+			parsed.hasVariations && Object.entries(cleanedVariationLabels?.names || []).length !== 0;
 
 		// Validate stock reference if provided
 		if (parsed.stockReferenceProductId) {
@@ -219,7 +222,7 @@ export const actions: Actions = {
 								}
 							}),
 						hideDiscountExpiration: parsed.hideDiscountExpiration,
-						standalone: parsed.payWhatYouWant || parsed.standalone,
+						standalone: parsed.payWhatYouWant || hasVariations || parsed.standalone,
 						free: parsed.free,
 						...(parsed.deliveryFees && { deliveryFees: parsed.deliveryFees }),
 						applyDeliveryFeesOnlyOnce: parsed.applyDeliveryFeesOnlyOnce,
@@ -283,12 +286,11 @@ export const actions: Actions = {
 							paymentMethods: parsed.paymentMethods ?? []
 						}),
 						hasVariations,
-						...(hasVariations && {
-							variations: variationsParsedPrice.filter(
-								(variation) => variation.name && variation.value
-							),
-							variationLabels: cleanedVariationLabels
-						}),
+						...(hasVariations &&
+							validVariations.length > 0 && {
+								variations: validVariations,
+								variationLabels: cleanedVariationLabels
+							}),
 						hasSellDisclaimer: parsed.hasSellDisclaimer,
 						...(parsed.hasSellDisclaimer &&
 							parsed.sellDisclaimerTitle &&
@@ -323,11 +325,15 @@ export const actions: Actions = {
 							pricingSchedule: ''
 						}),
 						...(!parsed.restrictPaymentMethods && { paymentMethods: '' }),
-						...(!hasVariations && { variations: '', variationLabels: '' }),
 						...(!parsed.hasSellDisclaimer && { sellDisclaimer: '' }),
 						...(!parsed.payWhatYouWant && { recommendedPWYWAmount: '' }),
 						...(!parsed.bookingSpec && { bookingSpec: '' }),
 						...(!parsed.hasMaximumPrice && { maximumPrice: '' }),
+						...(parsed.hasVariations &&
+							validVariations.length === 0 && {
+								variations: '',
+								variationLabels: ''
+							}),
 						...(!parsed.paidOrderWebhook && { paidOrderWebhook: '' })
 					}
 				}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -36,7 +36,6 @@ import { logProductCreationEvents } from '$lib/server/accounting-log';
 
 export const load = async ({ url }) => {
 	const productId = url.searchParams.get('duplicate_from');
-
 	const tags = await collections.tags
 		.find({})
 		.project<Pick<Tag, '_id' | 'name'>>({ _id: 1, name: 1 })
@@ -141,6 +140,9 @@ export const actions: Actions = {
 		if (!parsed.free && !parsed.payWhatYouWant && parsed.priceAmount === '0') {
 			parsed.free = true;
 		}
+		const validVariations = variationsParsedPrice.filter(
+			(variation) => variation.name && variation.value
+		);
 		const cleanedVariationLabels = cleanVariationLabels(parsed.variationLabels);
 
 		// Validate stock reference if provided
@@ -193,7 +195,7 @@ export const actions: Actions = {
 										currency: parsed.priceCurrency
 									}
 								}),
-							standalone: parsed.payWhatYouWant || parsed.standalone,
+							standalone: parsed.payWhatYouWant || parsed.hasVariations || parsed.standalone,
 							free: parsed.free,
 							bookingSpec: parsed.bookingSpec,
 							displayShortDescription: parsed.displayShortDescription,
@@ -243,16 +245,10 @@ export const actions: Actions = {
 							externalResources: parsed.externalResources?.filter(
 								(externalResourceLink) => externalResourceLink.label && externalResourceLink.href
 							),
-							...(parsed.standalone && { hasVariations: parsed.hasVariations }),
-							...(parsed.standalone &&
-								parsed.hasVariations && {
-									variations: variationsParsedPrice.filter(
-										(variation) => variation.name && variation.value
-									)
-								}),
-							...(parsed.standalone &&
-								parsed.hasVariations &&
-								parsed.variationLabels && {
+							hasVariations: parsed.hasVariations,
+							...(validVariations.length > 0 && { variations: validVariations }),
+							...(parsed.variationLabels &&
+								Object.keys(cleanedVariationLabels.names).length > 0 && {
 									variationLabels: cleanedVariationLabels
 								}),
 							...(parsed.vatProfileId && { vatProfileId: new ObjectId(parsed.vatProfileId) }),
@@ -385,6 +381,9 @@ export const actions: Actions = {
 			...variation,
 			price: Math.max(parsePriceAmount(variation.price, parsed.priceCurrency), 0)
 		}));
+		const validVariations = variationsParsedPrice.filter(
+			(variation) => variation.name && variation.value
+		);
 		const cleanedVariationLabels = cleanVariationLabels(parsed.variationLabels);
 
 		await withTransaction(async (session) => {
@@ -419,7 +418,7 @@ export const actions: Actions = {
 								currency: parsed.priceCurrency
 							}
 						}),
-					standalone: parsed.standalone,
+					standalone: parsed.payWhatYouWant || parsed.hasVariations || parsed.standalone,
 					free: parsed.free,
 					...(parsed.stock !== undefined && {
 						stock: { total: parsed.stock, available: parsed.stock, reserved: 0 }
@@ -458,16 +457,10 @@ export const actions: Actions = {
 					tagIds: product.tagIds,
 					cta: product.cta,
 					externalResources: product.externalResources,
-					...(parsed.standalone && { hasVariations: parsed.hasVariations }),
-					...(parsed.standalone &&
-						parsed.hasVariations && {
-							variations: variationsParsedPrice.filter(
-								(variation) => variation.name && variation.value
-							)
-						}),
-					...(parsed.standalone &&
-						parsed.hasVariations &&
-						parsed.variationLabels && {
+					hasVariations: parsed.hasVariations,
+					...(validVariations.length > 0 && { variations: validVariations }),
+					...(parsed.variationLabels &&
+						Object.keys(cleanedVariationLabels.names).length > 0 && {
 							variationLabels: cleanedVariationLabels
 						}),
 					hasSellDisclaimer: parsed.hasSellDisclaimer,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -244,7 +244,9 @@ export const productBaseSchema = () => ({
 				price: z
 					.string()
 					.regex(/^\d+(\.\d+)?$/)
-					.default('0')
+					.default('0'),
+				nameLabel: z.string().trim().optional(),
+				valueLabel: z.string().trim().optional()
 			})
 		)
 		.optional()


### PR DESCRIPTION
Products with variations could only have them listed in the order they were
first entered. A new variation always landed at the end of the list, and the
only way to place one between two others was to delete everything after it and
type it all again.

Variations can now be arranged from the product page. Each row carries controls
to move it up or down, to duplicate it — the copy appears directly under the
original, ready to be renamed — and to remove it. The order set here is the
order customers see on the product page.

A product that has variations is now standalone by default, so its stock is
counted per variation rather than shared with a parent item. Existing products
with variations are migrated on startup.

Fixes #1702
