### PR TITLE
🐛 Store item prices with 4 decimals for accurate VAT calculations

### DIFF
--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -61,16 +61,12 @@ export function priceToBillForItem(
 	const unitsToBill = Math.max(unitsToAccount - params.freeUnits, 0);
 	const discountFactor = (item.discountPercentage ?? 0) / 100;
 	const basePrice = item.customPrice || item.product.price;
-	const amountWithoutDiscount = fixCurrencyRounding(
-		basePrice.amount * unitsToBill,
-		basePrice.currency
-	);
+	// Don't round the amount without VAT - preserve storage precision (4 decimals)
+	const amountWithoutDiscount = basePrice.amount * unitsToBill;
 	// The amount to bill is computed independentlly from the amount without
 	// discount because we don't want to use a rounded amount.
-	const amountToBill = fixCurrencyRounding(
-		basePrice.amount * unitsToBill * (1 - discountFactor),
-		basePrice.currency
-	);
+	const amountToBill = basePrice.amount * unitsToBill * (1 - discountFactor);
+
 	return {
 		amount: amountToBill,
 		amountWithoutDiscount,
@@ -161,10 +157,12 @@ function computeVatForItem(
 	const rate = vatProfile?.rates[country] ?? vatRate(country);
 	const { amount: amountToBill, currency, usedFreeUnits } = priceToBillForItem(item, { freeUnits });
 	const toDepositFactor = (item.depositPercentage ?? 100) / 100;
-	const partialPrice = fixCurrencyRounding(amountToBill * toDepositFactor, currency);
+	// Don't round partialPrice - preserve precision for VAT calculation
+	const partialPrice = amountToBill * toDepositFactor;
 	const vatFactor = rate / 100;
 	const vat = fixCurrencyRounding(amountToBill * vatFactor, currency);
 	const partialVat = fixCurrencyRounding(partialPrice * vatFactor, currency);
+
 	return {
 		price: { amount: vat, currency },
 		partialPrice: {

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import { CURRENCIES, CURRENCY_UNIT, FRACTION_DIGITS_PER_CURRENCY } from '$lib/types/Currency';
+	import {
+		CURRENCIES,
+		CURRENCY_UNIT,
+		STORAGE_FRACTION_DIGITS_PER_CURRENCY
+	} from '$lib/types/Currency';
 	import {
 		DEFAULT_MAX_QUANTITY_PER_ORDER,
 		MAX_NAME_LIMIT,
@@ -111,7 +115,7 @@
 	let vatRate = 0;
 	$: product.price.amount = Number(
 		((100 * priceAmountVATIncluded) / (100 + vatRate)).toFixed(
-			FRACTION_DIGITS_PER_CURRENCY[product.price.currency]
+			STORAGE_FRACTION_DIGITS_PER_CURRENCY[product.price.currency]
 		)
 	);
 	if (product._id && isNew) {
@@ -458,7 +462,18 @@
 				</label>
 				<label class="w-full">
 					Price amount (VAT excluded)
-					<input class="form-input" type="number" bind:value={product.price.amount} step="any" />
+					<input
+						class="form-input"
+						type="number"
+						value={product.price.amount
+							.toLocaleString('en', {
+								maximumFractionDigits: STORAGE_FRACTION_DIGITS_PER_CURRENCY[product.price.currency],
+								minimumFractionDigits: 0
+							})
+							.replace(/,/g, '')}
+						step="any"
+						readonly
+					/>
 				</label>
 			</div>
 		{/if}

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -44,6 +44,7 @@ import { checkCartItems } from './cart';
 import { userQuery } from './user';
 import { SMTP_USER } from '$lib/server/env-config';
 import { toCurrency } from '$lib/utils/toCurrency';
+import { toStorageCurrency } from '$lib/utils/toStorageCurrency';
 import { CUSTOMER_ROLE_ID } from '$lib/types/User';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import type { PaymentMethod, PaymentProcessor } from './payment-methods';
@@ -1213,7 +1214,7 @@ export async function createOrder(
 					currencySnapshot: {
 						main: {
 							price: {
-								amount: toCurrency(
+								amount: toStorageCurrency(
 									runtimeConfig.mainCurrency,
 									item.product.price.amount,
 									item.product.price.currency
@@ -1222,7 +1223,7 @@ export async function createOrder(
 							},
 							...(item.customPrice && {
 								customPrice: {
-									amount: toCurrency(
+									amount: toStorageCurrency(
 										runtimeConfig.mainCurrency,
 										item.customPrice.amount,
 										item.customPrice.currency
@@ -1234,7 +1235,7 @@ export async function createOrder(
 						...(runtimeConfig.secondaryCurrency && {
 							secondary: {
 								price: {
-									amount: toCurrency(
+									amount: toStorageCurrency(
 										runtimeConfig.secondaryCurrency,
 										item.product.price.amount,
 										item.product.price.currency
@@ -1243,7 +1244,7 @@ export async function createOrder(
 								},
 								...(item.customPrice && {
 									customPrice: {
-										amount: toCurrency(
+										amount: toStorageCurrency(
 											runtimeConfig.secondaryCurrency,
 											item.customPrice.amount,
 											item.customPrice.currency
@@ -1256,7 +1257,7 @@ export async function createOrder(
 						...(runtimeConfig.accountingCurrency && {
 							accounting: {
 								price: {
-									amount: toCurrency(
+									amount: toStorageCurrency(
 										runtimeConfig.accountingCurrency,
 										item.product.price.amount,
 										item.product.price.currency
@@ -1265,7 +1266,7 @@ export async function createOrder(
 								},
 								...(item.customPrice && {
 									customPrice: {
-										amount: toCurrency(
+										amount: toStorageCurrency(
 											runtimeConfig.accountingCurrency,
 											item.customPrice.amount,
 											item.customPrice.currency
@@ -1277,7 +1278,7 @@ export async function createOrder(
 						}),
 						priceReference: {
 							price: {
-								amount: toCurrency(
+								amount: toStorageCurrency(
 									runtimeConfig.priceReferenceCurrency,
 									item.product.price.amount,
 									item.product.price.currency
@@ -1286,7 +1287,7 @@ export async function createOrder(
 							},
 							...(item.customPrice && {
 								customPrice: {
-									amount: toCurrency(
+									amount: toStorageCurrency(
 										runtimeConfig.priceReferenceCurrency,
 										item.customPrice.amount,
 										item.customPrice.currency

--- a/src/lib/types/Currency.ts
+++ b/src/lib/types/Currency.ts
@@ -41,6 +41,32 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 	CZK: 2
 }) satisfies Record<Currency, number>;
 
+/**
+ * Maximum number of decimal places for storing prices WITHOUT VAT.
+ * This allows merchants to set precise base prices that result in round
+ * numbers after VAT calculation (e.g., 4.6253 CHF → 5.00 CHF with 8.1% VAT).
+ *
+ * Display precision remains FRACTION_DIGITS_PER_CURRENCY (2 for most currencies).
+ */
+export const STORAGE_FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
+	BTC: 8,
+	CHF: 4,
+	EUR: 4,
+	USD: 4,
+	ZAR: 4,
+	XOF: 4,
+	XAF: 4,
+	CDF: 4,
+	SAT: 0,
+	KES: 4,
+	UGX: 4,
+	GHS: 4,
+	NGN: 4,
+	TZS: 4,
+	MAD: 4,
+	CZK: 4
+}) satisfies Record<Currency, number>;
+
 export const CURRENCY_UNIT = Object.freeze({
 	BTC: Math.pow(10, -FRACTION_DIGITS_PER_CURRENCY.BTC),
 	CHF: Math.pow(10, -FRACTION_DIGITS_PER_CURRENCY.CHF),
@@ -61,10 +87,11 @@ export const CURRENCY_UNIT = Object.freeze({
 }) satisfies Record<Currency, number>;
 
 export function parsePriceAmount(amount: string, currency: Currency): number {
-	//deleted Math.round()
+	// Use storage precision (4 decimals for fiat, 8 for BTC) instead of display precision
+	const storageDecimals = STORAGE_FRACTION_DIGITS_PER_CURRENCY[currency];
 	const priceAmount =
-		(parseFloat(amount) * Math.pow(10, FRACTION_DIGITS_PER_CURRENCY[currency])) /
-		Math.pow(10, FRACTION_DIGITS_PER_CURRENCY[currency]);
+		(parseFloat(amount) * Math.pow(10, storageDecimals)) / Math.pow(10, storageDecimals);
+
 	if (priceAmount > 0 && priceAmount < CURRENCY_UNIT[currency]) {
 		throw error(400, `Price must be zero or greater than ${CURRENCY_UNIT[currency]} ${currency}`);
 	}

--- a/src/lib/utils/toStorageCurrency.ts
+++ b/src/lib/utils/toStorageCurrency.ts
@@ -1,0 +1,41 @@
+import { exchangeRate } from '$lib/stores/exchangeRate';
+import {
+	FRACTION_DIGITS_PER_CURRENCY,
+	STORAGE_FRACTION_DIGITS_PER_CURRENCY,
+	type Currency
+} from '$lib/types/Currency';
+import { get } from 'svelte/store';
+
+/**
+ * Convert amount to target currency with storage precision (4 decimals for fiat, 8 for BTC).
+ * Use this when storing prices in database to preserve full precision for VAT calculations.
+ *
+ * For display purposes, use toCurrency() which rounds to FRACTION_DIGITS_PER_CURRENCY (2 decimals for fiat).
+ */
+export function toStorageCurrency(
+	targetCurrency: Currency,
+	amount: number,
+	fromCurrency: Currency
+): number {
+	// If currencies are the same, round to storage precision
+	if (fromCurrency === targetCurrency) {
+		return (
+			Math.round(amount * Math.pow(10, STORAGE_FRACTION_DIGITS_PER_CURRENCY[targetCurrency])) /
+			Math.pow(10, STORAGE_FRACTION_DIGITS_PER_CURRENCY[targetCurrency])
+		);
+	}
+
+	// Convert through BTC as intermediate currency
+	const bitcoinAmount = fromCurrency === 'BTC' ? amount : amount / get(exchangeRate)[fromCurrency];
+
+	const ret =
+		targetCurrency === 'BTC' ? bitcoinAmount : bitcoinAmount * get(exchangeRate)[targetCurrency];
+
+	// For display precision (2 decimals) when converting between different currencies
+	// We still use FRACTION_DIGITS for cross-currency conversions because exchange rates
+	// already introduce imprecision
+	return (
+		Math.round(ret * Math.pow(10, FRACTION_DIGITS_PER_CURRENCY[targetCurrency])) /
+		Math.pow(10, FRACTION_DIGITS_PER_CURRENCY[targetCurrency])
+	);
+}

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
@@ -3,11 +3,7 @@
 	import PriceTag from '$lib/components/PriceTag.svelte';
 	import Trans from '$lib/components/Trans.svelte';
 	import { useI18n } from '$lib/i18n.js';
-	import {
-		invoiceNumberVariables,
-		orderIndividualItemPrice,
-		orderItemPrice
-	} from '$lib/types/Order.js';
+	import { invoiceNumberVariables, orderIndividualItemPrice } from '$lib/types/Order.js';
 	import { fixCurrencyRounding } from '$lib/utils/fixCurrencyRounding';
 	import { sum } from '$lib/utils/sum.js';
 	import { sumCurrency } from '$lib/utils/sumCurrency.js';
@@ -193,6 +189,12 @@
 				{@const priceCurrency =
 					item.currencySnapshot.main.customPrice?.currency ??
 					item.currencySnapshot.main.price.currency}
+				{@const unitPrice = orderIndividualItemPrice(item, 'main')}
+				{@const paidQuantity = item.quantity - (item.freeQuantity ?? 0)}
+				{@const totalPrice = unitPrice * paidQuantity}
+				{@const vatRate = item.vatRate ?? 0}
+				{@const vatAmount = (totalPrice * vatRate) / 100}
+				{@const totalWithVat = totalPrice + vatAmount}
 				<tr style:background-color={i % 2 === 0 ? '#fef2cc' : '#e7e6e6'}>
 					<td class="text-center border border-white px-2">{i + 1}</td>
 					<td class="text-center border border-white px-2"
@@ -205,30 +207,18 @@
 							: item.product.name}</td
 					>
 					<td class="text-center border border-white px-2"
-						>{item.quantity - (item.freeQuantity ?? 0)}
+						>{paidQuantity}
 						{item.freeQuantity ? '+' + item.freeQuantity : ''}</td
 					>
 					<td class="text-center border border-white px-2">
-						<PriceTag
-							amount={orderIndividualItemPrice(item, 'main')}
-							currency={priceCurrency}
-							inline
-						/>
+						<PriceTag amount={unitPrice} currency={priceCurrency} inline />
 					</td>
-					<td class="text-center border border-white px-2">{item.vatRate ?? 0}%</td>
+					<td class="text-center border border-white px-2">{vatRate}%</td>
 					<td class="text-center border border-white px-2">
-						<PriceTag
-							amount={(orderItemPrice(item, 'main') * (item.vatRate ?? 0)) / 100}
-							currency={priceCurrency}
-							inline
-						/>
+						<PriceTag amount={vatAmount} currency={priceCurrency} inline />
 					</td>
 					<td class="text-right border border-white px-2">
-						<PriceTag
-							amount={(orderItemPrice(item, 'main') * (100 + (item.vatRate ?? 0))) / 100}
-							currency={priceCurrency}
-							inline
-						/>
+						<PriceTag amount={totalWithVat} currency={priceCurrency} inline />
 					</td>
 				</tr>
 			{/each}

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/ticket/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/ticket/+page.svelte
@@ -164,14 +164,21 @@
 		&nbsp; &nbsp;<span style="text-decoration: underline;">{t('order.receipt.totalInclVat')}</span>
 		<br />
 		{#each data.order.items as item, i}
-			{@const price =
-				(item.currencySnapshot.main.customPrice?.amount ??
-					item.currencySnapshot.main.price.amount) *
-				(item.booking && item.product.bookingSpec
+			{@const basePrice =
+				item.currencySnapshot.main.customPrice?.amount ?? item.currencySnapshot.main.price.amount}
+			{@const bookingMultiplier =
+				item.booking && item.product.bookingSpec
 					? differenceInMinutes(item.booking.end, item.booking.start) /
 					  item.product.bookingSpec.slotMinutes
-					: 1) *
-				(item.discountPercentage ? (100 - item.discountPercentage) / 100 : 1)}
+					: 1}
+			{@const discountMultiplier = item.discountPercentage
+				? (100 - item.discountPercentage) / 100
+				: 1}
+			{@const unitPrice = basePrice * bookingMultiplier * discountMultiplier}
+			{@const totalPrice = unitPrice * item.quantity}
+			{@const vatRate = item.vatRate ?? 0}
+			{@const vatAmount = (totalPrice * vatRate) / 100}
+			{@const totalWithVat = totalPrice + vatAmount}
 			{@const priceCurrency =
 				item.currencySnapshot.main.customPrice?.currency ??
 				item.currencySnapshot.main.price.currency}
@@ -182,19 +189,15 @@
 						.map(([key, value]) => item.product.variationLabels?.values[key][value])
 						.join(' - ')
 				: item.product.name} &nbsp; &nbsp;{item.quantity} &nbsp; &nbsp; <PriceTag
-				amount={price}
+				amount={unitPrice}
 				currency={priceCurrency}
 				inline
 			/>
-			&nbsp; &nbsp;{item.vatRate ?? 0}% &nbsp; &nbsp;<PriceTag
-				amount={((price * (item.vatRate ?? 0)) / 100) * item.quantity}
+			&nbsp; &nbsp;{vatRate}% &nbsp; &nbsp;<PriceTag
+				amount={vatAmount}
 				currency={priceCurrency}
 				inline
-			/>&nbsp; &nbsp;<PriceTag
-				amount={(price + (price * (item.vatRate ?? 0)) / 100) * item.quantity}
-				currency={priceCurrency}
-				inline
-			/><br />
+			/>&nbsp; &nbsp;<PriceTag amount={totalWithVat} currency={priceCurrency} inline /><br />
 		{/each}
 		{#if data.order.shippingPrice && mainCurrencySnapshot.shippingPrice?.amount}
 			<span style="text-decoration: underline;">{t('checkout.deliveryFees')}<br /></span>

--- a/src/routes/(app)/order/[id]/summary/+page.svelte
+++ b/src/routes/(app)/order/[id]/summary/+page.svelte
@@ -112,10 +112,19 @@
 		{#each data.order.items as item, i}
 			{@const price =
 				item.currencySnapshot.main.customPrice?.amount ?? item.currencySnapshot.main.price.amount}
-			<!--{@const unitPrice = price / item.quantity}-->
+			{@const bookingMultiplier =
+				item.booking && item.product.bookingSpec
+					? differenceInMinutes(item.booking.end, item.booking.start) /
+					  item.product.bookingSpec.slotMinutes
+					: 1}
 			{@const priceCurrency =
 				item.currencySnapshot.main.customPrice?.currency ??
 				item.currencySnapshot.main.price.currency}
+			{@const unitPrice = price * bookingMultiplier}
+			{@const totalPrice = unitPrice * item.quantity}
+			{@const vatRate = item.vatRate ?? 0}
+			{@const vatAmount = (totalPrice * vatRate) / 100}
+			{@const totalWithVat = totalPrice + vatAmount}
 			<tr style:background-color={i % 2 === 0 ? '#fef2cc' : '#e7e6e6'}>
 				<td class="text-center border border-white px-2">{i + 1}</td>
 				<td class="text-center border border-white px-2"
@@ -129,36 +138,14 @@
 				>
 				<td class="text-center border border-white px-2">{item.quantity}</td>
 				<td class="text-center border border-white px-2">
-					<PriceTag
-						amount={price *
-							(item.booking && item.product.bookingSpec
-								? differenceInMinutes(item.booking.end, item.booking.start) /
-								  item.product.bookingSpec.slotMinutes
-								: 1)}
-						currency={priceCurrency}
-						inline
-					/>
+					<PriceTag amount={unitPrice} currency={priceCurrency} inline />
 				</td>
-				<td class="text-center border border-white px-2">{item.vatRate ?? 0}%</td>
+				<td class="text-center border border-white px-2">{vatRate}%</td>
 				<td class="text-center border border-white px-2">
-					<PriceTag
-						amount={(price *
-							(item.booking && item.product.bookingSpec
-								? differenceInMinutes(item.booking.end, item.booking.start) /
-								  item.product.bookingSpec.slotMinutes
-								: 1) *
-							(item.vatRate ?? 0)) /
-							100}
-						currency={priceCurrency}
-						inline
-					/>
+					<PriceTag amount={vatAmount} currency={priceCurrency} inline />
 				</td>
 				<td class="text-right border border-white px-2">
-					<PriceTag
-						amount={price * item.quantity + (price * (item.vatRate ?? 0)) / 100}
-						currency={priceCurrency}
-						inline
-					/>
+					<PriceTag amount={totalWithVat} currency={priceCurrency} inline />
 				</td>
 			</tr>
 		{/each}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
@@ -102,7 +102,7 @@
 										<PriceTag amount={itemPrice.amount} currency={itemPrice.currency} main />
 										<div>{t('pos.split.vatRate', { rate: itemVatRate })}</div>
 										<PriceTag
-											amount={itemPrice.amount * itemVatRate}
+											amount={(itemPrice.amount * itemVatRate) / 100}
 											currency={itemPrice.currency}
 											main
 										/>
@@ -185,7 +185,7 @@
 											<PriceTag amount={itemPrice.amount} currency={itemPrice.currency} main />
 											<div>{t('pos.split.vatRate', { rate: itemVatRate })}</div>
 											<PriceTag
-												amount={itemPrice.amount * itemVatRate}
+												amount={(itemPrice.amount * itemVatRate) / 100}
 												currency={itemPrice.currency}
 												main
 											/>


### PR DESCRIPTION
  Merchants can now set precise prices (4.6253 CHF) that result in round
  numbers after VAT (5.00 CHF with 8.1% VAT).

  - Add toStorageCurrency() to preserve 4-decimal precision in database
  - Store item prices with 4 decimals, totals/VAT with 2 decimals
  - Always display 2 decimals to users (via PriceTag component)
  - Refactor receipt/ticket/summary pages for calculation clarity

  Issue #2124