### PR TITLE
Support for full-HTML CMS pages

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,25 +1,9 @@
 <!doctype html>
 <html>
 	<head>
-		<meta charset="utf-8" />
-		<script>
-			const theme = localStorage.getItem('theme') ?? document.documentElement.dataset.theme;
-			if (theme === 'dark') {
-				document.documentElement.classList.add('dark');
-			} else if (theme === 'light') {
-				document.documentElement.classList.remove('dark');
-			} else {
-				if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-					document.documentElement.classList.add('dark');
-				} else {
-					document.documentElement.classList.remove('dark');
-				}
-			}
-		</script>
 		%sveltekit.head%
 	</head>
-
 	<body>
-		<div style="display: contents">%sveltekit.body%</div>
+		%sveltekit.body%
 	</body>
 </html>

--- a/src/lib/components/CmsPage.svelte
+++ b/src/lib/components/CmsPage.svelte
@@ -48,23 +48,26 @@
 	export let galleries: CmsGallery[];
 	export let leaderboards: CmsLeaderboard[];
 	export let schedules: CmsSchedule[];
+	$: contentIsHtmlDocument = tokens.desktop[0]?.type === 'htmlDocumentMarker';
 
 	const { t } = useI18n();
 </script>
 
 <svelte:head>
-	<title>{cmsPage.title}</title>
-	{#if cmsPage.hideFromSEO}
-		<meta name="robots" content="noindex" />
-	{/if}
-	{#if cmsPage.metas?.length}
-		{#each cmsPage.metas as meta}
-			<meta name={meta.name} content={meta.content} />
-		{/each}
+	{#if !contentIsHtmlDocument}
+		<title>{cmsPage.title}</title>
+		{#if cmsPage.hideFromSEO}
+			<meta name="robots" content="noindex" />
+		{/if}
+		{#if cmsPage.metas?.length}
+			{#each cmsPage.metas as meta}
+				<meta name={meta.name} content={meta.content} />
+			{/each}
+		{/if}
 	{/if}
 </svelte:head>
 
-{#if cmsPage.fullScreen}
+{#if cmsPage.fullScreen || contentIsHtmlDocument}
 	<CmsDesign
 		{products}
 		{pictures}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -131,519 +131,526 @@
 	We use data-sveltekit-preload-data="off" on header/footer links due to this: 	https://github.com/sveltejs/kit/issues/9508#issuecomment-1807200239
 -->
 
-<div data-sveltekit-preload-data={data.isMaintenance ? 'tap' : 'hover'} style="display: contents;">
-	{#if $page.data.layoutReset || $page.url.searchParams.get('display') === 'headless'}
-		<slot />
-	{:else}
-		<header class="header items-center flex h-[100px] print:hidden">
-			<div class="mx-auto max-w-7xl flex items-center gap-6 px-6 grow">
-				<a class="flex items-center gap-4" href="/">
-					{#if data.logoPicture}
-						<Picture class="dark:hidden {logoClass}" picture={data.logoPicture} />
-						<Picture
-							class="hidden dark:inline {logoClass}"
-							picture={data.logoPictureDark || data.logoPicture}
-						/>
-					{:else}
-						<img class="hidden dark:inline {logoClass}" src={DEFAULT_LOGO} alt="" />
-						<img class="dark:hidden {logoClass}" src={DEFAULT_LOGO_DARK} alt="" />
-					{/if}
-					{#if !data.logo.isWide}
-						<span class="header-shopName font-bold text-[24px]">{data.brandName}</span>
-					{/if}
-				</a>
-				<span class="grow body-mainPlan" />
-				<nav class="flex gap-10 text-[22px] font-semibold header-tab">
-					{#each data.links.topbar as link}
-						<a
-							href={link.href.includes('/') || /^[a-zA-Z]+:/.test(link.href)
-								? link.href
-								: `/${link.href}`}
-							class=" {data.notResponsive ? '' : 'hidden lg:inline'}"
-							data-sveltekit-preload-data="off"
-							target={/^[a-zA-Z]+:/.test(link.href) ? '_blank' : '_self'}
-						>
-							{link.label}
-						</a>
-					{/each}
-				</nav>
-				<button
-					class="inline-flex flex-col justify-center {data.notResponsive ||
-					!data.links.topbar.length
-						? 'hidden'
-						: 'lg:hidden'} cursor-pointer text-4xl transition header-tab"
-					class:rotate-90={topMenuOpen}
-					on:click={() => (topMenuOpen = !topMenuOpen)}
-				>
-					<IconMenu />
-				</button>
-			</div>
-		</header>
-		{#if topMenuOpen}
-			<nav
-				transition:slide
-				class="header print:hidden header-tab flex flex-col lg:hidden text-[22px] font-semibold border-x-0 border-b-0 border-opacity-25 border-t-1 border-white px-10 py-4"
-			>
-				{#each data.links.topbar as link}
-					<a
-						class="py-4"
-						href={link.href.includes('/') || /^[a-zA-Z]+:/.test(link.href)
-							? link.href
-							: `/${link.href}`}
-						target={/^[a-zA-Z]+:/.test(link.href) ? '_blank' : '_self'}
-						data-sveltekit-preload-data="off">{link.label}</a
-					>
-				{/each}
-			</nav>
-		{/if}
-		<header class="navbar h-[66px] items-center flex print:hidden">
-			<div class="mx-auto max-w-7xl flex items-center gap-6 px-6 grow">
-				<nav class="flex gap-6 font-light items-center">
+{#if !!$page.data.disableAppLayout}
+	<slot />
+{:else}
+	<div
+		data-sveltekit-preload-data={data.isMaintenance ? 'tap' : 'hover'}
+		style="display: contents;"
+	>
+		{#if $page.data.layoutReset || $page.url.searchParams.get('display') === 'headless'}
+			<slot />
+		{:else}
+			<header class="header items-center flex h-[100px] print:hidden">
+				<div class="mx-auto max-w-7xl flex items-center gap-6 px-6 grow">
+					<a class="flex items-center gap-4" href="/">
+						{#if data.logoPicture}
+							<Picture class="dark:hidden {logoClass}" picture={data.logoPicture} />
+							<Picture
+								class="hidden dark:inline {logoClass}"
+								picture={data.logoPictureDark || data.logoPicture}
+							/>
+						{:else}
+							<img class="hidden dark:inline {logoClass}" src={DEFAULT_LOGO} alt="" />
+							<img class="dark:hidden {logoClass}" src={DEFAULT_LOGO_DARK} alt="" />
+						{/if}
+						{#if !data.logo.isWide}
+							<span class="header-shopName font-bold text-[24px]">{data.brandName}</span>
+						{/if}
+					</a>
+					<span class="grow body-mainPlan" />
+					<nav class="flex gap-10 text-[22px] font-semibold header-tab">
+						{#each data.links.topbar as link}
+							<a
+								href={link.href.includes('/') || /^[a-zA-Z]+:/.test(link.href)
+									? link.href
+									: `/${link.href}`}
+								class=" {data.notResponsive ? '' : 'hidden lg:inline'}"
+								data-sveltekit-preload-data="off"
+								target={/^[a-zA-Z]+:/.test(link.href) ? '_blank' : '_self'}
+							>
+								{link.label}
+							</a>
+						{/each}
+					</nav>
 					<button
 						class="inline-flex flex-col justify-center {data.notResponsive ||
-						!data.links.navbar.length
+						!data.links.topbar.length
 							? 'hidden'
-							: 'lg:hidden'} cursor-pointer text-2xl transition"
-						class:rotate-90={navMenuOpen}
-						on:click={() => (navMenuOpen = !navMenuOpen)}
+							: 'lg:hidden'} cursor-pointer text-4xl transition header-tab"
+						class:rotate-90={topMenuOpen}
+						on:click={() => (topMenuOpen = !topMenuOpen)}
 					>
 						<IconMenu />
 					</button>
-
-					{#each data.links.navbar as link}
+				</div>
+			</header>
+			{#if topMenuOpen}
+				<nav
+					transition:slide
+					class="header print:hidden header-tab flex flex-col lg:hidden text-[22px] font-semibold border-x-0 border-b-0 border-opacity-25 border-t-1 border-white px-10 py-4"
+				>
+					{#each data.links.topbar as link}
 						<a
+							class="py-4"
 							href={link.href.includes('/') || /^[a-zA-Z]+:/.test(link.href)
 								? link.href
 								: `/${link.href}`}
-							class={data.notResponsive ? '' : 'hidden lg:inline'}
 							target={/^[a-zA-Z]+:/.test(link.href) ? '_blank' : '_self'}
 							data-sveltekit-preload-data="off">{link.label}</a
 						>
 					{/each}
 				</nav>
+			{/if}
+			<header class="navbar h-[66px] items-center flex print:hidden">
+				<div class="mx-auto max-w-7xl flex items-center gap-6 px-6 grow">
+					<nav class="flex gap-6 font-light items-center">
+						<button
+							class="inline-flex flex-col justify-center {data.notResponsive ||
+							!data.links.navbar.length
+								? 'hidden'
+								: 'lg:hidden'} cursor-pointer text-2xl transition"
+							class:rotate-90={navMenuOpen}
+							on:click={() => (navMenuOpen = !navMenuOpen)}
+						>
+							<IconMenu />
+						</button>
 
-				<div class="flex items-center ml-auto gap-2">
-					<div class="flex flex-row relative">
-						{#if !data.hideCartInToolbar}
+						{#each data.links.navbar as link}
 							<a
-								href="/cart"
-								on:click={(ev) => {
-									const isMobile = window.innerWidth < LARGE_SCREEN;
-									if (!items.length || $page.url.pathname === '/checkout' || isMobile) {
-										return;
-									}
-									cartOpen = !cartOpen;
-									ev.preventDefault();
-								}}
-								class="flex gap-2 items-center"
-							>
-								<IconBasket />
-								{totalItems}
-							</a>
-						{/if}
-						{#if $productAddedToCart && !$productAddedToCart.widget}
-							<Popup>
-								<ProductAddedToCart
-									class="w-[562px] max-w-full"
-									on:dismiss={() => ($productAddedToCart = null)}
-									product={$productAddedToCart.product}
-									picture={$productAddedToCart.picture}
-									priceMultiplier={$productAddedToCart.priceMultiplier}
-									customPrice={$productAddedToCart.customPrice}
-									chosenVariations={$productAddedToCart.chosenVariations}
-									depositPercentage={$productAddedToCart.depositPercentage}
-									discountPercentage={$productAddedToCart.discountPercentage}
-									removePopinProductPrice={data.removePopinProductPrice}
-								/>
-							</Popup>
-						{:else if cartOpen}
-							<Popup>
-								<div class="p-2 gap-2 flex flex-col cartPreview">
-									{#each items as item, i}
-										{@const price = priceInfo.perItem[i]}
-										{#if cartErrorMessage && cartErrorProductId === item.product._id}
-											<div class="text-red-600 text-sm">{cartErrorMessage}</div>
-										{/if}
-										<form
-											class="flex border-b border-gray-300 pb-2 gap-2"
-											method="POST"
-											use:enhance={({ action }) => {
-												cartErrorMessage = '';
-												if (action.searchParams.has('/increase')) {
-													item.quantity++;
-												} else if (action.searchParams.has('/decrease')) {
-													item.quantity--;
-												} else if (action.searchParams.has('/remove')) {
-													item.quantity = 0;
-												}
-												actionCount++;
-												let currentCount = actionCount;
-
-												return async ({ result }) => {
-													if (actionCount === currentCount) {
-														if (result.type === 'redirect') {
-															// Invalidate all to remove 0-quantity items
-															await goto(result.location, {
-																noScroll: true,
-																invalidateAll: true
-															});
-															return;
-														}
-														if (result.type === 'error' && result.error?.message) {
-															cartErrorMessage = result.error.message;
-															cartErrorProductId = item.product._id;
-															await invalidate(UrlDependency.Cart);
-															return;
-														}
-														await applyAction(result);
-													}
-												};
-											}}
-										>
-											{#if item._id}
-												<input type="hidden" name="lineId" value={item._id} />
-											{/if}
-											{#if item.depositPercentage ?? undefined !== undefined}
-												<input
-													type="hidden"
-													name="depositPercentage"
-													value={item.depositPercentage}
-												/>
-											{/if}
-											<a
-												href="/product/{item.product._id}"
-												class="w-[44px] h-[44px] min-w-[44px] min-h-[44px] rounded flex items-center"
-											>
-												{#if item.picture}
-													<Picture
-														picture={item.picture}
-														class="mx-auto rounded h-full object-contain"
-														sizes="44px"
-													/>
-												{/if}
-											</a>
-											<div class="flex flex-col">
-												<a href="/product/{item.product._id}">
-													<h3 class="text-base font-medium">
-														{item.chosenVariations
-															? item.product.name +
-															  ' - ' +
-															  Object.entries(item.chosenVariations)
-																	.map(
-																		([key, value]) =>
-																			item.product.variationLabels?.values[key][value]
-																	)
-																	.join(' - ')
-															: item.product.name}
-													</h3>
-												</a>
-												{#if !oneMaxPerLine(item.product)}
-													<div class="flex items-center gap-2">
-														<span class="text-xs">{t('cart.quantity')}: </span>
-														<CartQuantity {item} sm disabled={!data.cartPreviewInteractive} />
-													</div>
-												{/if}
-											</div>
-
-											<div class="flex flex-col items-end gap-[6px] ml-auto">
-												<PriceTag
-													class="text-base"
-													amount={(price.amount * (item.depositPercentage ?? 100)) / 100}
-													currency={price.currency}
-													main
-													>{item.depositPercentage
-														? `(${(item.depositPercentage / 100).toLocaleString($locale, {
-																style: 'percent'
-														  })})`
-														: ''}
-												</PriceTag>
-												{#if data.cartPreviewInteractive}
-													<button formaction="/cart/{item.product._id}/?/remove">
-														<IconTrash class="body-secondaryText" />
-														<span class="sr-only">{t('cart.sr.remove')}</span>
-													</button>
-												{/if}
-											</div>
-										</form>
-									{/each}
-									{#if deliveryFees}
-										<div class="flex gap-1 text-lg justify-end items-center">
-											{t('checkout.deliveryFees')}
-											<div
-												title={t('checkout.deliveryFeesEstimationTooltip')}
-												class="cursor-pointer"
-											>
-												<IconInfo />
-											</div>
-
-											<PriceTag
-												class="truncate"
-												amount={deliveryFees}
-												currency={UNDERLYING_CURRENCY}
-												main
-											/>
-										</div>
-									{:else if isNaN(deliveryFees)}
-										<div class="alert-error mt-3">
-											{t('checkout.noDeliveryInCountry')}
-										</div>
-									{/if}
-									{#if items.some((item) => item.product.shipping) && priceInfo.physicalVatAtCustoms}
-										<div class="flex gap-1 text-lg justify-end items-center">
-											{t('product.vatExcluded')}
-											<div title={t('cart.vatNullOutsideSellerCountry')}>
-												<IconInfo class="cursor-pointer" />
-											</div>
-										</div>
-									{/if}
-									{#each priceInfo.vat as vat}
-										<div class="flex gap-1 text-lg justify-end items-center">
-											{t('cart.vat')} ({vat.rate}%) <PriceTag
-												currency={vat.partialPrice.currency}
-												amount={vat.partialPrice.amount}
-												main
-											/>
-										</div>
-									{/each}
-									<div class="flex gap-1 text-xl justify-end items-center">
-										{t('cart.total')}
-										<PriceTag
-											currency={priceInfo.currency}
-											amount={priceInfo.partialPriceWithVat}
-											main
-										/>
-									</div>
-									{#if priceInfo.totalPriceWithVat !== priceInfo.partialPriceWithVat}
-										<div class="flex gap-1 text-lg justify-end items-center">
-											{t('cart.remainingShort')}
-											<PriceTag
-												currency={priceInfo.currency}
-												amount={priceInfo.totalPriceWithVat - priceInfo.partialPriceWithVat}
-												main
-											/>
-										</div>
-									{/if}
-									<a href="/cart" class="btn cartPreview-mainCTA mt-1 whitespace-nowrap">
-										{t('cart.cta.view')}
-									</a>
-									<a
-										href="/checkout"
-										class="btn cartPreview-secondaryCTA {!physicalCartCanBeOrdered
-											? 'opacity-50'
-											: ''}"
-										style="pointer-events: {!physicalCartCanBeOrdered ? 'none' : ''};"
-									>
-										{t('cart.cta.checkout')}
-									</a>
-								</div>
-							</Popup>
-						{/if}
-						{#if !data.hideThemeSelectorInToolbar}
-							<div class="flex relative">
-								<button
-									class="ml-4 flex items-center gap-2 rounded text-xl"
-									on:click={() => (open = !open)}
-								>
-									{#each options as opt (opt.value)}
-										{#if opt.value === $theme}
-											<svelte:component this={opt.icon} class="w-5 h-5" />
-										{/if}
-									{/each}
-								</button>
-
-								{#if open}
-									<div class="absolute left-10 mt-2 shadow-lg rounded z-10 navbar">
-										{#each options as opt}
-											<button
-												class="flex items-center gap-2 w-full px-4 py-2 text-left"
-												on:click={() => setTheme(opt.value)}
-											>
-												<svelte:component this={opt.icon} class="w-5 h-5" />
-												<span class="hidden lg:contents">{opt.label}</span>
-											</button>
-										{/each}
-									</div>
-								{/if}
-							</div>
-						{/if}
-
-						{#if !data.disableLanguageSelector && data.locales.length > 1}
-							<select
-								class="ml-4 border-0 cursor-pointer rounded appearance-none bg-none bg-transparent text-xl p-0"
-								size="0"
-								bind:value={$locale}
-								on:change={() => {
-									document.cookie = `lang=${$locale};path=/;max-age=31536000`;
-									window.location.reload();
-								}}
-							>
-								{#each data.locales as locale}
-									<option style="background-color: var(--navbar-backgroundColor);" value={locale}>
-										{locale}
-									</option>
-								{/each}
-							</select>
-						{/if}
-					</div>
-				</div>
-			</div>
-		</header>
-		{#if navMenuOpen}
-			<nav
-				transition:slide
-				class="navbar print:hidden header-tab font-light flex flex-col lg:hidden border-x-0 border-b-0 border-opacity-25 border-t-1 border-white px-4 pb-3"
-			>
-				{#each data.links.navbar as link}
-					<a
-						class="py-2 hover:underline"
-						data-sveltekit-preload-data="off"
-						href={link.href.includes('/') || /^[a-zA-Z]+:/.test(link.href)
-							? link.href
-							: `/${link.href}`}>{link.label}</a
-					>
-				{/each}
-			</nav>
-		{/if}
-
-		{#if $page.url.pathname.startsWith('/admin')}
-			<div class="grow body-mainPlan">
-				<slot />
-			</div>
-		{:else if $page.url.pathname === '/pos'}
-			<div class="grow body-mainPlan">
-				<slot />
-			</div>
-		{:else}
-			<div class="grow body-mainPlan">
-				{#if data.ageRestriction.enabled && !data.sessionAcceptAgeLimitation && !$page.url.pathname.startsWith('/admin')}
-					<form class="mx-auto max-w-7xl" method="POST" action="{data.websiteLink}?/navigate">
-						{#if data.cmsAgewall && data.cmsAgewallData}
-							<CmsDesign
-								{...data.cmsAgewallData}
-								hasPosOptions={data.hasPosOptions}
-								pageName={data.cmsAgewall?.title}
-								websiteLink={data.websiteLink}
-								brandName={data.brandName}
-								sessionEmail={data.email}
-								class={data.hideCmsZonesOnMobile
-									? 'prose max-w-full hidden lg:contents'
-									: 'prose max-w-full'}
-							/>
-						{/if}
-						<label class="label-checkbox my-4">
-							<input type="checkbox" class="form-checkbox" bind:checked={ageWarning} />
-							{t('ageWarning.agreement')}
-						</label>
-						<input
-							type="submit"
-							class="btn body-mainCTA my-4 w-full"
-							value={t('ageWarning.navigate')}
-							disabled={!ageWarning}
-						/>
-					</form>
-				{:else}
-					<slot />
-				{/if}
-			</div>
-		{/if}
-
-		<footer class="footer h-auto items-center flex print:hidden">
-			<div
-				class="mx-auto max-w-7xl px-6 py-6 items-start justify-between gap-y-8 w-full grid grid-cols-1 lg:flex lg:flex-wrap gap-4"
-			>
-				{#if data.displayCompanyInfo && data.sellerIdentity}
-					<div>
-						<h3 class="text-lg font-semibold mb-2 uppercase">{t('footer.company.identity')}</h3>
-						<p class="whitespace-pre-line">
-							{textAddress({
-								firstName: data.sellerIdentity.businessName,
-								lastName: '',
-								address: data.sellerIdentity.address.street,
-								zip: data.sellerIdentity.address.zip,
-								city: data.sellerIdentity.address.city,
-								country: data.sellerIdentity.address.country,
-								state: data.sellerIdentity.address.state
-							})}
-						</p>
-					</div>
-				{/if}
-
-				{#if data.displayMainShopInfo && data.shopInformation}
-					<div>
-						<h3 class="text-lg font-semibold mb-2 uppercase">{t('footer.shop.info')}</h3>
-						<p class="whitespace-pre-line">
-							{textAddress({
-								firstName: data.shopInformation.businessName,
-								lastName: '',
-								address: data.shopInformation.address.street,
-								zip: data.shopInformation.address.zip,
-								city: data.shopInformation.address.city,
-								country: data.shopInformation.address.country,
-								state: data.shopInformation.address.state
-							})}
-						</p>
-					</div>
-				{/if}
-
-				{#if data.displayCompanyInfo && data.sellerIdentity}
-					{#if data.sellerIdentity.contact.email || data.sellerIdentity.contact.phone}
-						<div>
-							<h3 class="text-lg font-semibold mb-2 uppercase">{t('footer.company.contact')}</h3>
-							{#if data.sellerIdentity.contact.email}
-								<a href="mailto:{data.sellerIdentity.contact.email}">
-									{data.sellerIdentity.contact.email}
-								</a>
-							{/if}
-							<br />
-							{#if data.sellerIdentity.contact.phone}
-								<a href="tel:{data.sellerIdentity.contact.phone}">
-									{data.sellerIdentity.contact.phone}
-								</a>
-							{/if}
-						</div>
-					{/if}
-				{/if}
-
-				<div class="flex flex-col gap-4 items-end lg:items-center">
-					<div class="flex items-end lg:flex-row flex-col gap-2">
-						{#each data.links.footer as link}
-							<a
-								class={link.label === '-' ? 'hidden lg:contents' : ''}
 								href={link.href.includes('/') || /^[a-zA-Z]+:/.test(link.href)
 									? link.href
 									: `/${link.href}`}
+								class={data.notResponsive ? '' : 'hidden lg:inline'}
 								target={/^[a-zA-Z]+:/.test(link.href) ? '_blank' : '_self'}
 								data-sveltekit-preload-data="off">{link.label}</a
 							>
 						{/each}
-					</div>
-					<div class="flex flex-row gap-1">
-						{#each data.links.socialNetworkIcons as icon}
-							<a href={icon.href} target="_blank"
-								><img src="data:image/svg+xml;utf8, {icon.svg}" alt={icon.name} /></a
-							>
-						{/each}
+					</nav>
+
+					<div class="flex items-center ml-auto gap-2">
+						<div class="flex flex-row relative">
+							{#if !data.hideCartInToolbar}
+								<a
+									href="/cart"
+									on:click={(ev) => {
+										const isMobile = window.innerWidth < LARGE_SCREEN;
+										if (!items.length || $page.url.pathname === '/checkout' || isMobile) {
+											return;
+										}
+										cartOpen = !cartOpen;
+										ev.preventDefault();
+									}}
+									class="flex gap-2 items-center"
+								>
+									<IconBasket />
+									{totalItems}
+								</a>
+							{/if}
+							{#if $productAddedToCart && !$productAddedToCart.widget}
+								<Popup>
+									<ProductAddedToCart
+										class="w-[562px] max-w-full"
+										on:dismiss={() => ($productAddedToCart = null)}
+										product={$productAddedToCart.product}
+										picture={$productAddedToCart.picture}
+										priceMultiplier={$productAddedToCart.priceMultiplier}
+										customPrice={$productAddedToCart.customPrice}
+										chosenVariations={$productAddedToCart.chosenVariations}
+										depositPercentage={$productAddedToCart.depositPercentage}
+										discountPercentage={$productAddedToCart.discountPercentage}
+										removePopinProductPrice={data.removePopinProductPrice}
+									/>
+								</Popup>
+							{:else if cartOpen}
+								<Popup>
+									<div class="p-2 gap-2 flex flex-col cartPreview">
+										{#each items as item, i}
+											{@const price = priceInfo.perItem[i]}
+											{#if cartErrorMessage && cartErrorProductId === item.product._id}
+												<div class="text-red-600 text-sm">{cartErrorMessage}</div>
+											{/if}
+											<form
+												class="flex border-b border-gray-300 pb-2 gap-2"
+												method="POST"
+												use:enhance={({ action }) => {
+													cartErrorMessage = '';
+													if (action.searchParams.has('/increase')) {
+														item.quantity++;
+													} else if (action.searchParams.has('/decrease')) {
+														item.quantity--;
+													} else if (action.searchParams.has('/remove')) {
+														item.quantity = 0;
+													}
+													actionCount++;
+													let currentCount = actionCount;
+
+													return async ({ result }) => {
+														if (actionCount === currentCount) {
+															if (result.type === 'redirect') {
+																// Invalidate all to remove 0-quantity items
+																await goto(result.location, {
+																	noScroll: true,
+																	invalidateAll: true
+																});
+																return;
+															}
+															if (result.type === 'error' && result.error?.message) {
+																cartErrorMessage = result.error.message;
+																cartErrorProductId = item.product._id;
+																await invalidate(UrlDependency.Cart);
+																return;
+															}
+															await applyAction(result);
+														}
+													};
+												}}
+											>
+												{#if item._id}
+													<input type="hidden" name="lineId" value={item._id} />
+												{/if}
+												{#if item.depositPercentage ?? undefined !== undefined}
+													<input
+														type="hidden"
+														name="depositPercentage"
+														value={item.depositPercentage}
+													/>
+												{/if}
+												<a
+													href="/product/{item.product._id}"
+													class="w-[44px] h-[44px] min-w-[44px] min-h-[44px] rounded flex items-center"
+												>
+													{#if item.picture}
+														<Picture
+															picture={item.picture}
+															class="mx-auto rounded h-full object-contain"
+															sizes="44px"
+														/>
+													{/if}
+												</a>
+												<div class="flex flex-col">
+													<a href="/product/{item.product._id}">
+														<h3 class="text-base font-medium">
+															{item.chosenVariations
+																? item.product.name +
+																  ' - ' +
+																  Object.entries(item.chosenVariations)
+																		.map(
+																			([key, value]) =>
+																				item.product.variationLabels?.values[key][value]
+																		)
+																		.join(' - ')
+																: item.product.name}
+														</h3>
+													</a>
+													{#if !oneMaxPerLine(item.product)}
+														<div class="flex items-center gap-2">
+															<span class="text-xs">{t('cart.quantity')}: </span>
+															<CartQuantity {item} sm disabled={!data.cartPreviewInteractive} />
+														</div>
+													{/if}
+												</div>
+
+												<div class="flex flex-col items-end gap-[6px] ml-auto">
+													<PriceTag
+														class="text-base"
+														amount={(price.amount * (item.depositPercentage ?? 100)) / 100}
+														currency={price.currency}
+														main
+														>{item.depositPercentage
+															? `(${(item.depositPercentage / 100).toLocaleString($locale, {
+																	style: 'percent'
+															  })})`
+															: ''}
+													</PriceTag>
+													{#if data.cartPreviewInteractive}
+														<button formaction="/cart/{item.product._id}/?/remove">
+															<IconTrash class="body-secondaryText" />
+															<span class="sr-only">{t('cart.sr.remove')}</span>
+														</button>
+													{/if}
+												</div>
+											</form>
+										{/each}
+										{#if deliveryFees}
+											<div class="flex gap-1 text-lg justify-end items-center">
+												{t('checkout.deliveryFees')}
+												<div
+													title={t('checkout.deliveryFeesEstimationTooltip')}
+													class="cursor-pointer"
+												>
+													<IconInfo />
+												</div>
+
+												<PriceTag
+													class="truncate"
+													amount={deliveryFees}
+													currency={UNDERLYING_CURRENCY}
+													main
+												/>
+											</div>
+										{:else if isNaN(deliveryFees)}
+											<div class="alert-error mt-3">
+												{t('checkout.noDeliveryInCountry')}
+											</div>
+										{/if}
+										{#if items.some((item) => item.product.shipping) && priceInfo.physicalVatAtCustoms}
+											<div class="flex gap-1 text-lg justify-end items-center">
+												{t('product.vatExcluded')}
+												<div title={t('cart.vatNullOutsideSellerCountry')}>
+													<IconInfo class="cursor-pointer" />
+												</div>
+											</div>
+										{/if}
+										{#each priceInfo.vat as vat}
+											<div class="flex gap-1 text-lg justify-end items-center">
+												{t('cart.vat')} ({vat.rate}%) <PriceTag
+													currency={vat.partialPrice.currency}
+													amount={vat.partialPrice.amount}
+													main
+												/>
+											</div>
+										{/each}
+										<div class="flex gap-1 text-xl justify-end items-center">
+											{t('cart.total')}
+											<PriceTag
+												currency={priceInfo.currency}
+												amount={priceInfo.partialPriceWithVat}
+												main
+											/>
+										</div>
+										{#if priceInfo.totalPriceWithVat !== priceInfo.partialPriceWithVat}
+											<div class="flex gap-1 text-lg justify-end items-center">
+												{t('cart.remainingShort')}
+												<PriceTag
+													currency={priceInfo.currency}
+													amount={priceInfo.totalPriceWithVat - priceInfo.partialPriceWithVat}
+													main
+												/>
+											</div>
+										{/if}
+										<a href="/cart" class="btn cartPreview-mainCTA mt-1 whitespace-nowrap">
+											{t('cart.cta.view')}
+										</a>
+										<a
+											href="/checkout"
+											class="btn cartPreview-secondaryCTA {!physicalCartCanBeOrdered
+												? 'opacity-50'
+												: ''}"
+											style="pointer-events: {!physicalCartCanBeOrdered ? 'none' : ''};"
+										>
+											{t('cart.cta.checkout')}
+										</a>
+									</div>
+								</Popup>
+							{/if}
+							{#if !data.hideThemeSelectorInToolbar}
+								<div class="flex relative">
+									<button
+										class="ml-4 flex items-center gap-2 rounded text-xl"
+										on:click={() => (open = !open)}
+									>
+										{#each options as opt (opt.value)}
+											{#if opt.value === $theme}
+												<svelte:component this={opt.icon} class="w-5 h-5" />
+											{/if}
+										{/each}
+									</button>
+
+									{#if open}
+										<div class="absolute left-10 mt-2 shadow-lg rounded z-10 navbar">
+											{#each options as opt}
+												<button
+													class="flex items-center gap-2 w-full px-4 py-2 text-left"
+													on:click={() => setTheme(opt.value)}
+												>
+													<svelte:component this={opt.icon} class="w-5 h-5" />
+													<span class="hidden lg:contents">{opt.label}</span>
+												</button>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							{/if}
+
+							{#if !data.disableLanguageSelector && data.locales.length > 1}
+								<select
+									class="ml-4 border-0 cursor-pointer rounded appearance-none bg-none bg-transparent text-xl p-0"
+									size="0"
+									bind:value={$locale}
+									on:change={() => {
+										document.cookie = `lang=${$locale};path=/;max-age=31536000`;
+										window.location.reload();
+									}}
+								>
+									{#each data.locales as locale}
+										<option style="background-color: var(--navbar-backgroundColor);" value={locale}>
+											{locale}
+										</option>
+									{/each}
+								</select>
+							{/if}
+						</div>
 					</div>
 				</div>
-
-				{#if data.footerLogoId}
-					<div class="flex w-full">
-						<Picture class={logoClass} picture={data.footerPicture} />
-					</div>
-				{:else if data.displayPoweredBy}
-					<div class="justify-center lg:justify-normal flex w-full">
+			</header>
+			{#if navMenuOpen}
+				<nav
+					transition:slide
+					class="navbar print:hidden header-tab font-light flex flex-col lg:hidden border-x-0 border-b-0 border-opacity-25 border-t-1 border-white px-4 pb-3"
+				>
+					{#each data.links.navbar as link}
 						<a
-							class="items-center gap-4"
-							href="https://be-bop.io?lang={data.language}"
-							target="_blank"
+							class="py-2 hover:underline"
+							data-sveltekit-preload-data="off"
+							href={link.href.includes('/') || /^[a-zA-Z]+:/.test(link.href)
+								? link.href
+								: `/${link.href}`}>{link.label}</a
 						>
-							<span class="font-light">{t('footer.poweredBy')} </span>
-							<img class="h-[40px] w-auto hidden dark:inline" src={DEFAULT_LOGO} alt="" />
-							<img class="h-[40px] w-auto dark:hidden inline" src={DEFAULT_LOGO_DARK} alt="" />
-						</a>
+					{/each}
+				</nav>
+			{/if}
+
+			{#if $page.url.pathname.startsWith('/admin')}
+				<div class="grow body-mainPlan">
+					<slot />
+				</div>
+			{:else if $page.url.pathname === '/pos'}
+				<div class="grow body-mainPlan">
+					<slot />
+				</div>
+			{:else}
+				<div class="grow body-mainPlan">
+					{#if data.ageRestriction.enabled && !data.sessionAcceptAgeLimitation && !$page.url.pathname.startsWith('/admin')}
+						<form class="mx-auto max-w-7xl" method="POST" action="{data.websiteLink}?/navigate">
+							{#if data.cmsAgewall && data.cmsAgewallData}
+								<CmsDesign
+									{...data.cmsAgewallData}
+									hasPosOptions={data.hasPosOptions}
+									pageName={data.cmsAgewall?.title}
+									websiteLink={data.websiteLink}
+									brandName={data.brandName}
+									sessionEmail={data.email}
+									class={data.hideCmsZonesOnMobile
+										? 'prose max-w-full hidden lg:contents'
+										: 'prose max-w-full'}
+								/>
+							{/if}
+							<label class="label-checkbox my-4">
+								<input type="checkbox" class="form-checkbox" bind:checked={ageWarning} />
+								{t('ageWarning.agreement')}
+							</label>
+							<input
+								type="submit"
+								class="btn body-mainCTA my-4 w-full"
+								value={t('ageWarning.navigate')}
+								disabled={!ageWarning}
+							/>
+						</form>
+					{:else}
+						<slot />
+					{/if}
+				</div>
+			{/if}
+
+			<footer class="footer h-auto items-center flex print:hidden">
+				<div
+					class="mx-auto max-w-7xl px-6 py-6 items-start justify-between gap-y-8 w-full grid grid-cols-1 lg:flex lg:flex-wrap gap-4"
+				>
+					{#if data.displayCompanyInfo && data.sellerIdentity}
+						<div>
+							<h3 class="text-lg font-semibold mb-2 uppercase">{t('footer.company.identity')}</h3>
+							<p class="whitespace-pre-line">
+								{textAddress({
+									firstName: data.sellerIdentity.businessName,
+									lastName: '',
+									address: data.sellerIdentity.address.street,
+									zip: data.sellerIdentity.address.zip,
+									city: data.sellerIdentity.address.city,
+									country: data.sellerIdentity.address.country,
+									state: data.sellerIdentity.address.state
+								})}
+							</p>
+						</div>
+					{/if}
+
+					{#if data.displayMainShopInfo && data.shopInformation}
+						<div>
+							<h3 class="text-lg font-semibold mb-2 uppercase">{t('footer.shop.info')}</h3>
+							<p class="whitespace-pre-line">
+								{textAddress({
+									firstName: data.shopInformation.businessName,
+									lastName: '',
+									address: data.shopInformation.address.street,
+									zip: data.shopInformation.address.zip,
+									city: data.shopInformation.address.city,
+									country: data.shopInformation.address.country,
+									state: data.shopInformation.address.state
+								})}
+							</p>
+						</div>
+					{/if}
+
+					{#if data.displayCompanyInfo && data.sellerIdentity}
+						{#if data.sellerIdentity.contact.email || data.sellerIdentity.contact.phone}
+							<div>
+								<h3 class="text-lg font-semibold mb-2 uppercase">{t('footer.company.contact')}</h3>
+								{#if data.sellerIdentity.contact.email}
+									<a href="mailto:{data.sellerIdentity.contact.email}">
+										{data.sellerIdentity.contact.email}
+									</a>
+								{/if}
+								<br />
+								{#if data.sellerIdentity.contact.phone}
+									<a href="tel:{data.sellerIdentity.contact.phone}">
+										{data.sellerIdentity.contact.phone}
+									</a>
+								{/if}
+							</div>
+						{/if}
+					{/if}
+
+					<div class="flex flex-col gap-4 items-end lg:items-center">
+						<div class="flex items-end lg:flex-row flex-col gap-2">
+							{#each data.links.footer as link}
+								<a
+									class={link.label === '-' ? 'hidden lg:contents' : ''}
+									href={link.href.includes('/') || /^[a-zA-Z]+:/.test(link.href)
+										? link.href
+										: `/${link.href}`}
+									target={/^[a-zA-Z]+:/.test(link.href) ? '_blank' : '_self'}
+									data-sveltekit-preload-data="off">{link.label}</a
+								>
+							{/each}
+						</div>
+						<div class="flex flex-row gap-1">
+							{#each data.links.socialNetworkIcons as icon}
+								<a href={icon.href} target="_blank"
+									><img src="data:image/svg+xml;utf8, {icon.svg}" alt={icon.name} /></a
+								>
+							{/each}
+						</div>
 					</div>
-				{/if}
-			</div>
-		</footer>
-	{/if}
-</div>
+
+					{#if data.footerLogoId}
+						<div class="flex w-full">
+							<Picture class={logoClass} picture={data.footerPicture} />
+						</div>
+					{:else if data.displayPoweredBy}
+						<div class="justify-center lg:justify-normal flex w-full">
+							<a
+								class="items-center gap-4"
+								href="https://be-bop.io?lang={data.language}"
+								target="_blank"
+							>
+								<span class="font-light">{t('footer.poweredBy')} </span>
+								<img class="h-[40px] w-auto hidden dark:inline" src={DEFAULT_LOGO} alt="" />
+								<img class="h-[40px] w-auto dark:hidden inline" src={DEFAULT_LOGO_DARK} alt="" />
+							</a>
+						</div>
+					{/if}
+				</div>
+			</footer>
+		{/if}
+	</div>
+{/if}

--- a/src/routes/(app)/[slug]/+page.server.ts
+++ b/src/routes/(app)/[slug]/+page.server.ts
@@ -70,18 +70,21 @@ export async function load({ params, locals, url }) {
 			? 'mobile'
 			: undefined;
 
+	const cmsData = await cmsFromContent(
+		{
+			desktopContent: cmsPage.content,
+			employeeContent: (cmsPage.hasEmployeeContent && cmsPage.employeeContent) || undefined,
+			mobileContent: (cmsPage.hasMobileContent && cmsPage.mobileContent) || undefined,
+			forceContentVersion,
+			forceUnsanitizedContent: cmsPage.displayRawContent
+		},
+		locals
+	);
+
 	return {
 		cmsPage: omit(cmsPage, ['content', 'mobileContent', 'employeeContent']),
-		cmsData: cmsFromContent(
-			{
-				desktopContent: cmsPage.content,
-				employeeContent: (cmsPage.hasEmployeeContent && cmsPage.employeeContent) || undefined,
-				mobileContent: (cmsPage.hasMobileContent && cmsPage.mobileContent) || undefined,
-				forceContentVersion,
-				forceUnsanitizedContent: cmsPage.displayRawContent
-			},
-			locals
-		),
+		cmsData,
+		disableAppLayout: cmsData.tokens.desktop[0]?.type === 'htmlDocumentMarker',
 		layoutReset: cmsPage.fullScreen,
 		websiteShortDescription: cmsPage.shortDescription
 	};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,12 @@
 <script>
-	import '../app.css';
-	import '@fontsource/outfit/700.css';
-	import '@fontsource/outfit/600.css';
-	import '@fontsource/outfit/500.css';
-	import '@fontsource/outfit/400.css';
-	import '@fontsource/outfit/300.css';
-	import '@fontsource/poppins/400.css';
-	import '@fontsource/gloock/400.css';
+	import appCssUrl from '../app.css?url';
+	import fsOutfit700Url from '@fontsource/outfit/700.css?url';
+	import fsOutfit600Url from '@fontsource/outfit/600.css?url';
+	import fsOutfit500Url from '@fontsource/outfit/500.css?url';
+	import fsOutfit400Url from '@fontsource/outfit/400.css?url';
+	import fsOutfit300Url from '@fontsource/outfit/300.css?url';
+	import fsPoppins400Url from '@fontsource/poppins/400.css?url';
+	import fsGloock400Url from '@fontsource/gloock/400.css?url';
 	import { page } from '$app/stores';
 	import { setContext } from 'svelte';
 	import { PUBLIC_VERSION } from '$env/static/public';
@@ -16,30 +16,80 @@
 	setContext('language', data.language);
 </script>
 
+<!--
+  PLEASE READ CAREFULLY:
+
+  Svelte controls all page rendering in this application.
+
+  When the CMS “advanced HTML” mode is enabled, pages may contain a full HTML
+  document (including <head> and <body>). In that case, we inject the document’s
+  <head> content via <svelte:head> and render its <body> content directly in the
+  slot. The flag $page.data.disableAppLayout indicates this mode.
+
+  Since disableAppLayout originates from the page content itself (the lowest
+  layer in the render stack), it prevents effective server pre-rendering.
+
+  For this reason, we avoid wrapping the body in
+  <div style="display: contents">...</div> in app.html (as SvelteKit normally
+  recommends) and only apply that wrapper here when $page.data.disableAppLayout
+  is not set.
+-->
+
 <svelte:head>
-	<title>{data.websiteTitle}</title>
-	<meta name="viewport" content={data.viewportWidth} />
-	<meta name="description" content={$page.data.websiteShortDescription} />
-	<link rel="stylesheet" href="/style/variables.css?v={data.themeChangeNumber}" />
-	{#if data.faviconPictureId}
-		<link rel="icon" href="/favicon/{data.faviconPictureId}" />
-	{:else}
-		<link rel="icon" href="/favicon.png" />
-	{/if}
-	<script
-		lang="javascript"
-		src="/script/language/en.js?v={PUBLIC_VERSION}-{data.enUpdatedAt.getTime()}"
-	></script>
-	{#if data.language !== 'en'}
+	{#if !$page.data.disableAppLayout}
+		<title>{data.websiteTitle}</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content={data.viewportWidth} />
+		<meta name="description" content={$page.data.websiteShortDescription} />
+		<link rel="stylesheet" href={appCssUrl} />
+		<link rel="stylesheet" href={fsOutfit700Url} />
+		<link rel="stylesheet" href={fsOutfit600Url} />
+		<link rel="stylesheet" href={fsOutfit500Url} />
+		<link rel="stylesheet" href={fsOutfit400Url} />
+		<link rel="stylesheet" href={fsOutfit300Url} />
+		<link rel="stylesheet" href={fsPoppins400Url} />
+		<link rel="stylesheet" href={fsGloock400Url} />
+		<link rel="stylesheet" href="/style/variables.css?v={data.themeChangeNumber}" />
+		<script>
+			const theme = localStorage.getItem('theme') ?? document.documentElement.dataset.theme;
+			if (theme === 'dark') {
+				document.documentElement.classList.add('dark');
+			} else if (theme === 'light') {
+				document.documentElement.classList.remove('dark');
+			} else {
+				if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					document.documentElement.classList.add('dark');
+				} else {
+					document.documentElement.classList.remove('dark');
+				}
+			}
+		</script>
+		{#if data.faviconPictureId}
+			<link rel="icon" href="/favicon/{data.faviconPictureId}" />
+		{:else}
+			<link rel="icon" href="/favicon.png" />
+		{/if}
 		<script
 			lang="javascript"
-			src="/script/language/{data.language}.js?v={PUBLIC_VERSION}-{data.languageUpdatedAt.getTime()}"
+			src="/script/language/en.js?v={PUBLIC_VERSION}-{data.enUpdatedAt.getTime()}"
 		></script>
-	{/if}
-	{#if data.analyticsScriptSnippet}
-		<!-- eslint-disable svelte/no-at-html-tags -->
-		{@html data.analyticsScriptSnippet}
+		{#if data.language !== 'en'}
+			<script
+				lang="javascript"
+				src="/script/language/{data.language}.js?v={PUBLIC_VERSION}-{data.languageUpdatedAt.getTime()}"
+			></script>
+		{/if}
+		{#if data.analyticsScriptSnippet}
+			<!-- eslint-disable svelte/no-at-html-tags -->
+			{@html data.analyticsScriptSnippet}
+		{/if}
 	{/if}
 </svelte:head>
 
-<slot class="body body-mainPlan" />
+{#if $page.data.disableAppLayout}
+	<slot />
+{:else}
+	<div style="display: contents">
+		<slot class="body body-mainPlan" />
+	</div>
+{/if}


### PR DESCRIPTION
You can now publish full HTML documents using “advanced HTML” CMS pages.

To enable this, the page content **must** begin with the `<!doctype html>` tag. When enabled, these pages are served exactly¹ as authored — without any additional layout, styling, or scripts from be-BOP.

This mode is ideal for:

- Embedding completely custom pages created in your CMS, without mixing in be-BOP’s styles;
- Serving standalone documents that require full control of the HTML structure, such as pages implementing [the Open Graph protocol](https://ogp.me/);
- Integrating externally designed landing pages or microsites.

All other pages continue to render through the standard application layout as before, so your existing content and styles remain unaffected. This also includes CMS pages already using the “advanced HTML” mode that are not full HTML documents.

¹: Because the content is still parsed by Svelte, the served HTML is not byte-for-byte identical to the CMS source, but it is guaranteed to be *semantically* equivalent.