### PR TITLE
 🦋 Add tag-based price breakdown to POS checkout (#2109)

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -682,7 +682,10 @@
 			"shares": "shares",
 			"itemize": "itemize",
 			"return": "Return",
-			"paySelected": "Pay selected"
+			"paySelected": "Pay selected",
+			"includingVatIncluded": "Including (VAT included):",
+			"tagProducts": "Tag \"{name}\" products",
+			"otherProducts": "Other products"
 		}
 	},
 	"product": {

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -97,6 +97,7 @@ export async function load(params) {
 							| 'name'
 							| 'price'
 							| 'shortDescription'
+							| 'tagIds'
 							| 'type'
 							| 'availableDate'
 							| 'shipping'
@@ -121,6 +122,7 @@ export async function load(params) {
 						shortDescription: {
 							$ifNull: [`$translations.${locals.language}.shortDescription`, '$shortDescription']
 						},
+						tagIds: 1,
 						type: 1,
 						shipping: 1,
 						availableDate: 1,

--- a/src/routes/(app)/checkout/+page.server.ts
+++ b/src/routes/(app)/checkout/+page.server.ts
@@ -16,6 +16,7 @@ import { cmsFromContent } from '$lib/server/cms';
 import { omit } from '$lib/utils/omit.js';
 import { set } from '$lib/utils/set';
 import { ObjectId } from 'mongodb';
+import type { Tag } from '$lib/types/Tag';
 
 export async function load({ parent, locals }) {
 	const parentData = await parent();
@@ -93,8 +94,17 @@ export async function load({ parent, locals }) {
 		.sort({ sortOrder: 1 })
 		.toArray();
 
+	const reportingTags = locals.user?.hasPosOptions
+		? await collections.tags
+				.find({ reportingFilter: true })
+				.project<Pick<Tag, '_id' | 'name'>>({ _id: 1, name: 1 })
+				.sort({ name: 1 })
+				.toArray()
+		: [];
+
 	return {
 		paymentMethods: methods,
+		reportingTags,
 		emailsEnabled,
 		collectIPOnDeliverylessOrders: runtimeConfig.collectIPOnDeliverylessOrders,
 		posPrefillTermOfUse: runtimeConfig.posPrefillTermOfUse,


### PR DESCRIPTION
  Display cart totals grouped by product tags (with VAT) for POS users. Helps
  waiters calculate manual discounts for programs like Passeport Gourmand.

  - Load reportingTags and add tagIds to cart
  - Calculate tag totals
  - Show breakdown above "Payer" button (POS only)