### PR TITLE
🦋 Auto-create default CMS pages on new installation

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/+layout.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+layout.server.ts
@@ -5,7 +5,61 @@ import { isLndConfigured } from '$lib/server/lnd.js';
 import { paymentMethods } from '$lib/server/payment-methods.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
 
+const DEFAULT_CMS_PAGES = [
+	'home',
+	'terms',
+	'privacy',
+	'why-vat-customs',
+	'why-collect-ip',
+	'why-pay-remainder',
+	'maintenance',
+	'error',
+	'order-top',
+	'order-bottom',
+	'checkout-top',
+	'checkout-bottom',
+	'cart-top',
+	'cart-bottom',
+	'agewall'
+] as const;
+
+const SEO_VISIBLE_PAGES = new Set(['home', 'privacy', 'terms']);
+
+async function ensureDefaultCmsPages() {
+	// Check which pages already exist (single query)
+	const existingPageIds = await collections.cmsPages
+		.find({ _id: { $in: [...DEFAULT_CMS_PAGES] } })
+		.project<{ _id: string }>({ _id: 1 })
+		.toArray()
+		.then((pages) => new Set(pages.map((p) => p._id)));
+
+	const missingPages = DEFAULT_CMS_PAGES.filter((slug) => !existingPageIds.has(slug));
+
+	if (missingPages.length === 0) {
+		return; // All pages exist
+	}
+
+	// Create missing pages
+	const now = new Date();
+	const pagesToCreate = missingPages.map((slug) => ({
+		_id: slug,
+		title: slug.charAt(0).toUpperCase() + slug.slice(1).replace(/-/g, ' '),
+		content: '<p>This page is empty. Please edit it to add your content.</p>',
+		shortDescription: '',
+		fullScreen: false,
+		maintenanceDisplay: false,
+		hideFromSEO: !SEO_VISIBLE_PAGES.has(slug),
+		createdAt: now,
+		updatedAt: now
+	}));
+
+	await collections.cmsPages.insertMany(pagesToCreate);
+}
+
 export async function load({ locals }) {
+	// Ensure default CMS pages exist on every admin access
+	await ensureDefaultCmsPages();
+
 	/**
 	 * Warning: do not send sensitive data here, it will be sent to the client on /admin/login!
 	 */


### PR DESCRIPTION
New be-BOP installations now come with 15 essential CMS pages pre-created
  (home, privacy, terms, and 12 utility pages), ready to edit. Admins no
  longer need to manually create system pages from the suggestion list.

  The pages are created automatically on first admin panel access with:
  - Placeholder content ready for customization
  - Correct SEO visibility settings (home/privacy/terms visible, others hidden)
  - Proper titles generated from slug names

  This reduces setup time and ensures all required pages are available
  immediately after installation.