### PR TITLE
docker-compose: Limit log file sizes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,10 @@ services:
         required: true
     extra_hosts:
       - 'host.docker.internal:host-gateway'
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
   mongo:
     image: mongo:6.0.9
     hostname: mongodb
@@ -42,6 +46,10 @@ services:
       interval: 5s
     volumes:
       - mongo-data:/data/db
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
   minio:
     image: quay.io/minio/minio:latest
     hostname: minio
@@ -59,6 +67,10 @@ services:
         required: true
       - path: .env.local
         required: true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
 volumes:
   mongo-data:
   minio-data:


### PR DESCRIPTION
Pilots with this one seem to be healthier in term on spacedisk saturation.