### PR TITLE
In SSO settings, display correct redirect URL by adding provider slug

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/oauth/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/oauth/[id]/+page.svelte
@@ -6,8 +6,8 @@
 <h1 class="text-3xl">Update OAuth provider</h1>
 
 <p>
-	Specify <span class="underline">{$page.url.origin}/oauth/callback</span> as the redirect URL when creating
-	the OAuth application.
+	Specify <span class="underline">{$page.url.origin}/oauth/{data.provider.slug}/callback</span> as the
+	redirect URL when creating the OAuth application.
 </p>
 
 <form class="flex flex-col gap-4" method="POST">

--- a/src/routes/(app)/admin[[hash=admin_hash]]/oauth/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/oauth/new/+page.svelte
@@ -10,7 +10,7 @@
 
 <p>
 	Create an OAuth application with your provider of choice. Specify <span class="underline"
-		>{$page.url.origin}/oauth/callback</span
+		>{$page.url.origin}/oauth/{slug || '[slug]'}/callback</span
 	> as the redirect URL when creating the OAuth application.
 </p>
 


### PR DESCRIPTION
<img width="1398" height="1001" alt="image" src="https://github.com/user-attachments/assets/f3ad31a7-776e-4b17-b1a7-e1107f73e07a" />

Noticed when testing SSO

Add the provider slug between "/oauth" and "/callback"