### PR TITLE
🦋Enable subscription renewal reminder through email

### DIFF
--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -81,7 +81,7 @@ export async function sendEmail(params: {
 		})
 	});
 
-	console.log('Email sent', res);
+	console.log(`✅ Email sent [${params.subject}] → ${params.to}`, res);
 }
 
 export async function queueEmail(
@@ -93,6 +93,8 @@ export async function queueEmail(
 		bcc?: string;
 	}
 ): Promise<void> {
+	console.log(`📧 Queueing email: ${templateKey} → ${to}`);
+
 	const lowerVars = mapKeys(
 		{
 			...vars,

--- a/src/lib/server/locks/email-notifications.ts
+++ b/src/lib/server/locks/email-notifications.ts
@@ -1,10 +1,12 @@
-import type { ChangeStream, ChangeStreamDocument } from 'mongodb';
+import { MongoServerError, Timestamp, type ChangeStream, type ChangeStreamDocument } from 'mongodb';
 import { Lock } from '../lock';
 import { collections } from '../database';
 import type { EmailNotification } from '$lib/types/EmailNotification';
 import { isEmailConfigured, sendEmail } from '../email';
 import { building } from '$app/environment';
 import { rateLimit } from '../rateLimit';
+import { getUnixTime, subHours } from 'date-fns';
+import { typedInclude } from '$lib/utils/typedIncludes';
 
 const lock = new Lock('notifications.email');
 
@@ -66,24 +68,51 @@ async function handleEmailNotification(email: EmailNotification): Promise<void> 
 	}
 }
 
-let changeStream: ChangeStream<EmailNotification>;
+let changeStream: ChangeStream<EmailNotification> | null = null;
 
-function watch() {
+async function watch(opts?: { requestChangesSince?: Timestamp }) {
 	try {
 		rateLimit('0.0.0.0', 'changeStream.email-notifications', 10, { minutes: 5 });
 	} catch {
 		console.error("Too many change streams errors for 'email-notifications', exiting");
 		process.exit(1);
 	}
-	changeStream = collections.emailNotifications.watch([{ $match: { operationType: 'insert' } }], {
-		fullDocument: 'updateLookup'
-	});
-	changeStream.on('change', (ev) => handleChanges(ev).catch(console.error));
-	changeStream.on('error', (err) => {
-		console.error('email-notifications', err);
-		changeStream.close().catch(console.error);
-		watch();
-	});
+
+	try {
+		changeStream = collections.emailNotifications
+			.watch([{ $match: { operationType: 'insert' } }], {
+				fullDocument: 'updateLookup',
+				...(opts?.requestChangesSince && {
+					startAtOperationTime: opts.requestChangesSince
+				})
+			})
+			.on('change', (ev) => handleChanges(ev).catch(console.error))
+			.once('error', async (err) => {
+				console.error('change stream error', err);
+				changeStream?.close().catch(console.error);
+				changeStream = null;
+
+				if (
+					err instanceof MongoServerError &&
+					typedInclude(['ChangeStreamHistoryLost', 'ChangeStreamFatalError'], err.codeName)
+				) {
+					// Restart from 1 hour ago if history was lost
+					return watch({
+						requestChangesSince: Timestamp.fromBits(0, getUnixTime(subHours(new Date(), 1)))
+					});
+				} else {
+					return watch();
+				}
+			});
+
+		return changeStream;
+	} catch (err) {
+		if (err instanceof MongoServerError && err.codeName === 'ChangeStreamHistoryLost') {
+			console.warn('Oplog time out of range when starting change stream, falling back to now', err);
+			return watch();
+		}
+		throw err;
+	}
 }
 
 async function processEmailNotifications() {

--- a/src/lib/server/locks/subscription-lock.test.ts
+++ b/src/lib/server/locks/subscription-lock.test.ts
@@ -1,0 +1,366 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanDb } from '../test-utils';
+import { collections } from '../database';
+import { addHours, subDays } from 'date-fns';
+import {
+	getSubscriptionsToRemindViaEmail,
+	getSubscriptionsToRemindViaNostr,
+	getSubscriptionsToNotifyEndViaEmail
+} from './subscription-lock';
+
+// Test constants
+const REMINDER_WINDOW_HOURS = 2;
+const TEST_PRODUCT_ID = 'test-product';
+const TEST_SESSION_ID = 'test-session';
+const TEST_EMAIL = 'test@example.com';
+const TEST_NPUB = 'npub1test';
+
+describe('subscription-lock queries', () => {
+	beforeEach(async () => {
+		await cleanDb();
+	});
+
+	describe('getSubscriptionsToRemindViaEmail', () => {
+		it('should return subscription approaching expiration when first purchased', async () => {
+			const now = new Date();
+			const reminderWindow = addHours(now, REMINDER_WINDOW_HOURS);
+
+			// Create subscription expiring in 1 hour (within reminder window)
+			const subscriptionId = crypto.randomUUID();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId,
+				productId: TEST_PRODUCT_ID,
+				number: 1,
+				user: {
+					sessionId: TEST_SESSION_ID,
+					email: TEST_EMAIL
+				},
+				paidUntil: addHours(now, 1),
+				notifications: [],
+				createdAt: now,
+				updatedAt: now
+			});
+
+			// Should return subscription for reminder
+			const result = await getSubscriptionsToRemindViaEmail(now, reminderWindow).toArray();
+			expect(result).toHaveLength(1);
+			expect(result[0]._id).toBe(subscriptionId);
+
+			// Should NOT return for end notification (not expired yet)
+			const endResult = await getSubscriptionsToNotifyEndViaEmail(now).toArray();
+			expect(endResult).toHaveLength(0);
+		});
+
+		it('should return subscription for end notification when expired', async () => {
+			const now = new Date();
+
+			// Create subscription that expired 1 hour ago
+			const subscriptionId = crypto.randomUUID();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId,
+				productId: TEST_PRODUCT_ID,
+				number: 1,
+				user: {
+					sessionId: TEST_SESSION_ID,
+					email: TEST_EMAIL
+				},
+				paidUntil: subDays(now, 1),
+				notifications: [],
+				createdAt: subDays(now, 30),
+				updatedAt: now
+			});
+
+			// Should return for end notification
+			const endResult = await getSubscriptionsToNotifyEndViaEmail(now).toArray();
+			expect(endResult).toHaveLength(1);
+			expect(endResult[0]._id).toBe(subscriptionId);
+
+			// Should NOT return for reminder (already expired)
+			const reminderWindow = addHours(now, REMINDER_WINDOW_HOURS);
+			const reminderResult = await getSubscriptionsToRemindViaEmail(now, reminderWindow).toArray();
+			expect(reminderResult).toHaveLength(0);
+		});
+
+		it('should return renewed subscription for reminder when renewal approaching expiration', async () => {
+			const now = new Date();
+			const reminderWindow = addHours(now, REMINDER_WINDOW_HOURS);
+			const oldPaidUntil = subDays(now, 5);
+
+			// Create subscription with reminder already sent for old period
+			const subscriptionId = crypto.randomUUID();
+			const oldNotificationId = new (await import('mongodb')).ObjectId();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId,
+				productId: TEST_PRODUCT_ID,
+				number: 1,
+				user: {
+					sessionId: TEST_SESSION_ID,
+					email: TEST_EMAIL
+				},
+				paidUntil: oldPaidUntil,
+				notifications: [
+					{
+						type: 'reminder' as const,
+						medium: 'email' as const,
+						createdAt: subDays(now, 6),
+						_id: oldNotificationId
+					}
+				],
+				createdAt: subDays(now, 35),
+				updatedAt: subDays(now, 5)
+			});
+
+			// Simulate renewal: archive old notifications and update paidUntil
+			const subscription = await collections.paidSubscriptions.findOne({ _id: subscriptionId });
+			if (!subscription) {
+				throw new Error('Subscription not found');
+			}
+
+			const archivedNotifications = subscription.notifications.map((notif) => ({
+				...notif,
+				forPaidUntil: oldPaidUntil
+			}));
+
+			await collections.paidSubscriptions.updateOne(
+				{ _id: subscriptionId },
+				{
+					$set: {
+						paidUntil: addHours(now, 1),
+						updatedAt: now,
+						notifications: []
+					},
+					$push: {
+						notificationHistory: { $each: archivedNotifications }
+					}
+				}
+			);
+
+			// After renewal, should return for reminder again
+			const result = await getSubscriptionsToRemindViaEmail(now, reminderWindow).toArray();
+			expect(result).toHaveLength(1);
+			expect(result[0]._id).toBe(subscriptionId);
+
+			// Verify notification history was preserved
+			const updated = await collections.paidSubscriptions.findOne({ _id: subscriptionId });
+			expect(updated?.notifications).toHaveLength(0);
+			expect(updated?.notificationHistory).toHaveLength(1);
+			expect(updated?.notificationHistory?.[0]).toMatchObject({
+				type: 'reminder',
+				medium: 'email',
+				forPaidUntil: oldPaidUntil
+			});
+		});
+
+		it('should return renewed subscription for end notification when renewal expired', async () => {
+			const now = new Date();
+			const oldPaidUntil = subDays(now, 35);
+
+			// Create subscription with previous reminder/expiration notifications
+			const subscriptionId = crypto.randomUUID();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId,
+				productId: TEST_PRODUCT_ID,
+				number: 1,
+				user: {
+					sessionId: TEST_SESSION_ID,
+					email: TEST_EMAIL
+				},
+				paidUntil: oldPaidUntil,
+				notifications: [
+					{
+						type: 'reminder' as const,
+						medium: 'email' as const,
+						createdAt: subDays(now, 36),
+						_id: new (await import('mongodb')).ObjectId()
+					},
+					{
+						type: 'expiration' as const,
+						medium: 'email' as const,
+						createdAt: subDays(now, 35),
+						_id: new (await import('mongodb')).ObjectId()
+					}
+				],
+				createdAt: subDays(now, 65),
+				updatedAt: subDays(now, 35)
+			});
+
+			// Simulate renewal: archive old notifications and extend paidUntil to yesterday
+			const subscription = await collections.paidSubscriptions.findOne({ _id: subscriptionId });
+			if (!subscription) {
+				throw new Error('Subscription not found');
+			}
+
+			const archivedNotifications = subscription.notifications.map((notif) => ({
+				...notif,
+				forPaidUntil: oldPaidUntil
+			}));
+
+			await collections.paidSubscriptions.updateOne(
+				{ _id: subscriptionId },
+				{
+					$set: {
+						paidUntil: subDays(now, 1),
+						updatedAt: now,
+						notifications: []
+					},
+					$push: {
+						notificationHistory: { $each: archivedNotifications }
+					}
+				}
+			);
+
+			// After renewal expiration, should return for end notification
+			const endResult = await getSubscriptionsToNotifyEndViaEmail(now).toArray();
+			expect(endResult).toHaveLength(1);
+			expect(endResult[0]._id).toBe(subscriptionId);
+
+			// Verify notification history was preserved (2 notifications from old period)
+			const updated = await collections.paidSubscriptions.findOne({ _id: subscriptionId });
+			expect(updated?.notifications).toHaveLength(0);
+			expect(updated?.notificationHistory).toHaveLength(2);
+			expect(updated?.notificationHistory?.[0].type).toBe('reminder');
+			expect(updated?.notificationHistory?.[1].type).toBe('expiration');
+			expect(updated?.notificationHistory?.[0].forPaidUntil).toEqual(oldPaidUntil);
+		});
+
+		it('should not return subscription if reminder already sent', async () => {
+			const now = new Date();
+			const reminderWindow = addHours(now, REMINDER_WINDOW_HOURS);
+
+			// Create subscription with reminder already sent
+			const subscriptionId = crypto.randomUUID();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId,
+				productId: TEST_PRODUCT_ID,
+				number: 1,
+				user: {
+					sessionId: TEST_SESSION_ID,
+					email: TEST_EMAIL
+				},
+				paidUntil: addHours(now, 1),
+				notifications: [
+					{
+						type: 'reminder' as const,
+						medium: 'email' as const,
+						createdAt: subDays(now, 1),
+						_id: new (await import('mongodb')).ObjectId()
+					}
+				],
+				createdAt: subDays(now, 30),
+				updatedAt: now
+			});
+
+			// Should NOT return (reminder already sent)
+			const result = await getSubscriptionsToRemindViaEmail(now, reminderWindow).toArray();
+			expect(result).toHaveLength(0);
+		});
+
+		it('should not return subscription if expiration already sent', async () => {
+			const now = new Date();
+
+			// Create expired subscription with expiration notification already sent
+			const subscriptionId = crypto.randomUUID();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId,
+				productId: TEST_PRODUCT_ID,
+				number: 1,
+				user: {
+					sessionId: TEST_SESSION_ID,
+					email: TEST_EMAIL
+				},
+				paidUntil: subDays(now, 1),
+				notifications: [
+					{
+						type: 'expiration' as const,
+						medium: 'email' as const,
+						createdAt: subDays(now, 1),
+						_id: new (await import('mongodb')).ObjectId()
+					}
+				],
+				createdAt: subDays(now, 30),
+				updatedAt: now
+			});
+
+			// Should NOT return (expiration already sent)
+			const result = await getSubscriptionsToNotifyEndViaEmail(now).toArray();
+			expect(result).toHaveLength(0);
+		});
+
+		it('should not return cancelled subscriptions', async () => {
+			const now = new Date();
+			const reminderWindow = addHours(now, REMINDER_WINDOW_HOURS);
+
+			// Create cancelled subscription approaching expiration
+			const subscriptionId = crypto.randomUUID();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId,
+				productId: TEST_PRODUCT_ID,
+				number: 1,
+				user: {
+					sessionId: TEST_SESSION_ID,
+					email: TEST_EMAIL
+				},
+				paidUntil: addHours(now, 1),
+				notifications: [],
+				cancelledAt: now,
+				createdAt: subDays(now, 30),
+				updatedAt: now
+			});
+
+			// Should NOT return (subscription is cancelled)
+			const reminderResult = await getSubscriptionsToRemindViaEmail(now, reminderWindow).toArray();
+			expect(reminderResult).toHaveLength(0);
+
+			// Should also NOT return for end notification
+			const endResult = await getSubscriptionsToNotifyEndViaEmail(now).toArray();
+			expect(endResult).toHaveLength(0);
+		});
+
+		it('should only return subscriptions with email, not nostr-only', async () => {
+			const now = new Date();
+			const reminderWindow = addHours(now, REMINDER_WINDOW_HOURS);
+
+			// Create subscription with npub but no email
+			const subscriptionId1 = crypto.randomUUID();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId1,
+				productId: TEST_PRODUCT_ID,
+				number: 1,
+				user: {
+					sessionId: TEST_SESSION_ID,
+					npub: TEST_NPUB
+				},
+				paidUntil: addHours(now, 1),
+				notifications: [],
+				createdAt: subDays(now, 30),
+				updatedAt: now
+			});
+
+			// Create subscription with email
+			const subscriptionId2 = crypto.randomUUID();
+			await collections.paidSubscriptions.insertOne({
+				_id: subscriptionId2,
+				productId: TEST_PRODUCT_ID,
+				number: 2,
+				user: {
+					sessionId: 'test-session-2',
+					email: TEST_EMAIL
+				},
+				paidUntil: addHours(now, 1),
+				notifications: [],
+				createdAt: subDays(now, 30),
+				updatedAt: now
+			});
+
+			// Should only return email subscription
+			const emailResult = await getSubscriptionsToRemindViaEmail(now, reminderWindow).toArray();
+			expect(emailResult).toHaveLength(1);
+			expect(emailResult[0]._id).toBe(subscriptionId2);
+
+			// Nostr query should only return npub subscription
+			const nostrResult = await getSubscriptionsToRemindViaNostr(now, reminderWindow).toArray();
+			expect(nostrResult).toHaveLength(1);
+			expect(nostrResult[0]._id).toBe(subscriptionId1);
+		});
+	});
+});

