### PR TITLE
Recognise SSO emails as the user secondary emails

### DIFF
--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -55,10 +55,12 @@ export async function createSuperAdminUserInDb(login: string, password: string) 
 }
 
 export function userIdentifier(locals: App.Locals): UserIdentifier {
+	const secondaryEmails = locals.sso?.flatMap((sso) => (sso.email ? [sso.email] : []));
 	return {
 		ssoIds: locals.sso?.map((sso) => sso.id),
 		userId: locals.user?._id,
 		email: locals.email,
+		secondaryEmails,
 		npub: locals.npub,
 		sessionId: locals.sessionId,
 
@@ -70,10 +72,11 @@ export function userIdentifier(locals: App.Locals): UserIdentifier {
 }
 
 export function userQuery(user: UserIdentifier) {
+	const emails = [...(user.email ? [user.email] : []), ...(user.secondaryEmails ?? [])];
 	const ret = {
 		$or: [
 			...(user.userId ? [{ 'user.userId': user.userId }] : []),
-			...(user.email ? [{ 'user.email': user.email }] : []),
+			...(emails.length ? [{ 'user.email': { $in: emails } }] : []),
 			...(user.npub ? [{ 'user.npub': user.npub }] : []),
 			...(user.sessionId ? [{ 'user.sessionId': user.sessionId }] : []),
 			...(user.ssoIds?.length ? [{ 'user.ssoIds': { $in: user.ssoIds } }] : [])

--- a/src/lib/types/UserIdentifier.ts
+++ b/src/lib/types/UserIdentifier.ts
@@ -2,7 +2,10 @@ import type { ObjectId } from 'mongodb';
 
 export interface UserIdentifier {
 	userId?: ObjectId;
+	/** The user's primary email address. Cannot be renamed to keep backwards compatibility. */
 	email?: string;
+	/** Emails that can be associated with the user (e.g. via SSO). */
+	secondaryEmails?: string[];
 	npub?: string;
 	sessionId?: string;
 	ssoIds?: string[];


### PR DESCRIPTION
When a user connects via SSO, the user may end-up linking multiple identities. Each identity may provide us with an email address.

This commit extends the UserIdentifier to contain these secondary emails. This is useful, for example when searching the discounts belonging to a user.

This that this commit accidentally persists the secondary emails. This is because there is no distinction between the domain object UserIdentifier and the database object UserIdentifier. Unfortunatelly, there is no time available to split these. This is also part of the reason why there are now `email` and `secondaryEmails` in UserIdentifier.

fixes #2047.