### PR TITLE
feat: add POS payment subtypes (issue #790)

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -49,6 +49,7 @@ import type { OrderLabel } from '$lib/types/OrderLabel';
 import type { ScheduleEventBooked, Schedule } from '$lib/types/Schedule';
 import type { Leaderboard } from '$lib/types/Leaderboard';
 import type { OrderTab } from '$lib/types/OrderTab';
+import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
 
 // Bigger than the default 10, helpful with MongoDB errors
 Error.stackTraceLimit = 100;
@@ -108,6 +109,7 @@ const genCollection = () => ({
 	labels: db.collection<OrderLabel>('labels'),
 	schedules: db.collection<Schedule>('schedules'),
 	scheduleEvents: db.collection<ScheduleEventBooked>('schedule.events'),
+	posPaymentSubtypes: db.collection<PosPaymentSubtype>('posPaymentSubtypes'),
 
 	errors: db.collection<unknown & { _id: ObjectId; url: string; method: string }>('errors')
 });
@@ -208,7 +210,10 @@ const indexes: Array<[Collection<any>, IndexSpecification, CreateIndexesOptions?
 	[collections.scheduleEvents, { scheduleId: 1, status: 1, beginsAt: 1, endsAt: 1 }], // endsAt is just used for index-only scan
 	[collections.scheduleEvents, { scheduleId: 1, status: 1, endsAt: 1 }],
 	[collections.scheduleEvents, { orderId: 1 }],
-	[collections.scheduleEvents, { orderCreated: 1, _id: 1 }] // To cleanup events where there was an error during order creation
+	[collections.scheduleEvents, { orderCreated: 1, _id: 1 }], // To cleanup events where there was an error during order creation
+	[collections.posPaymentSubtypes, { slug: 1 }, { unique: true }],
+	[collections.posPaymentSubtypes, { sortOrder: 1 }],
+	[collections.posPaymentSubtypes, { disabled: 1 }]
 ];
 
 export async function createIndexes() {

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -5,6 +5,7 @@ import { env } from '$env/dynamic/private';
 import type { OrderPayment } from '$lib/types/Order';
 import { Lock } from './lock';
 import { ORIGIN } from '$lib/server/env-config';
+import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
 
 const migrations = [
 	{
@@ -591,6 +592,31 @@ const migrations = [
 				{ $unset: { 'items.$[].freeQuantity': 1 } },
 				{ session }
 			);
+		}
+	},
+	{
+		_id: new ObjectId('68e52126bf9841f187344d14'),
+		name: 'Create default PoS payment subtype: Cash',
+		run: async (session: ClientSession) => {
+			const existingCount = await collections.posPaymentSubtypes.countDocuments({}, { session });
+			if (existingCount > 0) {
+				console.log('PoS payment subtypes already exist, skipping migration');
+				return;
+			}
+
+			const defaultSubtype: PosPaymentSubtype = {
+				_id: new ObjectId(),
+				slug: 'cash',
+				name: 'Cash',
+				description: 'Cash payments',
+				sortOrder: 1,
+				createdAt: new Date(),
+				updatedAt: new Date()
+			};
+
+			await collections.posPaymentSubtypes.insertOne(defaultSubtype, { session });
+
+			console.log('Created default PoS payment subtype: Cash');
 		}
 	}
 ];

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -576,6 +576,7 @@ export async function createOrder(
 		};
 		onLocation?: boolean;
 		paymentTimeOut?: number;
+		posSubtype?: string;
 		session?: ClientSession;
 	}
 ): Promise<Order['_id']> {
@@ -1557,7 +1558,12 @@ export async function createOrder(
 					order,
 					paymentMethod,
 					{ currency: 'SAT', amount: partialSatoshis },
-					{ session, expiresAt }
+					{
+						session,
+						expiresAt,
+						...(paymentMethod === 'point-of-sale' &&
+							params.posSubtype && { posSubtype: params.posSubtype })
+					}
 				);
 				order.payments.push(orderPayment);
 			}
