### PR TITLE
🐛 Include git-lfs assets in releases

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Install pnpm
         uses: pnpm/action-setup@v4
       - name: Set up Node


### PR DESCRIPTION
Due to a CI misconfiguration, the git-lfs assets were not present when building the release artifact.