### PR TITLE
🐛  Fix VAT calculation rounding on invoices and receipts

### DIFF
--- a/src/lib/components/PriceTag.svelte
+++ b/src/lib/components/PriceTag.svelte
@@ -31,46 +31,48 @@
 	const mainCurrency = $currencies.main;
 	const secondaryCurrency = $currencies.secondary;
 
-	$: actualCurrency = main ? mainCurrency : secondary ? secondaryCurrency : convertedTo ?? currency;
+	$: actualCurrency = (
+		main ? mainCurrency : secondary ? secondaryCurrency : convertedTo ?? currency
+	) as Currency | null;
 	$: actualAmount = actualCurrency === null ? 0 : toCurrency(actualCurrency, amount, currency);
 
-	$: displayedAmount = !force
-		? actualCurrency === 'BTC' && actualAmount < 0.01
-			? actualAmount * SATOSHIS_PER_BTC
-			: actualCurrency === 'SAT' && actualAmount >= 1_000_000
-			? actualAmount / SATOSHIS_PER_BTC
-			: actualAmount
-		: actualAmount;
-	$: displayedCurrency = !force
-		? actualCurrency === 'BTC' && actualAmount < 0.01
-			? 'SAT'
-			: actualCurrency === 'SAT' && actualAmount >= 1_000_000
-			? 'BTC'
-			: actualCurrency || 'BTC'
-		: actualCurrency || 'BTC';
+	// Auto-conversion thresholds: small BTC amounts show as SAT, large SAT amounts show as BTC
+	$: [displayedAmount, displayedCurrency] = (() => {
+		if (!force && actualCurrency === 'BTC' && actualAmount < 0.01) {
+			return [actualAmount * SATOSHIS_PER_BTC, 'SAT'] as const;
+		}
+		if (!force && actualCurrency === 'SAT' && actualAmount >= 1_000_000) {
+			return [actualAmount / SATOSHIS_PER_BTC, 'BTC'] as const;
+		}
+		return [actualAmount, actualCurrency || 'BTC'] as const;
+	})() as [number, Currency];
 
