### PR TITLE
🦋 Improve product tag selection in /pos/touch

### DIFF
--- a/src/lib/components/CategorySelect.svelte
+++ b/src/lib/components/CategorySelect.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { useI18n } from '$lib/i18n';
+	import type { Tag } from '$lib/types/Tag';
+
+	export let tags: Pick<Tag, '_id' | 'name'>[];
+	export let currentFilter: string;
+	export let onSelect: (filterId: string) => void;
+
+	const { t } = useI18n();
+
+	let isOpen = false;
+
+	interface Option {
+		id: string;
+		label: string;
+	}
+
+	$: options = [
+		{ id: 'pos-favorite', label: t('pos.touch.favorites') },
+		...tags.map((tag) => ({ id: tag._id, label: tag.name })),
+		{ id: 'all', label: t('pos.touch.allProducts') }
+	] as Option[];
+
+	$: currentLabel =
+		options.find((opt) => opt.id === currentFilter)?.label || t('pos.touch.favorites');
+
+	function toggleDropdown() {
+		isOpen = !isOpen;
+	}
+
+	function selectOption(optionId: string) {
+		onSelect(optionId);
+		isOpen = false;
+	}
+
+	function closeDropdown() {
+		isOpen = false;
+	}
+</script>
+
+<div class="relative w-full">
+	<!-- bg-[#310d40] and text-white are added directly to avoid race condition with touch.css loading -->
+	<button
+		type="button"
+		class="touchScreen-category-cta bg-[#310d40] text-white w-full flex items-center justify-between text-3xl px-6 min-h-[4.25rem]"
+		on:click={toggleDropdown}
+	>
+		<span class="uppercase">{currentLabel}</span>
+		<svg
+			class="w-8 h-8 transition-transform {isOpen ? 'rotate-180' : ''}"
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+		</svg>
+	</button>
+
+	{#if isOpen}
+		<!-- Backdrop -->
+		<div
+			class="fixed inset-0 z-40"
+			on:click={closeDropdown}
+			role="button"
+			tabindex="-1"
+			on:keydown={(e) => e.key === 'Escape' && closeDropdown()}
+		></div>
+
+		<!-- Dropdown -->
+		<div
+			class="absolute top-full left-0 right-0 mt-2 bg-white shadow-[0_0_0_4px_rgba(0,0,0,0.8)] max-h-[60vh] overflow-y-auto z-50"
+			on:click|stopPropagation
+			on:keydown={(e) => {
+				if (e.key === 'Escape') {
+					closeDropdown();
+				}
+			}}
+			role="menu"
+			tabindex="-1"
+		>
+			{#each options as option}
+				<button
+					type="button"
+					class="w-full text-left px-6 py-4 text-2xl font-medium uppercase border-b border-gray-200 transition-colors hover:bg-gray-100 hover:text-purple-600 {option.id ===
+					currentFilter
+						? 'bg-purple-100 text-purple-600 font-bold'
+						: 'text-gray-900'}"
+					on:click={() => selectOption(option.id)}
+					role="menuitem"
+				>
+					{option.label}
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -239,6 +239,7 @@ const baseConfig = {
 	contactModesForceOption: false,
 	posTouchTag: [] as Tag['_id'][],
 	posTabGroups: defaultPosTabGroups(),
+	posUseSelectForTags: false,
 	posPrefillTermOfUse: false,
 	posTapToPay: {
 		processor: undefined as PaymentProcessor | undefined,

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -635,6 +635,7 @@
 		},
 		"sessionLink": "POS session",
 		"sessionTouchLink": "POS session - touch screen",
+		"useSelectForTags": "Use select menu for product tag selection",
 		"tapToPay": {
 			"inProgress": "The payment will be automatically validated once the external transaction is recorded and validated.",
 			"inUseByOtherOrder": "Tap-to-pay is disabled because another order is currently using this payment method. You can collect payment manually and then enter the transaction number in this field."

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
@@ -36,6 +36,7 @@ export const load = async ({}) => {
 		tags: tags.filter((tag) => tag._id !== 'pos-favorite'),
 		posTouchTag: runtimeConfig.posTouchTag,
 		posTabGroups: runtimeConfig.posTabGroups,
+		posUseSelectForTags: runtimeConfig.posUseSelectForTags,
 		posPrefillTermOfUse: runtimeConfig.posPrefillTermOfUse,
 		posDisplayOrderQrAfterPayment: runtimeConfig.posDisplayOrderQrAfterPayment,
 		posQrCodeAfterPayment: runtimeConfig.posQrCodeAfterPayment,
@@ -72,6 +73,7 @@ export const actions: Actions = {
 			.object({
 				posDisplayOrderQrAfterPayment: z.boolean({ coerce: true }),
 				posPrefillTermOfUse: z.boolean({ coerce: true }),
+				posUseSelectForTags: z.boolean({ coerce: true }),
 				posTabGroups: z
 					.object({
 						name: z.string().min(1).max(100),
@@ -133,6 +135,8 @@ export const actions: Actions = {
 		runtimeConfig.posTouchTag = result.posTouchTag;
 		await persistConfigElement('posTabGroups', result.posTabGroups);
 		runtimeConfig.posTabGroups = result.posTabGroups;
+		await persistConfigElement('posUseSelectForTags', result.posUseSelectForTags);
+		runtimeConfig.posUseSelectForTags = result.posUseSelectForTags;
 		await persistConfigElement('posQrCodeAfterPayment', posQrCodeAfterPayment);
 		runtimeConfig.posQrCodeAfterPayment = posQrCodeAfterPayment;
 		await persistConfigElement('posTapToPay', posTapToPay);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import ManageOrderTabs from '$lib/components/ManageOrderTabs.svelte';
 	import { MultiSelect } from 'svelte-multiselect';
+	import { useI18n } from '$lib/i18n';
 	export let data;
+
+	const { t } = useI18n();
 
 	let selectedTags =
 		data.posTouchTag?.map((tagId) => ({
@@ -166,6 +169,16 @@
 		/>
 	</label>
 	<input type="hidden" name="posTouchTag" bind:value={serializedTags} />
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			name="posUseSelectForTags"
+			class="form-checkbox"
+			checked={data.posUseSelectForTags}
+		/>
+		{t('pos.useSelectForTags')}
+	</label>
 
 	<!-- svelte-ignore a11y-label-has-associated-control -->
 	<label class="form-label">

--- a/src/routes/(app)/pos/+layout.server.ts
+++ b/src/routes/(app)/pos/+layout.server.ts
@@ -46,6 +46,7 @@ export const load = async ({ locals }) => {
 		layoutReset: true,
 		pictures,
 		products,
-		tags
+		tags,
+		posUseSelectForTags: runtimeConfig.posUseSelectForTags
 	};
 };

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
@@ -113,7 +113,8 @@ export const load = async ({ locals, depends, params }) => {
 	return {
 		orderTab: pojo(orderTab),
 		posTabGroups: runtimeConfig.posTabGroups,
-		tabSlug
+		tabSlug,
+		posUseSelectForTags: runtimeConfig.posUseSelectForTags
 	};
 };
 

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -2,6 +2,7 @@
 	import type { SetRequired } from 'type-fest';
 	import type { Picture } from '$lib/types/Picture';
 	import ProductWidgetPOS from '$lib/components/ProductWidget/ProductWidgetPOS.svelte';
+	import CategorySelect from '$lib/components/CategorySelect.svelte';
 	import { POS_PRODUCT_PAGINATION, isPreorder } from '$lib/types/Product';
 	import { page } from '$app/stores';
 	import { useI18n } from '$lib/i18n.js';
@@ -131,6 +132,10 @@
 		goto(`${tab}`).then(() => {
 			closeTabSelectModel();
 		});
+	}
+
+	function handleCategorySelect(filterId: string) {
+		goto(selfPageLink({ filter: filterId, skip: 0 }));
 	}
 </script>
 
@@ -280,22 +285,34 @@
 			</div>
 			<div class="col-span-2 overflow-y-auto">
 				<div class="grid grid-cols-2 gap-4 text-3xl text-center">
-					<a
-						class="col-span-2 touchScreen-category-cta"
-						href={selfPageLink({ filter: 'pos-favorite', skip: 0 })}>{t('pos.touch.favorites')}</a
-					>
-					{#each data.tags as favoriteTag}
+					{#if data.posUseSelectForTags}
+						<!-- Select menu mode -->
+						<div class="col-span-2">
+							<CategorySelect
+								tags={data.tags}
+								currentFilter={filter}
+								onSelect={handleCategorySelect}
+							/>
+						</div>
+					{:else}
+						<!-- Button mode (current) -->
 						<a
-							class="touchScreen-category-cta"
-							href={selfPageLink({ filter: favoriteTag._id, skip: 0 })}>{favoriteTag.name}</a
+							class="col-span-2 touchScreen-category-cta"
+							href={selfPageLink({ filter: 'pos-favorite', skip: 0 })}>{t('pos.touch.favorites')}</a
 						>
-					{/each}
-					<a
-						class="col-span-2 touchScreen-category-cta"
-						href={selfPageLink({ filter: 'all', skip: 0 })}
-					>
-						{t('pos.touch.allProducts')}</a
-					>
+						{#each data.tags as favoriteTag}
+							<a
+								class="touchScreen-category-cta"
+								href={selfPageLink({ filter: favoriteTag._id, skip: 0 })}>{favoriteTag.name}</a
+							>
+						{/each}
+						<a
+							class="col-span-2 touchScreen-category-cta"
+							href={selfPageLink({ filter: 'all', skip: 0 })}
+						>
+							{t('pos.touch.allProducts')}</a
+						>
+					{/if}
 
 					<div class="col-span-2 grid grid-cols-2 gap-4">
 						{#each displayedProducts as product}


### PR DESCRIPTION
  **Option for compact category selection in POS touch interface**

  - Admins can now enable a dropdown select menu instead of category buttons in `/admin/pos`
  - Useful for restaurants/bars with 6+ product categories - saves screen space
  - When enabled, all categories (Favorites + tags + All Products) appear in one compact dropdown
  - Default: OFF - existing POS setups keep familiar button interface
  - Easy toggle: just check "Use select menu for product tag selection" in POS settings

  Perfect for establishments with extensive menus who need more room for the product grid!
 
 issue #2165