### PR TITLE
CI: fix release job not checkout out code

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -43,6 +43,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Download built artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
A checkout is required to discover the commit message metadata.