-	$: displayed =
-		displayedCurrency !== 'BTC' && actualAmount > 0 && displayedAmount < 0.01
-			? '< ' +
-			  Number(0.01).toLocaleString('en', {
-					style: displayedCurrency === 'SAT' ? undefined : 'currency',
-					currency: displayedCurrency === 'SAT' ? undefined : displayedCurrency,
-					maximumFractionDigits: 2,
-					minimumFractionDigits: 0
-			  })
-			: displayedAmount.toLocaleString('en', {
-					style:
-						displayedCurrency === 'SAT' || displayedCurrency === 'BTC' ? undefined : 'currency',
-					currency:
-						displayedCurrency === 'SAT' || displayedCurrency === 'BTC'
-							? undefined
-							: displayedCurrency,
-					maximumFractionDigits: displayedCurrency === 'BTC' ? 8 : 2,
-					minimumFractionDigits:
-						!Number.isInteger(displayedAmount) && displayedCurrency !== 'BTC'
-							? FRACTION_DIGITS_PER_CURRENCY[displayedCurrency]
-							: 0
-			  }) + (displayedCurrency === 'SAT' && !short ? ' SAT' : '');
+	// Helper: check if currency is crypto (SAT or BTC)
+	$: isCrypto = displayedCurrency === 'SAT' || displayedCurrency === 'BTC';
+
+	// Determine decimal places based on currency
+	$: maximumFractionDigits = FRACTION_DIGITS_PER_CURRENCY[displayedCurrency];
+
+	$: minimumFractionDigits =
+		!Number.isInteger(displayedAmount) && !isCrypto ? maximumFractionDigits : 0;
+
+	// Edge case: very small fiat amounts (> 0 but < 0.01) show as "< 0.01"
+	$: isSmallFiatAmount = !isCrypto && actualAmount > 0 && displayedAmount < 0.01;
+
+	// Build small formatting config - crypto gets no currency symbol, fiat gets it
+	$: formatConfig = {
+		maximumFractionDigits,
+		minimumFractionDigits,
+		...(isCrypto ? {} : { style: 'currency' as const, currency: displayedCurrency })
+	} satisfies Intl.NumberFormatOptions;
+
+	$: formattedAmount = isSmallFiatAmount
+		? (0.01).toLocaleString('en', { style: 'currency', currency: displayedCurrency })
+		: displayedAmount.toLocaleString('en', formatConfig);
+
+	$: displayed = isSmallFiatAmount
+		? `< ${formattedAmount}`
+		: `${formattedAmount}${displayedCurrency === 'SAT' && !short ? ' SAT' : ''}`;
 </script>
 
 {#if actualCurrency}

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -49,6 +49,7 @@ import { checkCartItems } from './cart';
 import { userQuery } from './user';
 import { SMTP_USER } from '$lib/server/env-config';
 import { toCurrency } from '$lib/utils/toCurrency';
+import { convertAmountToCurrencyForStorage } from '$lib/utils/toStorageCurrency';
 import { CUSTOMER_ROLE_ID } from '$lib/types/User';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import type { PaymentMethod, PaymentProcessor } from './payment-methods';
@@ -1247,87 +1248,63 @@ export async function createOrder(
 					vatRate: priceInfo.vatRates[i],
 					currencySnapshot: {
 						main: {
-							price: {
-								amount: toCurrency(
-									runtimeConfig.mainCurrency,
-									item.product.price.amount,
-									item.product.price.currency
-								),
-								currency: runtimeConfig.mainCurrency
-							},
+							price: convertAmountToCurrencyForStorage(
+								runtimeConfig.mainCurrency,
+								item.product.price.amount,
+								item.product.price.currency
+							),
 							...(item.customPrice && {
-								customPrice: {
-									amount: toCurrency(
-										runtimeConfig.mainCurrency,
-										item.customPrice.amount,
-										item.customPrice.currency
-									),
-									currency: runtimeConfig.mainCurrency
-								}
+								customPrice: convertAmountToCurrencyForStorage(
+									runtimeConfig.mainCurrency,
+									item.customPrice.amount,
+									item.customPrice.currency
+								)
 							})
 						},
 						...(runtimeConfig.secondaryCurrency && {
 							secondary: {
-								price: {
-									amount: toCurrency(
-										runtimeConfig.secondaryCurrency,
-										item.product.price.amount,
-										item.product.price.currency
-									),
-									currency: runtimeConfig.secondaryCurrency
-								},
+								price: convertAmountToCurrencyForStorage(
+									runtimeConfig.secondaryCurrency,
+									item.product.price.amount,
+									item.product.price.currency
+								),
 								...(item.customPrice && {
-									customPrice: {
-										amount: toCurrency(
-											runtimeConfig.secondaryCurrency,
-											item.customPrice.amount,
-											item.customPrice.currency
-										),
-										currency: runtimeConfig.secondaryCurrency
-									}
+									customPrice: convertAmountToCurrencyForStorage(
+										runtimeConfig.secondaryCurrency,
+										item.customPrice.amount,
+										item.customPrice.currency
+									)
 								})
 							}
 						}),
 						...(runtimeConfig.accountingCurrency && {
 							accounting: {
-								price: {
-									amount: toCurrency(
-										runtimeConfig.accountingCurrency,
-										item.product.price.amount,
-										item.product.price.currency
-									),
-									currency: runtimeConfig.accountingCurrency
-								},
+								price: convertAmountToCurrencyForStorage(
+									runtimeConfig.accountingCurrency,
+									item.product.price.amount,
+									item.product.price.currency
+								),
 								...(item.customPrice && {
-									customPrice: {
-										amount: toCurrency(
-											runtimeConfig.accountingCurrency,
-											item.customPrice.amount,
-											item.customPrice.currency
-										),
-										currency: runtimeConfig.accountingCurrency
-									}
+									customPrice: convertAmountToCurrencyForStorage(
+										runtimeConfig.accountingCurrency,
+										item.customPrice.amount,
+										item.customPrice.currency
+									)
 								})
 							}
 						}),
 						priceReference: {
-							price: {
-								amount: toCurrency(
-									runtimeConfig.priceReferenceCurrency,
-									item.product.price.amount,
-									item.product.price.currency
-								),
-								currency: runtimeConfig.priceReferenceCurrency
-							},
+							price: convertAmountToCurrencyForStorage(
+								runtimeConfig.priceReferenceCurrency,
+								item.product.price.amount,
+								item.product.price.currency
+							),
 							...(item.customPrice && {
-								customPrice: {
-									amount: toCurrency(
-										runtimeConfig.priceReferenceCurrency,
-										item.customPrice.amount,
-										item.customPrice.currency
-									),
-									currency: runtimeConfig.priceReferenceCurrency
-								}
+								customPrice: convertAmountToCurrencyForStorage(
+									runtimeConfig.priceReferenceCurrency,
+									item.customPrice.amount,
+									item.customPrice.currency
+								)
 							})
 						}
 					}

--- a/src/lib/types/Currency.ts
+++ b/src/lib/types/Currency.ts
@@ -1,4 +1,5 @@
 import { error } from '@sveltejs/kit';
+import type { Price } from './Order';
 
 export const CURRENCIES = [
 	'BTC',
@@ -41,6 +42,32 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 	CZK: 2
 }) satisfies Record<Currency, number>;
 
+/**
+ * Maximum number of decimal places for storing prices WITHOUT VAT.
+ * This allows merchants to set precise base prices that result in round
+ * numbers after VAT calculation (e.g., 4.6253 CHF → 5.00 CHF with 8.1% VAT).
+ *
+ * Display precision remains FRACTION_DIGITS_PER_CURRENCY (2 for most currencies).
+ */
+const STORAGE_FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
+	BTC: 8,
+	CHF: 4,
+	EUR: 4,
+	USD: 4,
+	ZAR: 4,
+	XOF: 4,
+	XAF: 4,
+	CDF: 4,
+	SAT: 0,
+	KES: 4,
+	UGX: 4,
+	GHS: 4,
+	NGN: 4,
+	TZS: 4,
+	MAD: 4,
+	CZK: 4
+}) satisfies Record<Currency, number>;
+
 export const CURRENCY_UNIT = Object.freeze({
 	BTC: Math.pow(10, -FRACTION_DIGITS_PER_CURRENCY.BTC),
 	CHF: Math.pow(10, -FRACTION_DIGITS_PER_CURRENCY.CHF),
@@ -61,15 +88,84 @@ export const CURRENCY_UNIT = Object.freeze({
 }) satisfies Record<Currency, number>;
 
 export function parsePriceAmount(amount: string, currency: Currency): number {
-	//deleted Math.round()
+	// Use storage precision (4 decimals for fiat, 8 for BTC) instead of display precision
+	const storageDecimals = STORAGE_FRACTION_DIGITS_PER_CURRENCY[currency];
 	const priceAmount =
-		(parseFloat(amount) * Math.pow(10, FRACTION_DIGITS_PER_CURRENCY[currency])) /
-		Math.pow(10, FRACTION_DIGITS_PER_CURRENCY[currency]);
+		(parseFloat(amount) * Math.pow(10, storageDecimals)) / Math.pow(10, storageDecimals);
+
 	if (priceAmount > 0 && priceAmount < CURRENCY_UNIT[currency]) {
 		throw error(400, `Price must be zero or greater than ${CURRENCY_UNIT[currency]} ${currency}`);
 	}
 
 	return priceAmount;
+}
+
+/**
+ * Compute price for storage in database with full precision.
+ * Uses STORAGE_FRACTION_DIGITS_PER_CURRENCY (4 decimals for fiat, 8 for BTC).
+ *
+ * Use this when saving prices to preserve full precision for VAT calculations.
+ *
+ * @example
+ * computePriceForStorage(4.6253, 'CHF')
+ * // Returns: { amount: 4.6253, currency: 'CHF', precision: 4 }
+ */
+export function computePriceForStorage(amount: string | number, currency: Currency): Price {
+	const precision = STORAGE_FRACTION_DIGITS_PER_CURRENCY[currency];
+	const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount;
+	const rounded = Math.round(numAmount * Math.pow(10, precision)) / Math.pow(10, precision);
+
+	return {
+		amount: rounded,
+		currency,
+		precision
+	};
+}
+
+/**
+ * Compute price for display to users with standard precision.
+ * Uses FRACTION_DIGITS_PER_CURRENCY (2 decimals for fiat, 8 for BTC).
+ *
+ * Use this for displaying prices in UI when precision field is not needed.
+ *
+ * @example
+ * computePriceForDisplay(4.6253, 'CHF')
+ * // Returns: { amount: 4.63, currency: 'CHF' }
+ */
+export function computePriceForDisplay(amount: string | number, currency: Currency): Price {
+	const precision = FRACTION_DIGITS_PER_CURRENCY[currency];
+	const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount;
+	const rounded = Math.round(numAmount * Math.pow(10, precision)) / Math.pow(10, precision);
+
+	return {
+		amount: rounded,
+		currency
+	};
+}
+
+/**
+ * Read price from database and normalize precision field for backward compatibility.
+ *
+ * Ensures precision is always defined by defaulting to FRACTION_DIGITS_PER_CURRENCY
+ * (2 for fiat, 8 for BTC) for old records that don't have precision set.
+ *
+ * Use this when reading prices from the database to centralize backward compatibility logic.
+ *
+ * @example
+ * // Old record from DB (no precision field):
+ * readStoredPrice({ amount: 5.00, currency: 'CHF' })
+ * // Returns: { amount: 5.00, currency: 'CHF', precision: 2 }
+ *
+ * @example
+ * // New record from DB (has precision field):
+ * readStoredPrice({ amount: 4.6253, currency: 'CHF', precision: 4 })
+ * // Returns: { amount: 4.6253, currency: 'CHF', precision: 4 }
+ */
+export function readStoredPrice(storedPrice: Price): Price {
+	return {
+		...storedPrice,
+		precision: storedPrice.precision ?? FRACTION_DIGITS_PER_CURRENCY[storedPrice.currency]
+	};
 }
 
 /**

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -23,6 +23,27 @@ export type DiscountType = 'fiat' | 'percentage';
 export type Price = {
 	amount: number;
 	currency: Currency;
+	/**
+	 * Number of decimal places for storing this price.
+	 *
+	 * **Optional for backwards compatibility** - when undefined, defaults to
+	 * FRACTION_DIGITS_PER_CURRENCY (2 for fiat, 8 for BTC).
+	 *
+	 * New prices saved with storage precision will have this set to
+	 * STORAGE_FRACTION_DIGITS_PER_CURRENCY (4 for fiat, 8 for BTC).
+	 *
+	 * This allows storing precise base prices (e.g., 4.6253 CHF) that result
+	 * in round numbers after VAT calculation (e.g., 5.00 CHF with 8.1% VAT).
+	 *
+	 * @example
+	 * // Old price from DB (no precision field):
+	 * { amount: 5.00, currency: 'CHF' }  // precision defaults to 2
+	 *
+	 * @example
+	 * // New price from DB (with precision):
+	 * { amount: 4.6253, currency: 'CHF', precision: 4 }
+	 */
+	precision?: number;
 };
 
 export interface Note {

--- a/src/lib/utils/toStorageCurrency.ts
+++ b/src/lib/utils/toStorageCurrency.ts
@@ -1,0 +1,39 @@
+import { exchangeRate } from '$lib/stores/exchangeRate';
+import { computePriceForStorage, type Currency } from '$lib/types/Currency';
+import type { Price } from '$lib/types/Order';
+import { get } from 'svelte/store';
+
+/**
+ * Convert amount to target currency with storage precision (4 decimals for fiat, 8 for BTC).
+ * Returns a Price object with currency and precision fields for type safety.
+ *
+ * Use this when storing prices in database to preserve full precision for VAT calculations.
+ * For display purposes, use toCurrency() which rounds to FRACTION_DIGITS_PER_CURRENCY (2 decimals for fiat).
+ *
+ * @example
+ * convertAmountToCurrencyForStorage('CHF', 4.625, 'CHF')
+ * // Returns: { amount: 4.6250, currency: 'CHF', precision: 4 }
+ *
+ * @example
+ * convertAmountToCurrencyForStorage('EUR', 100, 'CHF')  // with exchange rate
+ * // Returns: { amount: 95.2341, currency: 'EUR', precision: 4 }
+ */
+export function convertAmountToCurrencyForStorage(
+	targetCurrency: Currency,
+	amount: number,
+	fromCurrency: Currency
+): Price {
+	// If currencies are the same, round to storage precision
+	if (fromCurrency === targetCurrency) {
+		return computePriceForStorage(amount, targetCurrency);
+	}
+
+	// Convert through BTC as intermediate currency
+	const bitcoinAmount = fromCurrency === 'BTC' ? amount : amount / get(exchangeRate)[fromCurrency];
+
+	const converted =
+		targetCurrency === 'BTC' ? bitcoinAmount : bitcoinAmount * get(exchangeRate)[targetCurrency];
+
+	// Use existing function instead of duplicating rounding logic
+	return computePriceForStorage(converted, targetCurrency);
+}

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
@@ -3,15 +3,12 @@
 	import PriceTag from '$lib/components/PriceTag.svelte';
 	import Trans from '$lib/components/Trans.svelte';
 	import { useI18n } from '$lib/i18n.js';
-	import {
-		invoiceNumberVariables,
-		orderIndividualItemPrice,
-		orderItemPrice
-	} from '$lib/types/Order.js';
+	import { invoiceNumberVariables, orderIndividualItemPrice } from '$lib/types/Order.js';
 	import { fixCurrencyRounding } from '$lib/utils/fixCurrencyRounding';
 	import { sum } from '$lib/utils/sum.js';
 	import { sumCurrency } from '$lib/utils/sumCurrency.js';
 	import { marked } from 'marked';
+	import { computePriceForDisplay } from '$lib/types/Currency';
 
 	export let data;
 
@@ -193,6 +190,12 @@
 				{@const priceCurrency =
 					item.currencySnapshot.main.customPrice?.currency ??
 					item.currencySnapshot.main.price.currency}
+				{@const unitPrice = orderIndividualItemPrice(item, 'main')}
+				{@const paidQuantity = item.quantity - (item.freeQuantity ?? 0)}
+				{@const totalPrice = unitPrice * paidQuantity}
+				{@const vatRate = item.vatRate ?? 0}
+				{@const vatAmount = (totalPrice * vatRate) / 100}
+				{@const totalWithVat = computePriceForDisplay(totalPrice + vatAmount, priceCurrency).amount}
 				<tr style:background-color={i % 2 === 0 ? '#fef2cc' : '#e7e6e6'}>
 					<td class="text-center border border-white px-2">{i + 1}</td>
 					<td class="text-center border border-white px-2"
@@ -205,30 +208,18 @@
 							: item.product.name}</td
 					>
 					<td class="text-center border border-white px-2"
-						>{item.quantity - (item.freeQuantity ?? 0)}
+						>{paidQuantity}
 						{item.freeQuantity ? '+' + item.freeQuantity : ''}</td
 					>
 					<td class="text-center border border-white px-2">
-						<PriceTag
-							amount={orderIndividualItemPrice(item, 'main')}
-							currency={priceCurrency}
-							inline
-						/>
+						<PriceTag amount={unitPrice} currency={priceCurrency} inline />
 					</td>
-					<td class="text-center border border-white px-2">{item.vatRate ?? 0}%</td>
+					<td class="text-center border border-white px-2">{vatRate}%</td>
 					<td class="text-center border border-white px-2">
-						<PriceTag
-							amount={(orderItemPrice(item, 'main') * (item.vatRate ?? 0)) / 100}
-							currency={priceCurrency}
-							inline
-						/>
+						<PriceTag amount={vatAmount} currency={priceCurrency} inline />
 					</td>
 					<td class="text-right border border-white px-2">
-						<PriceTag
-							amount={(orderItemPrice(item, 'main') * (100 + (item.vatRate ?? 0))) / 100}
-							currency={priceCurrency}
-							inline
-						/>
+						<PriceTag amount={totalWithVat} currency={priceCurrency} inline />
 					</td>
 				</tr>
 			{/each}

--- a/src/routes/(app)/order/[id]/summary/+page.svelte
+++ b/src/routes/(app)/order/[id]/summary/+page.svelte
@@ -7,6 +7,7 @@
 	import { sum } from '$lib/utils/sum.js';
 	import { differenceInMinutes } from 'date-fns';
 	import { marked } from 'marked';
+	import { computePriceForDisplay } from '$lib/types/Currency';
 
 	export let data;
 
@@ -112,10 +113,19 @@
 		{#each data.order.items as item, i}
 			{@const price =
 				item.currencySnapshot.main.customPrice?.amount ?? item.currencySnapshot.main.price.amount}
-			<!--{@const unitPrice = price / item.quantity}-->
 			{@const priceCurrency =
 				item.currencySnapshot.main.customPrice?.currency ??
 				item.currencySnapshot.main.price.currency}
+			{@const bookingMultiplier =
+				item.booking && item.product.bookingSpec
+					? differenceInMinutes(item.booking.end, item.booking.start) /
+					  item.product.bookingSpec.slotMinutes
+					: 1}
+			{@const unitPrice = price * bookingMultiplier}
+			{@const totalPrice = unitPrice * item.quantity}
+			{@const vatRate = item.vatRate ?? 0}
+			{@const vatAmount = (totalPrice * vatRate) / 100}
+			{@const totalWithVat = computePriceForDisplay(totalPrice + vatAmount, priceCurrency).amount}
 			<tr style:background-color={i % 2 === 0 ? '#fef2cc' : '#e7e6e6'}>
 				<td class="text-center border border-white px-2">{i + 1}</td>
 				<td class="text-center border border-white px-2"
@@ -129,36 +139,14 @@
 				>
 				<td class="text-center border border-white px-2">{item.quantity}</td>
 				<td class="text-center border border-white px-2">
-					<PriceTag
-						amount={price *
-							(item.booking && item.product.bookingSpec
-								? differenceInMinutes(item.booking.end, item.booking.start) /
-								  item.product.bookingSpec.slotMinutes
-								: 1)}
-						currency={priceCurrency}
-						inline
-					/>
+					<PriceTag amount={unitPrice} currency={priceCurrency} inline />
 				</td>
-				<td class="text-center border border-white px-2">{item.vatRate ?? 0}%</td>
+				<td class="text-center border border-white px-2">{vatRate}%</td>
 				<td class="text-center border border-white px-2">
-					<PriceTag
-						amount={(price *
-							(item.booking && item.product.bookingSpec
-								? differenceInMinutes(item.booking.end, item.booking.start) /
-								  item.product.bookingSpec.slotMinutes
-								: 1) *
-							(item.vatRate ?? 0)) /
-							100}
-						currency={priceCurrency}
-						inline
-					/>
+					<PriceTag amount={vatAmount} currency={priceCurrency} inline />
 				</td>
 				<td class="text-right border border-white px-2">
-					<PriceTag
-						amount={price * item.quantity + (price * (item.vatRate ?? 0)) / 100}
-						currency={priceCurrency}
-						inline
-					/>
+					<PriceTag amount={totalWithVat} currency={priceCurrency} inline />
 				</td>
 			</tr>
 		{/each}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
@@ -102,7 +102,7 @@
 										<PriceTag amount={itemPrice.amount} currency={itemPrice.currency} main />
 										<div>{t('pos.split.vatRate', { rate: itemVatRate })}</div>
 										<PriceTag
-											amount={itemPrice.amount * itemVatRate}
+											amount={(itemPrice.amount * itemVatRate) / 100}
 											currency={itemPrice.currency}
 											main
 										/>
@@ -185,7 +185,7 @@
 											<PriceTag amount={itemPrice.amount} currency={itemPrice.currency} main />
 											<div>{t('pos.split.vatRate', { rate: itemVatRate })}</div>
 											<PriceTag
-												amount={itemPrice.amount * itemVatRate}
+												amount={(itemPrice.amount * itemVatRate) / 100}
 												currency={itemPrice.currency}
 												main
 											/>


### PR DESCRIPTION
  Merchants can now set precise prices that result in round numbers after VAT is applied.

  Previously, setting a price like CHF 4.63 with 8.1% VAT would display incorrectly as CHF 5.01 instead of CHF 5.00 on invoices and receipts. This happened because the system rounded prices too early in
  calculations.

  Now you can set exact prices (like CHF 4.6253) that calculate to perfect round numbers with VAT (CHF 5.00), making invoices cleaner and more professional.

  Issue #2124