@@ -1987,7 +1993,7 @@ export async function addOrderPayment(
 	/**
 	 * `null` expiresAt means the payment method has no expiration
 	 */
-	opts?: { expiresAt?: Date | null; session?: ClientSession }
+	opts?: { expiresAt?: Date | null; session?: ClientSession; posSubtype?: string }
 ) {
 	if (order.status !== 'pending') {
 		throw error(400, 'Order is not pending');
@@ -2025,6 +2031,7 @@ export async function addOrderPayment(
 		status: 'pending',
 		method: paymentMethod,
 		price: paymentPrice(paymentMethod, priceToPay),
+		...(paymentMethod === 'point-of-sale' && opts?.posSubtype && { posSubtype: opts.posSubtype }),
 		currencySnapshot: {
 			main: {
 				price: {

--- a/src/lib/server/payment-methods.ts
+++ b/src/lib/server/payment-methods.ts
@@ -10,7 +10,7 @@ import { isBitcoinNodelessConfigured } from './bitcoin-nodeless';
 import { isSwissBitcoinPayConfigured } from './swiss-bitcoin-pay';
 import { isBtcpayServerConfigured } from './btcpay-server';
 
-const ALL_PAYMENT_METHODS = [
+export const ALL_PAYMENT_METHODS = [
 	'card',
 	'bank-transfer',
 	'bitcoin',

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -86,6 +86,17 @@ export interface OrderPayment {
 	};
 	method: PaymentMethod;
 	processor?: PaymentProcessor;
+
+	/**
+	 * For 'point-of-sale' payments, specifies the subtype slug
+	 * References PosPaymentSubtype.slug
+	 *
+	 * Examples: "cash", "check", "external-tpe"
+	 *
+	 * If undefined → legacy PoS payment (backward compatibility)
+	 */
+	posSubtype?: string;
+
 	/**
 	 * Can be unset for cash or bank transfer payments for example.
 	 */

--- a/src/lib/types/PosPaymentSubtype.ts
+++ b/src/lib/types/PosPaymentSubtype.ts
@@ -1,0 +1,16 @@
+import type { ObjectId } from 'mongodb';
+import type { Timestamps } from './Timestamps';
+import type { PaymentProcessor } from '$lib/server/payment-methods';
+
+export interface PosPaymentSubtype extends Timestamps {
+	_id: ObjectId;
+	slug: string;
+	name: string;
+	description?: string;
+	tapToPay?: {
+		processor: PaymentProcessor;
+		onActivationUrl?: string;
+	};
+	disabled?: boolean;
+	sortOrder: number;
+}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
@@ -141,6 +141,10 @@ export const adminLinks: AdminLinks = [
 			{
 				href: '/admin/lnd',
 				label: 'Lightning LND node'
+			},
+			{
+				href: '/admin/pos-payments',
+				label: 'PoS Payments'
 			}
 		]
 	},

--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/[id]/+page.server.ts
@@ -45,11 +45,13 @@ export const actions = {
 		const parsed = z
 			.object({
 				amount: z.string().regex(/^\d+(\.\d+)?$/),
-				method: z.enum(methods as [PaymentMethod, ...PaymentMethod[]])
+				method: z.enum(methods as [PaymentMethod, ...PaymentMethod[]]),
+				posSubtype: z.string().nullable().optional()
 			})
 			.parse({
 				amount: formData.get('amount'),
-				method: formData.get('method')
+				method: formData.get('method'),
+				posSubtype: formData.get('posSubtype')
 			});
 
 		const amount = parsePriceAmount(parsed.amount, order.currencySnapshot.main.totalPrice.currency);
@@ -67,7 +69,11 @@ export const actions = {
 				amount,
 				currency: order.currencySnapshot.main.totalPrice.currency
 			},
-			{ expiresAt: null }
+			{
+				expiresAt: null,
+				...(parsed.method === 'point-of-sale' &&
+					parsed.posSubtype && { posSubtype: parsed.posSubtype })
+			}
 		);
 
 		throw redirect(303, `/order/${order._id}`);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos-payments/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos-payments/+page.server.ts
@@ -1,0 +1,185 @@
+import type { Actions } from './$types';
+import { collections } from '$lib/server/database';
+import { fail } from '@sveltejs/kit';
+import { isStripeEnabled } from '$lib/server/stripe';
+import { isSumupEnabled } from '$lib/server/sumup';
+import { ObjectId } from 'mongodb';
+import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
+import { ALL_PAYMENT_PROCESSORS, type PaymentProcessor } from '$lib/server/payment-methods';
+import { z } from 'zod';
+import { typedInclude } from '$lib/utils/typedIncludes';
+
+function asPaymentProcessor(value: string): PaymentProcessor | undefined {
+	return typedInclude(ALL_PAYMENT_PROCESSORS, value) ? value : undefined;
+}
+
+export const load = async () => {
+	const subtypesRaw = await collections.posPaymentSubtypes
+		.find({})
+		.sort({ sortOrder: 1 })
+		.toArray();
+
+	const subtypes = subtypesRaw.map((subtype) => ({
+		...subtype,
+		_id: subtype._id.toString(),
+		createdAt: subtype.createdAt.toISOString(),
+		updatedAt: subtype.updatedAt.toISOString()
+	}));
+
+	const availableProcessors = [
+		{
+			processor: 'stripe' as const,
+			available: isStripeEnabled(),
+			displayName: 'Stripe'
+		},
+		{
+			processor: 'sumup' as const,
+			available: isSumupEnabled(),
+			displayName: 'SumUp'
+		}
+	];
+
+	return {
+		subtypes,
+		availableProcessors
+	};
+};
+
+export const actions: Actions = {
+	create: async ({ request }) => {
+		const formData = await request.formData();
+
+		const parsed = z
+			.object({
+				slug: z
+					.string()
+					.min(1)
+					.regex(/^[a-z0-9-]+$/, 'Slug must be lowercase alphanumeric with hyphens'),
+				name: z.string().min(1),
+				description: z.string().optional(),
+				tapToPayProcessor: z.enum(['', 'stripe', 'sumup']),
+				tapToPayUrl: z.string().trim().optional()
+			})
+			.safeParse({
+				slug: formData.get('slug'),
+				name: formData.get('name'),
+				description: formData.get('description'),
+				tapToPayProcessor: formData.get('tapToPayProcessor') || '',
+				tapToPayUrl: formData.get('tapToPayUrl') || ''
+			});
+
+		if (!parsed.success) {
+			return fail(400, { error: parsed.error.message });
+		}
+
+		const existing = await collections.posPaymentSubtypes.findOne({ slug: parsed.data.slug });
+		if (existing) {
+			return fail(400, { error: 'Subtype with this slug already exists' });
+		}
+
+		const maxSortOrder = await collections.posPaymentSubtypes
+			.find({})
+			.sort({ sortOrder: -1 })
+			.limit(1)
+			.toArray();
+
+		const processor = asPaymentProcessor(parsed.data.tapToPayProcessor);
+
+		const newSubtype: PosPaymentSubtype = {
+			_id: new ObjectId(),
+			slug: parsed.data.slug,
+			name: parsed.data.name,
+			description: parsed.data.description || undefined,
+			tapToPay: processor
+				? {
+						processor,
+						onActivationUrl: parsed.data.tapToPayUrl || undefined
+				  }
+				: undefined,
+			sortOrder: (maxSortOrder[0]?.sortOrder ?? 0) + 1,
+			createdAt: new Date(),
+			updatedAt: new Date()
+		};
+
+		await collections.posPaymentSubtypes.insertOne(newSubtype);
+
+		return { success: true };
+	},
+
+	update: async ({ request }) => {
+		const formData = await request.formData();
+
+		const parsed = z
+			.object({
+				id: z.string().min(1),
+				name: z.string().min(1),
+				description: z.string().optional(),
+				tapToPayProcessor: z.enum(['', 'stripe', 'sumup']),
+				tapToPayUrl: z.string().trim().optional(),
+				disabled: z.boolean().optional()
+			})
+			.safeParse({
+				id: formData.get('id'),
+				name: formData.get('name'),
+				description: formData.get('description'),
+				tapToPayProcessor: formData.get('tapToPayProcessor') || '',
+				tapToPayUrl: formData.get('tapToPayUrl') || '',
+				disabled: formData.get('disabled') === 'true'
+			});
+
+		if (!parsed.success) {
+			return fail(400, { error: parsed.error.message });
+		}
+
+		const processor = asPaymentProcessor(parsed.data.tapToPayProcessor);
+
+		const updateData: Partial<PosPaymentSubtype> = {
+			name: parsed.data.name,
+			description: parsed.data.description || undefined,
+			tapToPay: processor
+				? {
+						processor,
+						onActivationUrl: parsed.data.tapToPayUrl || undefined
+				  }
+				: undefined,
+			disabled: parsed.data.disabled,
+			updatedAt: new Date()
+		};
+
+		const result = await collections.posPaymentSubtypes.updateOne(
+			{ _id: new ObjectId(parsed.data.id) },
+			{ $set: updateData }
+		);
+
+		if (result.matchedCount === 0) {
+			return fail(404, { error: 'Subtype not found' });
+		}
+
+		return { success: true };
+	},
+
+	delete: async ({ request }) => {
+		const formData = await request.formData();
+		const id = String(formData.get('id'));
+
+		const subtype = await collections.posPaymentSubtypes.findOne({ _id: new ObjectId(id) });
+		if (!subtype) {
+			return fail(404, { error: 'Subtype not found' });
+		}
+
+		const ordersCount = await collections.orders.countDocuments({
+			'payments.method': 'point-of-sale',
+			'payments.posSubtype': subtype.slug
+		});
+
+		if (ordersCount > 0) {
+			return fail(400, {
+				error: `Cannot delete: ${ordersCount} orders use this subtype`
+			});
+		}
+
+		await collections.posPaymentSubtypes.deleteOne({ _id: new ObjectId(id) });
+
+		return { success: true };
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos-payments/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos-payments/+page.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+	import { applyAction, enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
+	import type { ActionData, PageData } from './$types';
+	import { generateId } from '$lib/utils/generateId';
+
+	export let data: PageData;
+	export let form: ActionData;
+
+	let showCreateForm = false;
+	let editingSubtype: (typeof data.subtypes)[0] | null = null;
+	let nameInput = '';
+	let slugInput = '';
+	let selectedProcessor = '';
+	let urlInput = '';
+
+	$: if (!editingSubtype && nameInput) {
+		slugInput = generateId(nameInput, false);
+	}
+
+	$: tapToPayUrlDisabled = !selectedProcessor;
+
+	function resetForm() {
+		showCreateForm = false;
+		editingSubtype = null;
+		nameInput = '';
+		slugInput = '';
+		selectedProcessor = '';
+		urlInput = '';
+	}
+</script>
+
+<h1 class="text-3xl mb-4">PoS Payment Subtypes</h1>
+
+<p class="text-gray-600 mb-6">
+	Configure different types of point-of-sale payments (cash, check, terminals, etc.)
+</p>
+
+{#if form?.error}
+	<div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+		{form.error}
+	</div>
+{/if}
+
+{#if form?.success}
+	<div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+		Operation successful!
+	</div>
+{/if}
+
+<div class="flex flex-col gap-6">
+	<!-- Existing Subtypes List -->
+	<section>
+		<h2 class="text-2xl mb-4">Existing Subtypes</h2>
+
+		{#if data.subtypes.length === 0}
+			<p class="text-gray-500">No subtypes configured yet. Create your first one below!</p>
+		{:else}
+			<div class="flex flex-col gap-4">
+				{#each data.subtypes as subtype}
+					<div
+						class="border rounded-lg p-4 flex justify-between items-start {subtype.disabled
+							? 'bg-gray-50 opacity-60'
+							: ''}"
+					>
+						<div class="flex-1">
+							<div class="flex items-center gap-2">
+								<h3 class="font-bold text-lg">{subtype.name}</h3>
+								{#if subtype.disabled}
+									<span class="text-xs bg-gray-500 text-white px-2 py-1 rounded">Disabled</span>
+								{/if}
+							</div>
+							<p class="text-sm text-gray-600">
+								Slug: <code class="bg-gray-100 px-1 rounded">{subtype.slug}</code>
+							</p>
+
+							{#if subtype.description}
+								<p class="text-sm mt-2">{subtype.description}</p>
+							{/if}
+
+							{#if subtype.tapToPay}
+								<div class="mt-3 p-3 bg-blue-50 rounded-lg border border-blue-200">
+									<p class="text-sm font-semibold text-blue-900">🔗 Tap-to-pay enabled</p>
+									<p class="text-sm text-blue-800">
+										Processor: <strong>{subtype.tapToPay.processor}</strong>
+									</p>
+									{#if subtype.tapToPay.onActivationUrl}
+										<p class="text-sm text-blue-800">URL: {subtype.tapToPay.onActivationUrl}</p>
+									{/if}
+								</div>
+							{/if}
+						</div>
+
+						<div class="flex gap-2 ml-4">
+							<button
+								type="button"
+								class="btn btn-sm"
+								on:click={() => {
+									editingSubtype = subtype;
+									showCreateForm = false;
+									nameInput = subtype.name;
+									selectedProcessor = subtype.tapToPay?.processor || '';
+									urlInput = subtype.tapToPay?.onActivationUrl || '';
+								}}
+							>
+								Edit
+							</button>
+
+							<form
+								method="post"
+								action="?/delete"
+								use:enhance={() => {
+									return async ({ result }) => {
+										await applyAction(result);
+										if (result.type === 'success') {
+											await invalidateAll();
+										}
+									};
+								}}
+							>
+								<input type="hidden" name="id" value={subtype._id.toString()} />
+								<button
+									type="submit"
+									class="btn btn-sm btn-danger"
+									on:click={(e) => {
+										if (!confirm(`Delete "${subtype.name}"?\n\nThis action cannot be undone.`)) {
+											e.preventDefault();
+										}
+									}}
+								>
+									Delete
+								</button>
+							</form>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</section>
+
+	<!-- Create/Edit Form Toggle -->
+	{#if !showCreateForm && !editingSubtype}
+		<button type="button" class="btn btn-black self-start" on:click={() => (showCreateForm = true)}>
+			+ Create New Subtype
+		</button>
+	{/if}
+
+	<!-- Create/Edit Form -->
+	{#if showCreateForm || editingSubtype}
+		<form
+			method="post"
+			action="?/{editingSubtype ? 'update' : 'create'}"
+			class="border rounded-lg p-6 flex flex-col gap-4 bg-gray-50"
+			use:enhance={() => {
+				return async ({ result }) => {
+					await applyAction(result);
+					if (result.type === 'success') {
+						await invalidateAll();
+						resetForm();
+					}
+				};
+			}}
+		>
+			<h3 class="text-xl font-bold">
+				{editingSubtype ? `Edit "${editingSubtype.name}"` : 'Create New Subtype'}
+			</h3>
+
+			{#if editingSubtype}
+				<input type="hidden" name="id" value={editingSubtype._id.toString()} />
+			{/if}
+
+			<!-- Display Name -->
+			<label class="form-label">
+				Display Name <span class="text-red-500">*</span>
+				<input
+					type="text"
+					name="name"
+					class="form-input"
+					bind:value={nameInput}
+					placeholder="e.g. Cash, Check, External POS Terminal"
+					required
+				/>
+			</label>
+
+			<!-- Slug (only for create) -->
+			{#if !editingSubtype}
+				<label class="form-label">
+					Slug <span class="text-red-500">*</span>
+					<input
+						type="text"
+						name="slug"
+						class="form-input"
+						bind:value={slugInput}
+						placeholder="e.g. cash, check, external-tpe"
+						pattern="[a-z0-9-]+"
+						title="Lowercase letters, numbers, and hyphens only"
+						required
+					/>
+					<p class="text-xs text-gray-500 mt-1">
+						Unique identifier (lowercase, alphanumeric, hyphens). Cannot be changed after creation.
+					</p>
+				</label>
+			{:else}
+				<div class="form-label">
+					Slug: <code class="bg-gray-200 px-2 py-1 rounded">{editingSubtype.slug}</code>
+					<p class="text-xs text-gray-500">Cannot be changed</p>
+				</div>
+			{/if}
+
+			<!-- Description -->
+			<label class="form-label">
+				Description (optional)
+				<textarea
+					name="description"
+					class="form-input"
+					rows="2"
+					placeholder="Optional description for admin reference"
+					>{editingSubtype?.description || ''}</textarea
+				>
+			</label>
+
+			<!-- Tap-to-pay Configuration -->
+			<hr class="my-2" />
+			<h4 class="text-lg font-semibold">Tap-to-pay Configuration (optional)</h4>
+			<p class="text-sm text-gray-600">
+				Configure automatic payment reconciliation via external POS terminals (Stripe Terminal,
+				SumUp, etc.)
+			</p>
+
+			<label class="form-label">
+				Tap-to-pay Processor
+				<select
+					name="tapToPayProcessor"
+					class="form-input"
+					bind:value={selectedProcessor}
+					on:change={() => {
+						if (!selectedProcessor) {
+							urlInput = '';
+						}
+					}}
+				>
+					<option value="">Not used</option>
+					{#each data.availableProcessors as proc}
+						<option value={proc.processor} disabled={!proc.available}>
+							{proc.displayName}
+							{#if !proc.available}(not configured){/if}
+						</option>
+					{/each}
+				</select>
+				<p class="text-xs text-gray-500 mt-1">
+					Select a payment processor for automatic reconciliation. Configure processors in Payment
+					Settings.
+				</p>
+			</label>
+
+			<label class="form-label">
+				Tap-to-pay URL (optional)
+				<input
+					type="url"
+					name="tapToPayUrl"
+					class="form-input"
+					bind:value={urlInput}
+					placeholder="e.g. https://open.paynow-app.com"
+					disabled={tapToPayUrlDisabled}
+				/>
+				<p class="text-xs text-gray-500 mt-1">
+					Deep link to open the payment terminal app (e.g. Paynow for Stripe)
+				</p>
+			</label>
+
+			<!-- Disabled checkbox (only for edit) -->
+			{#if editingSubtype}
+				<label class="checkbox-label flex items-center gap-2">
+					<input
+						type="checkbox"
+						name="disabled"
+						class="form-checkbox"
+						value="true"
+						checked={editingSubtype.disabled}
+					/>
+					<span>Disable this subtype (hide from selection)</span>
+				</label>
+			{/if}
+
+			<!-- Action Buttons -->
+			<div class="flex gap-2 mt-4">
+				<button type="submit" class="btn btn-black">
+					{editingSubtype ? 'Update' : 'Create'}
+				</button>
+
+				<button type="button" class="btn" on:click={resetForm}> Cancel </button>
+			</div>
+		</form>
+	{/if}
+</div>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
@@ -4,6 +4,7 @@ import { ALL_PAYMENT_PROCESSORS } from '$lib/server/payment-methods.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import type { Tag } from '$lib/types/Tag';
 import { set } from '$lib/utils/set';
+import { typedInclude } from '$lib/utils/typedIncludes';
 import { error, redirect } from '@sveltejs/kit';
 import type { JsonObject } from 'type-fest';
 import { z } from 'zod';
@@ -82,8 +83,8 @@ export const actions = {
 					})
 					.array(),
 				posTouchTag: z.string().array(),
-				tapToPayOnActivationUrl: z.string(),
-				tapToPayProvider: z.string()
+				tapToPayOnActivationUrl: z.string().trim().optional(),
+				tapToPayProvider: z.string().optional()
 			})
 			.parse({
 				...json,
@@ -91,9 +92,11 @@ export const actions = {
 				posTouchTag
 			});
 		const posTapToPay = {
-			processor: ALL_PAYMENT_PROCESSORS.find((p) => p === result.tapToPayProvider),
-			onActivationUrl:
-				result.tapToPayOnActivationUrl === '' ? undefined : result.tapToPayOnActivationUrl
+			processor:
+				result.tapToPayProvider && typedInclude(ALL_PAYMENT_PROCESSORS, result.tapToPayProvider)
+					? result.tapToPayProvider
+					: undefined,
+			onActivationUrl: result.tapToPayOnActivationUrl || undefined
 		};
 		const parsedOptsForPosQrCodeAfterPayment = z
 			.object({

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
@@ -22,34 +22,14 @@
 
 <h1 class="text-3xl">POS</h1>
 
+<div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+	<p class="text-sm text-blue-900">
+		ℹ️ Tap-to-pay settings have been moved to
+		<a href="/admin/pos-payments" class="font-bold underline">Payment Settings → PoS Payments</a>
+	</p>
+</div>
+
 <form method="post" class="flex flex-col gap-6" on:submit={handleSubmit}>
-	<h2 class="text-2xl">Tap-to-pay / external POS reconciliation</h2>
-	<label class="form-label">
-		Select Tap-to-pay provider
-		<select name="tapToPayProvider" class="form-input max-w-[25rem]">
-			{#each data.tapToPay.providers as provider}
-				<option
-					value={provider.provider}
-					selected={data.tapToPay.currentProcessor === provider.provider}
-					disabled={!provider.available}
-				>
-					{provider.displayName}
-				</option>
-			{/each}
-		</select>
-	</label>
-
-	<label class="form-label">
-		Fill mobile application URL (optional)
-		<input
-			type="text"
-			class="form-input max-w-[25rem]"
-			name="tapToPayOnActivationUrl"
-			placeholder="e.g. https://open.paynow-app.com"
-			value={data.tapToPay.onActivationUrl}
-		/>
-	</label>
-
 	<h2 class="text-2xl">Touchscreen PoS interface</h2>
 	<!-- svelte-ignore a11y-label-has-associated-control -->
 	<label class="form-label">

--- a/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.server.ts
@@ -60,12 +60,15 @@ export async function load({ url }) {
 		.sort({ name: 1 })
 		.toArray();
 
+	const posSubtypes = await collections.posPaymentSubtypes.find({}).toArray();
+
 	return {
 		orders: orders.map((order) => ({
 			_id: order._id,
 			payments: order.payments.map((payment) => ({
 				...pojo(payment),
-				id: payment._id.toString()
+				id: payment._id.toString(),
+				posSubtype: payment.posSubtype
 			})),
 			number: order.number,
 			createdAt: order.createdAt,
@@ -93,6 +96,10 @@ export async function load({ url }) {
 		})),
 		employeesAlias,
 		reportingTags,
-		tagId
+		tagId,
+		posSubtypes: posSubtypes.map((subtype) => ({
+			slug: subtype.slug,
+			name: subtype.name
+		}))
 	};
 }

--- a/src/routes/(app)/checkout/+page.server.ts
+++ b/src/routes/(app)/checkout/+page.server.ts
@@ -87,6 +87,12 @@ export async function load({ parent, locals }) {
 		locals.user?.roleId !== undefined && locals.user?.roleId !== CUSTOMER_ROLE_ID
 			? 'employee'
 			: undefined;
+
+	const posSubtypes = await collections.posPaymentSubtypes
+		.find({ disabled: { $ne: true } })
+		.sort({ sortOrder: 1 })
+		.toArray();
+
 	return {
 		paymentMethods: methods,
 		emailsEnabled,
@@ -105,6 +111,10 @@ export async function load({ parent, locals }) {
 		isBillingAddressMandatory: runtimeConfig.isBillingAddressMandatory,
 		displayNewsletterCommercialProspection: runtimeConfig.displayNewsletterCommercialProspection,
 		noProBilling: runtimeConfig.noProBilling,
+		posSubtypes: posSubtypes.map((subtype) => ({
+			slug: subtype.slug,
+			name: subtype.name
+		})),
 		...(cmsCheckoutTop && {
 			cmsCheckoutTop,
 			cmsCheckoutTopData: cmsFromContent(
@@ -302,6 +312,15 @@ export const actions = {
 					})
 					.parse(Object.fromEntries(formData)).paymentMethod;
 
+		const posSubtype =
+			paymentMethod === 'point-of-sale'
+				? z
+						.object({
+							posSubtype: z.string().optional()
+						})
+						.parse(Object.fromEntries(formData)).posSubtype
+				: undefined;
+
 		const { discountAmount, discountType, discountJustification } = z
 			.object({
 				discountAmount: z.coerce.number().optional(),
@@ -468,6 +487,7 @@ export const actions = {
 				{
 					locale: locals.language,
 					user: userIdentifier(locals),
+					...(posSubtype && { posSubtype }),
 					notifications: {
 						paymentStatus: {
 							npub: npubAddress,

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -506,6 +506,18 @@
 							{/if}
 						</div>
 					</label>
+					{#if paymentMethod === 'point-of-sale' && data.posSubtypes?.length}
+						<label class="form-label col-span-6">
+							<span>Payment Type</span>
+							<select name="posSubtype" class="form-input" required>
+								{#each data.posSubtypes as subtype}
+									<option value={subtype.slug}>
+										{subtype.name}
+									</option>
+								{/each}
+							</select>
+						</label>
+					{/if}
 				{/if}
 				{#if data.hasPosOptions && paymentMethod !== 'point-of-sale' && paymentMethod !== 'bank-transfer'}
 					<label class="checkbox-label">

--- a/src/routes/(app)/order/[id]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/+page.server.ts
@@ -81,13 +81,22 @@ export async function load({ params, depends, locals }) {
 			: undefined;
 	const tapToPay = {
 		configured: !!runtimeConfig.posTapToPay.processor,
-		inUseByOtherOrder: !!(await conflictingTapToPayOrder(order._id)),
-		onActivationUrl: runtimeConfig.posTapToPay.onActivationUrl
+		inUseByOtherOrder: !!(await conflictingTapToPayOrder(order._id))
 	};
+
+	const posSubtypes = (
+		await collections.posPaymentSubtypes.find({}).sort({ sortOrder: 1 }).toArray()
+	).map((subtype) => ({
+		slug: subtype.slug,
+		name: subtype.name,
+		description: subtype.description
+	}));
+
 	return {
 		order,
 		paymentMethods: methods,
 		tapToPay,
+		posSubtypes,
 		digitalFiles: Promise.all(
 			digitalFiles.map(async (file) => ({
 				name: file.name,

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -27,6 +27,23 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 		.find({ productId: { $in: order.items.map((item) => item.product._id) } })
 		.toArray();
 
+	const posSubtypesMap = new Map<
+		string,
+		{ tapToPayOnActivationUrl?: string; hasProcessor: boolean }
+	>();
+
+	for (const payment of order.payments) {
+		if (payment.posSubtype && !posSubtypesMap.has(payment.posSubtype)) {
+			const subtype = await collections.posPaymentSubtypes.findOne({
+				slug: payment.posSubtype
+			});
+			posSubtypesMap.set(payment.posSubtype, {
+				tapToPayOnActivationUrl: subtype?.tapToPay?.onActivationUrl,
+				hasProcessor: !!subtype?.tapToPay?.processor
+			});
+		}
+	}
+
 	for (const payment of order.payments) {
 		// Check if the payment has been paid but the status is still pending in DB
 		// In that case, we send back the status as paid, but do not update the DB (it's taken care of by order-lock)
@@ -110,7 +127,14 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 		payments: order.payments.map((payment) => ({
 			id: payment._id.toString(),
 			method: payment.method,
+			posSubtype: payment.posSubtype,
 			posTapToPay: payment.posTapToPay,
+			tapToPayOnActivationUrl: payment.posSubtype
+				? posSubtypesMap.get(payment.posSubtype)?.tapToPayOnActivationUrl
+				: undefined,
+			posSubtypeHasProcessor: payment.posSubtype
+				? posSubtypesMap.get(payment.posSubtype)?.hasProcessor ?? false
+				: false,
 			processor: payment.method === 'card' ? payment.processor : undefined,
 			status: payment.status,
 			address: payment.address,

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/+page.server.ts
@@ -1,6 +1,7 @@
 import { collections, withTransaction } from '$lib/server/database';
 import { addOrderPayment, onOrderPaymentFailed, paymentMethodExpiration } from '$lib/server/orders';
-import { paymentMethods, type PaymentMethod } from '$lib/server/payment-methods.js';
+import { paymentMethods, ALL_PAYMENT_METHODS } from '$lib/server/payment-methods.js';
+import { typedInclude } from '$lib/utils/typedIncludes';
 import { error, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 
@@ -42,11 +43,17 @@ export const actions = {
 		const formData = await request.formData();
 		const parsed = z
 			.object({
-				method: z.enum(methods as [PaymentMethod, ...PaymentMethod[]])
+				method: z.enum(ALL_PAYMENT_METHODS),
+				posSubtype: z.string().optional()
 			})
 			.parse({
-				method: formData.get('method')
+				method: formData.get('method'),
+				posSubtype: formData.get('posSubtype')
 			});
+
+		if (!typedInclude(methods, parsed.method)) {
+			throw error(400, 'Payment method not available for this order');
+		}
 
 		await withTransaction(async (session) => {
 			await onOrderPaymentFailed(order, payment, 'canceled', {
@@ -56,7 +63,9 @@ export const actions = {
 
 			await addOrderPayment(order, parsed.method, payment.currencySnapshot.main.price, {
 				expiresAt: paymentMethodExpiration(parsed.method),
-				session
+				session,
+				...(parsed.method === 'point-of-sale' &&
+					parsed.posSubtype && { posSubtype: parsed.posSubtype })
 			});
 		});
 		throw redirect(303, `/order/${order._id}`);


### PR DESCRIPTION
Add ability to configure different types of point-of-sale payments (cash, check, terminals) with per-subtype tap-to-pay settings.

New Features:
- Admin UI at /admin/pos-payments for managing subtypes
- Display subtype in orders: "Point of Sale (Cash)"
- Per-subtype tap-to-pay processor and URL configuration

Changes:
- Add PosPaymentSubtype type and collection
- Add posSubtype field to OrderPayment
- Move tap-to-pay config from /admin/pos to /admin/pos-payments
- Migration creates one default subtype (cash)
- Backward compatible with existing orders!

- Reports: Display subtype in payment detail table: "point-of-sale (Cash)"
- Reports: Group payment synthesis by subtype for separate statistics
- Reports: Show quantity and total for each POS subtype separately