--- a/src/lib/server/locks/subscription-lock.ts
+++ b/src/lib/server/locks/subscription-lock.ts
@@ -4,11 +4,239 @@ import { Lock } from '../lock';
 import { processClosed } from '../process';
 import { setTimeout } from 'node:timers/promises';
 import { refreshPromise, runtimeConfig } from '../runtime-config';
-import { ObjectId } from 'mongodb';
+import { type FindCursor, ObjectId } from 'mongodb';
 import { ORIGIN } from '$lib/server/env-config';
 import { Kind } from 'nostr-tools';
+import { queueEmail } from '../email';
+import type { PaidSubscription } from '$lib/types/PaidSubscription';
 
 const lock = new Lock('paid-subscriptions');
+
+export function getSubscriptionsToRemindViaNostr(
+	now: Date,
+	reminderWindow: Date
+): FindCursor<PaidSubscription> {
+	return collections.paidSubscriptions.find({
+		paidUntil: {
+			$gt: now,
+			$lt: reminderWindow
+		},
+		cancelledAt: { $exists: false },
+		'user.npub': { $exists: true },
+		notifications: { $not: { $elemMatch: { type: 'reminder', medium: 'nostr' } } }
+	});
+}
+
+export function getSubscriptionsToRemindViaEmail(
+	now: Date,
+	reminderWindow: Date
+): FindCursor<PaidSubscription> {
+	return collections.paidSubscriptions.find({
+		paidUntil: {
+			$gt: now,
+			$lt: reminderWindow
+		},
+		cancelledAt: { $exists: false },
+		'user.email': { $exists: true },
+		notifications: { $not: { $elemMatch: { type: 'reminder', medium: 'email' } } }
+	});
+}
+
+export function getSubscriptionsToNotifyEndViaNostr(now: Date): FindCursor<PaidSubscription> {
+	return collections.paidSubscriptions.find({
+		paidUntil: {
+			$lt: now
+		},
+		cancelledAt: { $exists: false },
+		'user.npub': { $exists: true },
+		notifications: { $not: { $elemMatch: { type: 'expiration', medium: 'nostr' } } }
+	});
+}
+
+export function getSubscriptionsToNotifyEndViaEmail(now: Date): FindCursor<PaidSubscription> {
+	return collections.paidSubscriptions.find({
+		paidUntil: {
+			$lt: now
+		},
+		cancelledAt: { $exists: false },
+		'user.email': { $exists: true },
+		notifications: { $not: { $elemMatch: { type: 'expiration', medium: 'email' } } }
+	});
+}
+
+async function notifySubscriptionReminderViaNostr(subscription: PaidSubscription) {
+	const userNpub = subscription.user.npub;
+	if (!userNpub) {
+		console.log(
+			`Cannot send subscription reminder via Nostr: subscription ${subscription._id} - user has no npub`
+		);
+		return;
+	}
+
+	await withTransaction(async (session) => {
+		const notifId = new ObjectId();
+		await collections.nostrNotifications.insertOne(
+			{
+				_id: notifId,
+				kind: Kind.EncryptedDirectMessage,
+				dest: userNpub,
+				content: `Your subscription #${subscription.number} is going to expire ${formatDistance(
+					subscription.paidUntil,
+					new Date(),
+					{
+						addSuffix: true
+					}
+				)}. Renew here: ${ORIGIN}/subscription/${subscription._id}`,
+				createdAt: new Date(),
+				updatedAt: new Date()
+			},
+			{ session }
+		);
+
+		await collections.paidSubscriptions.updateOne(
+			{
+				_id: subscription._id
+			},
+			{
+				$push: {
+					notifications: {
+						createdAt: new Date(),
+						_id: notifId,
+						type: 'reminder',
+						medium: 'nostr'
+					}
+				}
+			},
+			{ session }
+		);
+	}).catch(console.error);
+}
+
+async function notifySubscriptionReminderViaEmail(subscription: PaidSubscription) {
+	const userEmail = subscription.user.email;
+	if (!userEmail) {
+		console.log(
+			`Cannot send subscription reminder email: subscription ${subscription._id} - user has no email`
+		);
+		return;
+	}
+
+	await withTransaction(async (session) => {
+		const notifId = new ObjectId();
+
+		await queueEmail(
+			userEmail,
+			'subscription.reminder',
+			{
+				subscriptionNumber: subscription.number.toString(),
+				expirationTime: formatDistance(subscription.paidUntil, new Date(), {
+					addSuffix: true
+				}),
+				subscriptionLink: `${ORIGIN}/subscription/${subscription._id}`
+			},
+			{ session }
+		);
+
+		await collections.paidSubscriptions.updateOne(
+			{
+				_id: subscription._id
+			},
+			{
+				$push: {
+					notifications: {
+						createdAt: new Date(),
+						_id: notifId,
+						type: 'reminder',
+						medium: 'email'
+					}
+				}
+			},
+			{ session }
+		);
+	}).catch(console.error);
+}
+
+async function notifySubscriptionEndedViaNostr(subscription: PaidSubscription) {
+	const userNpub = subscription.user.npub;
+	if (!userNpub) {
+		console.log(
+			`Cannot send subscription ended notification via Nostr: subscription ${subscription._id} - user has no npub`
+		);
+		return;
+	}
+
+	await withTransaction(async (session) => {
+		const notifId = new ObjectId();
+		await collections.nostrNotifications.insertOne(
+			{
+				_id: notifId,
+				kind: Kind.EncryptedDirectMessage,
+				dest: userNpub,
+				content: `Your subscription #${subscription.number} expired. Renew here if you wish: ${ORIGIN}/subscription/${subscription._id}`,
+				createdAt: new Date(),
+				updatedAt: new Date()
+			},
+			{ session }
+		);
+		await collections.paidSubscriptions.updateOne(
+			{
+				_id: subscription._id
+			},
+			{
+				$push: {
+					notifications: {
+						createdAt: new Date(),
+						_id: notifId,
+						type: 'expiration',
+						medium: 'nostr'
+					}
+				}
+			},
+			{ session }
+		);
+	}).catch(console.error);
+}
+
+async function notifySubscriptionEndedViaEmail(subscription: PaidSubscription) {
+	const userEmail = subscription.user.email;
+	if (!userEmail) {
+		console.log(
+			`Cannot send subscription ended email: subscription ${subscription._id} - user has no email`
+		);
+		return;
+	}
+
+	await withTransaction(async (session) => {
+		const notifId = new ObjectId();
+
+		await queueEmail(
+			userEmail,
+			'subscription.ended',
+			{
+				subscriptionNumber: subscription.number.toString(),
+				subscriptionLink: `${ORIGIN}/subscription/${subscription._id}`
+			},
+			{ session }
+		);
+
+		await collections.paidSubscriptions.updateOne(
+			{
+				_id: subscription._id
+			},
+			{
+				$push: {
+					notifications: {
+						createdAt: new Date(),
+						_id: notifId,
+						type: 'expiration',
+						medium: 'email'
+					}
+				}
+			},
+			{ session }
+		);
+	}).catch(console.error);
+}
 
 async function maintainLock() {
 	await refreshPromise;
@@ -20,140 +248,32 @@ async function maintainLock() {
 		}
 
 		try {
-			const subscriptionsToRemind = collections.paidSubscriptions.find({
-				paidUntil: {
-					$gt: new Date(),
-					$lt: addSeconds(new Date(), runtimeConfig.subscriptionReminderSeconds)
-				},
-				cancelledAt: { $exists: false },
-				'notifications.type': { $ne: 'reminder' }
-			});
+			const now = new Date();
+			const reminderWindow = addSeconds(now, runtimeConfig.subscriptionReminderSeconds);
 
-			for await (const subscription of subscriptionsToRemind) {
-				await withTransaction(async (session) => {
-					if (subscription.user.npub) {
-						const notifId = new ObjectId();
-						await collections.nostrNotifications.insertOne(
-							{
-								_id: notifId,
-								kind: Kind.EncryptedDirectMessage,
-								dest: subscription.user.npub,
-								content: `Your subscription #${
-									subscription.number
-								} is going to expire ${formatDistance(subscription.paidUntil, new Date(), {
-									addSuffix: true
-								})}. Renew here: ${ORIGIN}/subscription/${subscription._id}`,
-								createdAt: new Date(),
-								updatedAt: new Date()
-							},
-							{ session }
-						);
+			const subscriptionsToRemindNostr = getSubscriptionsToRemindViaNostr(now, reminderWindow);
+			for await (const subscription of subscriptionsToRemindNostr) {
+				await notifySubscriptionReminderViaNostr(subscription);
+			}
 
-						await collections.paidSubscriptions.updateOne(
-							{
-								_id: subscription._id
-							},
-							{
-								$push: {
-									notifications: {
-										createdAt: new Date(),
-										_id: notifId,
-										type: 'reminder',
-										medium: 'nostr'
-									}
-								}
-							},
-							{ session }
-						);
-					}
-					if (subscription.user.email) {
-						const notifId = new ObjectId();
-						await collections.paidSubscriptions.updateOne(
-							{
-								_id: subscription._id
-							},
-							{
-								$push: {
-									notifications: {
-										createdAt: new Date(),
-										_id: notifId,
-										type: 'reminder',
-										medium: 'none' // todo: switch to "email"
-									}
-								}
-							},
-							{ session }
-						);
-						// todo
-					}
-				}).catch(console.error);
+			const subscriptionsToRemindEmail = getSubscriptionsToRemindViaEmail(now, reminderWindow);
+			for await (const subscription of subscriptionsToRemindEmail) {
+				await notifySubscriptionReminderViaEmail(subscription);
 			}
 		} catch (err) {
 			console.error(err);
 		}
 
 		try {
-			const subscriptionsToNotifyEnd = collections.paidSubscriptions.find({
-				paidUntil: {
-					$lt: new Date()
-				},
-				cancelledAt: { $exists: false },
-				'notifications.type': { $ne: 'expiration' }
-			});
+			const now = new Date();
+			const subscriptionsToNotifyEndNostr = getSubscriptionsToNotifyEndViaNostr(now);
+			for await (const subscription of subscriptionsToNotifyEndNostr) {
+				await notifySubscriptionEndedViaNostr(subscription);
+			}
 
-			for await (const subscription of subscriptionsToNotifyEnd) {
-				await withTransaction(async (session) => {
-					if (subscription.user.npub) {
-						const notifId = new ObjectId();
-						await collections.nostrNotifications.insertOne(
-							{
-								_id: notifId,
-								kind: Kind.EncryptedDirectMessage,
-								dest: subscription.user.npub,
-								content: `Your subscription #${subscription.number} expired. Renew here if you wish: ${ORIGIN}/subscription/${subscription._id}`,
-								createdAt: new Date(),
-								updatedAt: new Date()
-							},
-							{ session }
-						);
-						await collections.paidSubscriptions.updateOne(
-							{
-								_id: subscription._id
-							},
-							{
-								$push: {
-									notifications: {
-										createdAt: new Date(),
-										_id: notifId,
-										type: 'expiration',
-										medium: 'nostr'
-									}
-								}
-							},
-							{ session }
-						);
-					}
-					if (subscription.user.email) {
-						const notifId = new ObjectId();
-						// todo: send email & store in DB
-						await collections.paidSubscriptions.updateOne(
-							{
-								_id: subscription._id
-							},
-							{
-								$push: {
-									notifications: {
-										createdAt: new Date(),
-										_id: notifId,
-										type: 'expiration',
-										medium: 'none' // todo: set to 'email'
-									}
-								}
-							},
-							{ session }
-						);
-					}
-				}).catch(console.error);
+			const subscriptionsToNotifyEndEmail = getSubscriptionsToNotifyEndViaEmail(now);
+			for await (const subscription of subscriptionsToNotifyEndEmail) {
+				await notifySubscriptionEndedViaEmail(subscription);
 			}
 		} catch (err) {
 			console.error(err);

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -2139,23 +2139,50 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 			for (const discount of discountsForSubscription) {
 				addDiscountFreeProducts(discount, updatedFreeProductsById);
 			}
+			const newPaidUntil = add(max([existing.paidUntil, new Date()]), subscriptionDuration);
+
+			const archivedNotifications = existing.notifications.map((notif) => ({
+				...notif,
+				forPaidUntil: existing.paidUntil
+			}));
+
 			const result = await collections.paidSubscriptions.updateOne(
 				{ _id: existing._id },
 				{
 					$set: {
-						paidUntil: add(max([existing.paidUntil, new Date()]), subscriptionDuration),
+						paidUntil: newPaidUntil,
 						updatedAt: new Date(),
 						notifications: [],
 						...(Object.keys(updatedFreeProductsById).length !== 0 && {
 							freeProductsById: updatedFreeProductsById
 						})
 					},
+					...(archivedNotifications.length > 0 && {
+						$push: {
+							notificationHistory: { $each: archivedNotifications }
+						}
+					}),
 					$unset: { cancelledAt: 1 }
 				},
 				{ session }
 			);
 			if (!result.modifiedCount) {
 				throw new Error('Failed to update subscription');
+			}
+
+			if (existing.user.email) {
+				await queueEmail(
+					existing.user.email,
+					'subscription.renewed',
+					{
+						subscriptionNumber: existing.number.toString(),
+						newExpirationDate: newPaidUntil.toLocaleString(order.locale || 'en', {
+							dateStyle: 'full',
+							timeStyle: 'short'
+						})
+					},
+					{ session }
+				);
 			}
 		} else {
 			const freeProductsById: PaidSubscription['freeProductsById'] = {};

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -422,6 +422,35 @@ It contains the following product(s) that increase the leaderboard {{leaderboard
 <p>Opened by: {{openedBy}}</p>
 <p>Date: {{openedAt}}</p>`,
 			default: true as boolean
+		},
+		'subscription.reminder': {
+			subject: 'Your subscription #{{subscriptionNumber}} is expiring soon',
+			html: `<p>Dear customer,</p>
+<p>Your subscription #{{subscriptionNumber}} is going to expire {{expirationTime}}.</p>
+<p>To continue enjoying our services, please renew your subscription by following this link:</p>
+<p><a href="{{subscriptionLink}}">{{subscriptionLink}}</a></p>
+<p>If you have any questions, please contact us.</p>
+<p>Best regards,<br/>{{brandName}}</p>`,
+			default: true as boolean
+		},
+		'subscription.ended': {
+			subject: 'Your subscription #{{subscriptionNumber}} has expired',
+			html: `<p>Dear customer,</p>
+<p>Your subscription #{{subscriptionNumber}} has expired.</p>
+<p>If you wish to renew your subscription, please follow this link:</p>
+<p><a href="{{subscriptionLink}}">{{subscriptionLink}}</a></p>
+<p>Thank you for using our services.</p>
+<p>Best regards,<br/>{{brandName}}</p>`,
+			default: true as boolean
+		},
+		'subscription.renewed': {
+			subject: 'Your subscription #{{subscriptionNumber}} has been renewed',
+			html: `<p>Dear customer,</p>
+<p>Your subscription #{{subscriptionNumber}} has been successfully renewed!</p>
+<p>New expiration date: {{newExpirationDate}}</p>
+<p>Thank you for your continued support.</p>
+<p>Best regards,<br/>{{brandName}}</p>`,
+			default: true as boolean
 		}
 	}
 };

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -769,7 +769,9 @@
 	},
 	"subscription": {
 		"associated": {
-			"npub": "Associated to npub: {npub}"
+			"title": "Associated to:",
+			"npub": "Associated to npub: {npub}",
+			"email": "Associated to email: {email}"
 		},
 		"cantRenew": "Subscription not due for renewal",
 		"cta": {

--- a/src/lib/types/PaidSubscription.ts
+++ b/src/lib/types/PaidSubscription.ts
@@ -21,8 +21,16 @@ export interface PaidSubscription extends Timestamps {
 		type: 'reminder' | 'expiration';
 		createdAt: Date;
 		/** 'none' is in the case where the notification medium is not supported */
-		medium: 'nostr' | 'none'; // todo: email
+		medium: 'nostr' | 'email' | 'none';
 		_id: ObjectId;
+	}>;
+
+	notificationHistory?: Array<{
+		type: 'reminder' | 'expiration';
+		createdAt: Date;
+		medium: 'nostr' | 'email' | 'none';
+		_id: ObjectId;
+		forPaidUntil: Date;
 	}>;
 
 	cancelledAt?: Date;

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -15,7 +15,17 @@
 
 	<ProductItem product={data.product} picture={data.picture} />
 
-	<p>{t('subscription.associated.npub', { npub: data.subscription.npub })}</p>
+	{#if data.subscription.npub || data.subscription.email}
+		<div class="flex flex-col gap-1">
+			<p class="font-semibold">{t('subscription.associated.title')}</p>
+			{#if data.subscription.npub}
+				<p class="ml-4">npub: {data.subscription.npub}</p>
+			{/if}
+			{#if data.subscription.email}
+				<p class="ml-4">email: {data.subscription.email}</p>
+			{/if}
+		</div>
+	{/if}
 
 	<p>
 		<Trans key="subscription.initiallyCreated"


### PR DESCRIPTION
Added email notifications for subscription lifecycle events:
- Reminder email sent 24h before expiration
- Expiration notification when subscription ends
- Renewal confirmation email after successful payment

Updated notification medium type to support 'email' alongside 'nostr'. Fixed subscription renewal flow with proper user data handling.

Closes #2045