### PR TITLE
🐛 Fix schedule event checkboxes not working on existing events #2054

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/schedule/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/schedule/[id]/+page.svelte
@@ -14,16 +14,32 @@
 	let slug = data.schedule._id;
 	let displayPastEvents = data.schedule.displayPastEvents;
 	let eventLines = data.schedule.events.length || 1;
-	$: eventAvailable = data.schedule.events.map((eve) => ({
+	let eventAvailable = data.schedule.events.map((eve) => ({
 		isUnavailable: eve.unavailabity?.isUnavailable ?? false
 	}));
-	$: eventCalendar = data.schedule.events.map((eve) => ({
+	let eventCalendar = data.schedule.events.map((eve) => ({
 		calendarColor: !!eve.calendarColor
 	}));
-	$: rsvpOptions = data.schedule.events.map((eve) => ({
+	let rsvpOptions = data.schedule.events.map((eve) => ({
 		option: !!eve.rsvp?.target
 	}));
-	$: createATicket = data.schedule.events.map(() => false);
+	let createATicket = data.schedule.events.map(() => false);
+
+	$: if (data.schedule.events.length !== eventAvailable.length) {
+		eventAvailable = data.schedule.events.map((eve) => ({
+			isUnavailable: eve.unavailabity?.isUnavailable ?? false
+		}));
+		eventCalendar = data.schedule.events.map((eve) => ({
+			calendarColor: !!eve.calendarColor
+		}));
+		rsvpOptions = data.schedule.events.map((eve) => ({
+			option: !!eve.rsvp?.target
+		}));
+		createATicket = data.schedule.events.map(() => false);
+		errorMessage = data.schedule.events.map(() => '');
+		eventLines = data.schedule.events.length;
+	}
+
 	let beginsAt: string[] = [];
 	let endsAt: string[] = [];
 	let hideAll = true;


### PR DESCRIPTION
Problem: Checkboxes for RSVP, calendar color, and unavailability weren't working when editing existing schedule events. The checkboxes appeared to not respond to clicks.

Root cause: Commit cd09df8 changed `let` declarations to reactive statements (`$:`), which breaks Svelte's two-way binding for checkboxes. Reactive statements recreate arrays on every dependency change, losing user input.

Solution:
- Revert to `let` declarations for checkbox state arrays
- Add reactive sync when data.schedule.events length changes
- This preserves checkbox bindings while handling picture uploads

Fixes #2054