### PR TITLE
🦋 Add opt-in telemetry beacon for be-BOP.io statistics

### DIFF
--- a/src/lib/components/TelemetryBanner.svelte
+++ b/src/lib/components/TelemetryBanner.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { useI18n } from '$lib/i18n';
+	import { enhance } from '$app/forms';
+	import DEFAULT_LOGO from '$lib/assets/bebop-light.svg';
+
+	export let adminPrefix: string;
+
+	const { t } = useI18n();
+
+	type ViewState = 'initial' | 'accepted' | 'declined' | 'hidden' | 'minimal-accepted';
+
+	let currentView: ViewState = 'initial';
+	let countdownSeconds = 0;
+	let countdownInterval: ReturnType<typeof setInterval> | null = null;
+
+	function updateCountdown() {
+		countdownSeconds--;
+		if (countdownSeconds <= 0) {
+			if (countdownInterval) {
+				clearInterval(countdownInterval);
+			}
+			currentView = currentView === 'accepted' ? 'minimal-accepted' : 'hidden';
+		}
+	}
+
+	onDestroy(() => {
+		if (countdownInterval) {
+			clearInterval(countdownInterval);
+		}
+	});
+</script>
+
+{#if currentView !== 'hidden'}
+	<h1 class="text-xl mb-0 flex items-center gap-2">
+		<span>{t('telemetry.banner.aWordFrom')}</span><img
+			src={DEFAULT_LOGO}
+			alt="be-BOP"
+			class="mb-3 h-10 inline-block align-middle"
+		/><span>:</span>
+	</h1>
+
+	{#if currentView === 'minimal-accepted'}
+		<p class="text-sm mt-2 mb-6">
+			{t('telemetry.banner.accepted.thankYou')}
+		</p>
+	{:else}
+		<div class="p-6 mb-6 border border-gray-200 rounded-lg bg-white shadow-sm">
+			<div class="flex items-start gap-4 mb-4">
+				<div class="flex-shrink-0 w-[80px] ml-3">
+					<svg
+						class="h-16 w-16"
+						viewBox="0 0 100 100"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<circle cx="50" cy="50" r="8" fill="#31A5DC" />
+						<path
+							d="M 35 35 Q 30 40, 35 45"
+							stroke="#1683f7"
+							stroke-width="3"
+							fill="none"
+							stroke-linecap="round"
+						/>
+						<path
+							d="M 65 35 Q 70 40, 65 45"
+							stroke="#31A5DC"
+							stroke-width="3"
+							fill="none"
+							stroke-linecap="round"
+						/>
+						<path
+							d="M 25 25 Q 18 40, 25 55"
+							stroke="#31A5DC"
+							stroke-width="3"
+							fill="none"
+							stroke-linecap="round"
+						/>
+						<path
+							d="M 75 25 Q 82 40, 75 55"
+							stroke="#31A5DC"
+							stroke-width="3"
+							fill="none"
+							stroke-linecap="round"
+						/>
+						<path
+							d="M 15 15 Q 5 40, 15 65"
+							stroke="#31A5DC"
+							stroke-width="3"
+							fill="none"
+							stroke-linecap="round"
+						/>
+						<path
+							d="M 85 15 Q 95 40, 85 65"
+							stroke="#31A5DC"
+							stroke-width="3"
+							fill="none"
+							stroke-linecap="round"
+						/>
+						<line
+							x1="50"
+							y1="58"
+							x2="50"
+							y2="85"
+							stroke="#31A5DC"
+							stroke-width="4"
+							stroke-linecap="round"
+						/>
+						<line
+							x1="50"
+							y1="85"
+							x2="35"
+							y2="95"
+							stroke="#31A5DC"
+							stroke-width="4"
+							stroke-linecap="round"
+						/>
+						<line
+							x1="50"
+							y1="85"
+							x2="65"
+							y2="95"
+							stroke="#31A5DC"
+							stroke-width="4"
+							stroke-linecap="round"
+						/>
+					</svg>
+				</div>
+				<div class="flex-1">
+					<div class="space-y-2 text-sm">
+						<p>{t('telemetry.banner.description1')}</p>
+						<p>{t('telemetry.banner.description2')}</p>
+						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+						<p class="font-semibold">{@html t('telemetry.banner.description3')}</p>
+						<p class="font-semibold">{t('telemetry.banner.question')}</p>
+					</div>
+				</div>
+			</div>
+
+			{#if currentView === 'initial'}
+				<div class="flex gap-4">
+					<form
+						method="post"
+						action="{adminPrefix}?/telemetry"
+						use:enhance={() => {
+							currentView = 'accepted';
+							countdownSeconds = 10;
+							countdownInterval = setInterval(updateCountdown, 1000);
+							return async () => {};
+						}}
+					>
+						<input type="hidden" name="choice" value="accept" />
+						<button type="submit" class="btn bg-green-600 text-white hover:bg-green-700">
+							{t('telemetry.banner.acceptButton')}
+						</button>
+					</form>
+
+					<form
+						method="post"
+						action="{adminPrefix}?/telemetry"
+						use:enhance={() => {
+							currentView = 'declined';
+							countdownSeconds = 30;
+							countdownInterval = setInterval(updateCountdown, 1000);
+							return async () => {};
+						}}
+					>
+						<input type="hidden" name="choice" value="decline" />
+						<button type="submit" class="btn bg-gray-600 text-white hover:bg-gray-500">
+							{t('telemetry.banner.declineButton')}
+						</button>
+					</form>
+				</div>
+			{:else if currentView === 'accepted'}
+				<div class="p-4 border-t border-gray-200 bg-green-50">
+					<div class="flex items-start gap-4 ml-0 pl-0">
+						<div class="flex-shrink-0 w-[75px] ml-0 pl-1 flex items-left justify-left">
+							<span class="text-5xl leading-none ml-0 pl-0">✅</span>
+						</div>
+						<div class="flex-1 space-y-2 text-sm">
+							<p class="font-semibold">{t('telemetry.banner.accepted.thankYou')}</p>
+							<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+							<p>{@html t('telemetry.banner.accepted.message')}</p>
+							<p class="text-gray-600">
+								{t('telemetry.banner.accepted.autoHideCountdown', { seconds: countdownSeconds })}
+							</p>
+						</div>
+					</div>
+				</div>
+			{:else if currentView === 'declined'}
+				<div class="p-4 border-t border-gray-200 bg-yellow-50">
+					<div class="flex items-start gap-4 ml-0 pl-0">
+						<div class="flex-shrink-0 w-[75px] ml-0 pl-1 flex items-left justify-left">
+							<span class="text-5xl leading-none ml-0 pl-0">🔒</span>
+						</div>
+						<div class="flex-1 space-y-2 text-sm">
+							<p class="font-semibold">{t('telemetry.banner.declined.respect')}</p>
+							<p>
+								{t('telemetry.banner.declined.reaskCountdown', { seconds: countdownSeconds })}
+							</p>
+							<div>
+								{t('telemetry.banner.declined.reask')}
+								<form
+									method="post"
+									action="{adminPrefix}?/telemetry"
+									use:enhance={() => {
+										currentView = 'hidden';
+										return async () => {};
+									}}
+									class="inline"
+								>
+									<input type="hidden" name="choice" value="hide" />
+									<button type="submit" class="font-bold text-red-600 hover:text-red-800 underline">
+										{t('telemetry.banner.declined.hideButton')}
+									</button>
+								</form>
+							</div>
+						</div>
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/if}
+{/if}

--- a/src/lib/server/locks/nostr-notifications.ts
+++ b/src/lib/server/locks/nostr-notifications.ts
@@ -18,6 +18,7 @@ import {
 import { NOSTR_PROTOCOL_VERSION } from './handle-messages';
 import { building } from '$app/environment';
 import { rateLimit } from '../rateLimit';
+import { sendPeriodicBeacon } from '../telemetry-helpers';
 
 const lock = new Lock('notifications.nostr');
 const processingIds = new Set<string>();
@@ -35,6 +36,12 @@ export async function closeRelayPool() {
 
 async function maintainLock() {
 	while (!processClosed) {
+		try {
+			await sendPeriodicBeacon();
+		} catch (err) {
+			console.error('Telemetry beacon error:', err);
+		}
+
 		if (!lock?.ownsLock || !isNostrConfigured()) {
 			await closeRelayPool();
 		} else if (!relayPool && isNostrConfigured()) {

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -257,6 +257,11 @@ const baseConfig = {
 	displayMainShopInfo: false,
 	disableNostrBotIntro: false,
 	hideFromSearchEngines: false,
+	telemetry: null as null | {
+		enabled: boolean;
+		nextPrompt: Date | null;
+		nextBeaconDate: Date | null;
+	},
 	posDisplayOrderQrAfterPayment: false,
 	posQrCodeAfterPayment: {
 		timeBeforeRedirecting: 10,

--- a/src/lib/server/sendNotification.ts
+++ b/src/lib/server/sendNotification.ts
@@ -9,6 +9,8 @@ import { addMinutes } from 'date-fns';
 import { adminPrefix } from '$lib/server/admin';
 import { error } from '@sveltejs/kit';
 import { queueEmail } from './email';
+import { isNostrConfigured } from './nostr';
+import { PUBLIC_VERSION } from '$env/static/public';
 
 export async function sendResetPasswordNotification(
 	user: User,
@@ -104,4 +106,32 @@ ${runtimeConfig.brandName} team`;
 			sessionLink: `${ORIGIN}/login?token=${encodeURIComponent(jwt)}`
 		});
 	}
+}
+
+const BEACON_TARGET_NPUB = 'npub1vqwvj93sezl4c0a4a55ppgejqa37p5g63l3pmzph2asfpha2flxs2dgcz4';
+
+export async function queueTelemetryBeaconMessage() {
+	if (!isNostrConfigured()) {
+		console.warn('Telemetry beacon: shop has no Nostr key configured, skipping');
+		return false;
+	}
+
+	const content = `be-BOP Shop Beacon
+
+Shop URL: ${ORIGIN}
+be-BOP Version: ${PUBLIC_VERSION || 'unknown'}
+Timestamp: ${new Date().toISOString()}
+
+This is an automated telemetry beacon sent with shop owner consent.`;
+
+	await collections.nostrNotifications.insertOne({
+		_id: new ObjectId(),
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		kind: Kind.EncryptedDirectMessage,
+		content,
+		dest: BEACON_TARGET_NPUB
+	});
+
+	return true;
 }

--- a/src/lib/server/telemetry-helpers.ts
+++ b/src/lib/server/telemetry-helpers.ts
@@ -1,0 +1,124 @@
+import { collections } from './database';
+import { runtimeConfig } from './runtime-config';
+import { queueTelemetryBeaconMessage } from './sendNotification';
+
+export function calculateNextBeaconDate(): Date {
+	const daysUntilNext = 6 + Math.random() * 2;
+	return new Date(Date.now() + daysUntilNext * 24 * 60 * 60 * 1000);
+}
+
+async function sendBeaconAndGetNextDate(): Promise<Date | null> {
+	const sent = await queueTelemetryBeaconMessage();
+	return sent ? calculateNextBeaconDate() : null;
+}
+
+export async function sendPeriodicBeacon() {
+	const telemetryConfig = runtimeConfig.telemetry;
+
+	if (
+		telemetryConfig?.enabled &&
+		telemetryConfig.nextBeaconDate &&
+		new Date() >= telemetryConfig.nextBeaconDate
+	) {
+		const nextBeaconDate = await sendBeaconAndGetNextDate();
+		if (nextBeaconDate) {
+			const updatedTelemetry = {
+				...telemetryConfig,
+				nextBeaconDate
+			};
+
+			await collections.runtimeConfig.updateOne(
+				{ _id: 'telemetry' },
+				{
+					$set: { data: updatedTelemetry, updatedAt: new Date() }
+				}
+			);
+
+			runtimeConfig.telemetry = updatedTelemetry;
+
+			console.log(`Telemetry: periodic beacon sent, next: ${nextBeaconDate.toISOString()}`);
+		}
+	}
+}
+
+export async function enableTelemetry(options?: { forceBeaconNow?: boolean; source?: string }) {
+	const currentTelemetry = runtimeConfig.telemetry;
+	const now = new Date();
+
+	const shouldSendNow =
+		options?.forceBeaconNow ||
+		!currentTelemetry?.nextBeaconDate ||
+		new Date() >= currentTelemetry.nextBeaconDate;
+
+	let nextBeaconDate: Date | null;
+
+	if (shouldSendNow) {
+		nextBeaconDate = await sendBeaconAndGetNextDate();
+		if (nextBeaconDate) {
+			console.log(`Telemetry beacon enabled and sent via ${options?.source ?? 'unknown'}`);
+		} else {
+			console.log(
+				`Telemetry beacon enabled via ${
+					options?.source ?? 'unknown'
+				} (beacon not sent - Nostr not configured)`
+			);
+		}
+	} else {
+		nextBeaconDate =
+			currentTelemetry?.nextBeaconDate && new Date() < currentTelemetry.nextBeaconDate
+				? currentTelemetry.nextBeaconDate
+				: null;
+		console.log(
+			`Telemetry enabled via ${options?.source ?? 'unknown'} (next beacon: ${
+				nextBeaconDate?.toISOString() ?? 'unknown'
+			})`
+		);
+	}
+
+	const telemetryConfig = {
+		enabled: true,
+		nextPrompt: null,
+		nextBeaconDate
+	};
+
+	await collections.runtimeConfig.updateOne(
+		{ _id: 'telemetry' },
+		{
+			$set: { data: telemetryConfig, updatedAt: now },
+			$setOnInsert: { createdAt: now }
+		},
+		{ upsert: true }
+	);
+
+	runtimeConfig.telemetry = telemetryConfig;
+
+	return { beaconSent: shouldSendNow, nextBeacon: nextBeaconDate };
+}
+
+export async function disableTelemetry(options?: { neverAskAgain?: boolean; source?: string }) {
+	const now = new Date();
+	const neverAsk = options?.neverAskAgain ?? false;
+
+	const telemetryConfig = {
+		enabled: false,
+		nextPrompt: neverAsk ? null : new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+		nextBeaconDate: null
+	};
+
+	await collections.runtimeConfig.updateOne(
+		{ _id: 'telemetry' },
+		{
+			$set: { data: telemetryConfig, updatedAt: now },
+			$setOnInsert: { createdAt: now }
+		},
+		{ upsert: true }
+	);
+
+	runtimeConfig.telemetry = telemetryConfig;
+
+	console.log(
+		neverAsk
+			? `Telemetry disabled via ${options?.source ?? 'unknown'} (never ask)`
+			: `Telemetry disabled via ${options?.source ?? 'unknown'}, reminder set for 30 days`
+	);
+}

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -772,5 +772,32 @@
 	},
 	"widget": {
 		"specification": "Spezifikationen"
+	},
+	"telemetry": {
+		"banner": {
+			"aWordFrom": "Ein Wort von",
+			"title": "Ein Wort von be-BOP:",
+			"description1": "Um die kostenlose be-BOP-Software zu unterstützen, können Sie die Existenz Ihres Shops öffentlich machen.",
+			"description2": "Es werden keine Daten an be-BOP.io SA gesendet, außer der URI Ihres Shops und Ihrer Zustimmung zur Kommunikation darüber. Ihre privaten Informationen und die Informationen Ihrer Kunden werden nicht weitergegeben.",
+			"description3": "Ihr Beitrag wird für anonyme Statistiken über die Anzahl der be-BOP-Benutzer verwendet (die nicht automatisch erfasst werden, da wir Datenschutz und Einwilligung respektieren) und um gelegentlich Kommunikations- und Promotionskampagnen über weltweit eingesetzte be-BOPs durchzuführen. Eine erste Benachrichtigung wird an den Nostr-Bot von be-BOP.io gesendet, dann wöchentlich, solange Ihr be-BOP aktiv ist. Sie können diese regelmäßige Nachricht später unter <a href=\"/admin/seo\" class=\"underline font-semibold\">/admin/SEO</a> deaktivieren.",
+			"question": "Akzeptieren Sie, die Existenz Ihres be-BOP zu teilen?",
+			"acceptButton": "Teilen",
+			"declineButton": "Erinnern Sie mich in 30 Tagen",
+			"accepted": {
+				"thankYou": "Vielen Dank, dass Sie sich entschieden haben, die Existenz Ihres Shops mit be-BOP.io für statistische und Werbezwecke zu teilen!",
+				"message": "Es werden keine Daten an be-BOP.io SA gesendet, außer der URL Ihres Shops und Ihrer Zustimmung zur Kommunikation darüber. Sie können unter <a href=\"/admin/seo\" class=\"underline font-semibold text-blue-600 hover:text-blue-800\">/admin/seo</a> diese optionale Telemetrie deaktivieren.",
+				"autoHideCountdown": "Diese Nachricht verschwindet in {seconds} Sekunden..."
+			},
+			"declined": {
+				"respect": "Wir respektieren Ihre Entscheidung, keine Informationen über Ihren Shop zu teilen.",
+				"reaskCountdown": "Diese Nachricht wird in {seconds} Sekunden ausgeblendet...",
+				"reask": "Wir werden Sie in 30 Tagen erneut fragen. Sie können die Erinnerung jedoch direkt ablehnen, indem Sie auf die Schaltfläche klicken",
+				"hideButton": "Nie wieder fragen"
+			}
+		},
+		"seo": {
+			"checkboxLabel": "Beacon-Signal an be-BOP.io Nostr-Bot aktivieren, um die Existenz Ihres Shops zu teilen",
+			"infoBlock": "Diese Einstellung steuert, ob Ihr Shop regelmäßige Signale an be-BOP.io sendet. Wir legen Wert auf Datenschutz: Es werden nur Ihre Shop-URL und die be-BOP-Softwareversion weitergegeben. Keine persönlichen Daten oder Kundendaten werden übertragen. Dies hilft uns beim Debuggen und zeigt uns, dass die be-BOP-Community wächst."
+		}
 	}
 }

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -791,5 +791,32 @@
 	},
 	"widget": {
 		"specification": "Specifications"
+	},
+	"telemetry": {
+		"banner": {
+			"aWordFrom": "A word from",
+			"title": "A word from be-BOP:",
+			"description1": "To support the free be-BOP software, you can make your shop's existence public.",
+			"description2": "No data will be sent to be-BOP.io SA, except your shop's URI and your consent to communicate about it. Your private information and your customers' information will not be shared.",
+			"description3": "Your sharing will be used for anonymous statistics on the number of be-BOP users (which is not automatically tracked because we respect privacy and consent), and to occasionally conduct communication and promotional campaigns about be-BOP deployments around the world. An initial notification will be sent to be-BOP.io's Nostr-bot, then weekly as long as your be-BOP is active. You can later disable this regular message in <a href=\"/admin/seo\" class=\"underline font-semibold text-blue-600 hover:text-blue-800\">/admin/SEO</a>.",
+			"question": "Do you accept to share the existence of your be-BOP?",
+			"acceptButton": "Share",
+			"declineButton": "Remind me in 30 days",
+			"accepted": {
+				"thankYou": "Thank you for choosing to share your shop's existence with be-BOP.io for statistical and promotional purposes!",
+				"message": "No data will be sent to be-BOP.io SA, except your shop's URL and your consent to communicate about it. You can go to <a href=\"/admin/seo\" class=\"underline font-semibold text-blue-600 hover:text-blue-800\">/admin/seo</a> to disable this optional telemetry.",
+				"autoHideCountdown": "This message will disappear in {seconds} seconds..."
+			},
+			"declined": {
+				"respect": "We respect your choice not to share information about your shop.",
+				"reaskCountdown": "This message will hide in {seconds} seconds...",
+				"reask": "We will ask you again in 30 days. However, you can directly refuse the reminder by clicking on the button",
+				"hideButton": "Never ask me again"
+			}
+		},
+		"seo": {
+			"checkboxLabel": "Enable beacon signal to be-BOP.io nostr-bot to share your shop existence",
+			"infoBlock": "This setting controls whether your shop sends periodic signals to be-BOP.io. We value privacy: only your shop URL and be-BOP software version are shared. No personal or customer data is transmitted. This helps us with debugging and shows us that the be-BOP community is growing."
+		}
 	}
 }

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -787,5 +787,32 @@
 	},
 	"widget": {
 		"specification": "Especificaciones"
+	},
+	"telemetry": {
+		"banner": {
+			"aWordFrom": "Unas palabras de",
+			"title": "Unas palabras de be-BOP:",
+			"description1": "Para apoyar gratuitamente el software be-BOP, puedes hacer pública la existencia de tu tienda.",
+			"description2": "No se enviarán datos a be-BOP.io SA, excepto la URI de tu tienda y tu consentimiento para comunicar sobre ella. Tu información privada y la información de tus clientes no se compartirán.",
+			"description3": "Tu participación se utilizará para estadísticas anónimas sobre el número de usuarios de be-BOP (que no se rastrea automáticamente porque respetamos la privacidad y el consentimiento), y para realizar ocasionalmente campañas de comunicación y promoción sobre los be-BOP desplegados en todo el mundo. Se enviará una primera notificación al bot Nostr de be-BOP.io, luego semanalmente mientras tu be-BOP esté activo. Puedes desactivar este mensaje regular más adelante en <a href=\"/admin/seo\" class=\"underline font-semibold\">/admin/SEO</a>.",
+			"question": "¿Aceptas compartir la existencia de tu be-BOP?",
+			"acceptButton": "Compartir",
+			"declineButton": "Recordármelo en 30 días",
+			"accepted": {
+				"thankYou": "¡Gracias por elegir compartir la existencia de tu tienda con be-BOP.io con fines estadísticos y promocionales!",
+				"message": "No se enviarán datos a be-BOP.io SA, excepto la URL de tu tienda y tu consentimiento para comunicar sobre ella. Puedes ir a <a href=\"/admin/seo\" class=\"underline font-semibold text-blue-600 hover:text-blue-800\">/admin/seo</a> para desactivar esta telemetría opcional.",
+				"autoHideCountdown": "Este mensaje desaparecerá en {seconds} segundos..."
+			},
+			"declined": {
+				"respect": "Respetamos tu decisión de no compartir información sobre tu tienda.",
+				"reaskCountdown": "Este mensaje se ocultará en {seconds} segundos...",
+				"reask": "Te preguntaremos de nuevo en 30 días. Sin embargo, puedes rechazar directamente el recordatorio haciendo clic en el botón",
+				"hideButton": "No volver a preguntarme"
+			}
+		},
+		"seo": {
+			"checkboxLabel": "Activar señal beacon al bot Nostr de be-BOP.io para compartir la existencia de tu tienda",
+			"infoBlock": "Esta configuración controla si tu tienda envía señales periódicas a be-BOP.io. Valoramos la privacidad: solo se comparten la URL de tu tienda y la versión del software be-BOP. No se transmite ninguna información personal o de clientes. Esto nos ayuda con la depuración y nos muestra que la comunidad be-BOP está creciendo."
+		}
 	}
 }

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -787,5 +787,32 @@
 	},
 	"widget": {
 		"specification": "Caractéristiques techniques"
+	},
+	"telemetry": {
+		"banner": {
+			"aWordFrom": "Un mot de",
+			"title": "Un mot de be-BOP :",
+			"description1": "Afin de soutenir gratuitement le logiciel be-BOP, vous pouvez rendre publique l'existence de votre boutique.",
+			"description2": "Aucune donnée ne sera envoyée à be-BOP.io SA, à part l'uri de votre boutique et votre consentement pour communiquer autour de cette dernière. Vos informations privées et les informations de vos clients ne seront pas partagées.",
+			"description3": "Votre partage sera utilisé pour des statistiques anonymes sur le nombre d'utilisateurs et d'utilisatrices de be-BOP (qui n'est pas suivi automatiquement car nous respectons la vie privée et le consentement), et pour ponctuellement faire des campagnes de communication et de promotion autour des be-BOP déployés partout dans le monde. Une première notification sera envoyée au Nostr-bot de be-BOP.io, puis chaque semaine tant que votre be-BOP est actif. Vous pouvez par la suite désactiver ce message régulier dans <a href=\"/admin/seo\" class=\"underline font-semibold\">/admin/SEO</a>.",
+			"question": "Acceptez-vous de partager l'existence de votre be-BOP ?",
+			"acceptButton": "Partager",
+			"declineButton": "Me rappeler dans 30 jours",
+			"accepted": {
+				"thankYou": "Merci d'avoir choisi de partager l'existence de votre boutique à be-BOP.io à des fins statistiques et promotionnelles !",
+				"message": "Aucune donnée ne sera envoyée à be-BOP.io SA, à part l'url de votre boutique et votre consentement pour communiquer autour de cette dernière. Vous pouvez vous rendre dans <a href=\"/admin/seo\" class=\"underline font-semibold text-blue-600 hover:text-blue-800\">/admin/seo</a> pour désactiver cette télémétrie optionnelle.",
+				"autoHideCountdown": "Ce message disparaîtra dans {seconds} secondes..."
+			},
+			"declined": {
+				"respect": "Nous respectons votre choix de ne pas partager d'informations de votre boutique.",
+				"reaskCountdown": "Ce message sera masqué dans {seconds} secondes...",
+				"reask": "Nous vous reposerons la question dans 30 jours. Néanmoins, vous pouvez directement refuser le rappel en cliquant sur le bouton",
+				"hideButton": "Masquer définitivement"
+			}
+		},
+		"seo": {
+			"checkboxLabel": "Activer le signal beacon vers le nostr-bot be-BOP.io pour partager l'existence de votre boutique",
+			"infoBlock": "Ce paramètre contrôle si votre boutique envoie des signaux périodiques à be-BOP.io. Nous valorisons la vie privée : seuls l'URL de votre boutique et la version du logiciel be-BOP sont partagés. Aucune donnée personnelle ou client n'est transmise. Cela nous aide pour le débogage et nous montre que la communauté be-BOP grandit."
+		}
 	}
 }

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -787,5 +787,32 @@
 	},
 	"widget": {
 		"specification": "Specificità"
+	},
+	"telemetry": {
+		"banner": {
+			"aWordFrom": "Una parola da",
+			"title": "Una parola da be-BOP:",
+			"description1": "Per supportare gratuitamente il software be-BOP, puoi rendere pubblica l'esistenza del tuo negozio.",
+			"description2": "Nessun dato verrà inviato a be-BOP.io SA, tranne l'URI del tuo negozio e il tuo consenso a comunicare al riguardo. Le tue informazioni private e quelle dei tuoi clienti non verranno condivise.",
+			"description3": "La tua condivisione sarà utilizzata per statistiche anonime sul numero di utenti be-BOP (che non viene tracciato automaticamente perché rispettiamo la privacy e il consenso), e per condurre occasionalmente campagne di comunicazione e promozione sui be-BOP distribuiti in tutto il mondo. Una prima notifica verrà inviata al bot Nostr di be-BOP.io, poi settimanalmente finché il tuo be-BOP è attivo. Puoi successivamente disattivare questo messaggio regolare in <a href=\"/admin/seo\" class=\"underline font-semibold\">/admin/SEO</a>.",
+			"question": "Accetti di condividere l'esistenza del tuo be-BOP?",
+			"acceptButton": "Condividi",
+			"declineButton": "Ricordamelo tra 30 giorni",
+			"accepted": {
+				"thankYou": "Grazie per aver scelto di condividere l'esistenza del tuo negozio con be-BOP.io per scopi statistici e promozionali!",
+				"message": "Nessun dato verrà inviato a be-BOP.io SA, tranne l'URL del tuo negozio e il tuo consenso a comunicare al riguardo. Puoi andare su <a href=\"/admin/seo\" class=\"underline font-semibold text-blue-600 hover:text-blue-800\">/admin/seo</a> per disattivare questa telemetria opzionale.",
+				"autoHideCountdown": "Questo messaggio scomparirà tra {seconds} secondi..."
+			},
+			"declined": {
+				"respect": "Rispettiamo la tua scelta di non condividere informazioni sul tuo negozio.",
+				"reaskCountdown": "Questo messaggio verrà nascosto tra {seconds} secondi...",
+				"reask": "Ti faremo nuovamente la domanda tra 30 giorni. Tuttavia, puoi rifiutare direttamente il promemoria facendo clic sul pulsante",
+				"hideButton": "Non chiedermelo mai più"
+			}
+		},
+		"seo": {
+			"checkboxLabel": "Abilita il segnale beacon verso il bot Nostr di be-BOP.io per condividere l'esistenza del tuo negozio",
+			"infoBlock": "Questa impostazione controlla se il tuo negozio invia segnali periodici a be-BOP.io. Diamo valore alla privacy: vengono condivisi solo l'URL del tuo negozio e la versione del software be-BOP. Non vengono trasmessi dati personali o dei clienti. Questo ci aiuta con il debug e ci mostra che la comunità be-BOP sta crescendo."
+		}
 	}
 }

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -787,5 +787,32 @@
 	},
 	"widget": {
 		"specification": "Specificaties"
+	},
+	"telemetry": {
+		"banner": {
+			"aWordFrom": "Een woord van",
+			"title": "Een woord van be-BOP:",
+			"description1": "Om de gratis be-BOP-software te ondersteunen, kunt u het bestaan van uw winkel openbaar maken.",
+			"description2": "Er worden geen gegevens naar be-BOP.io SA verzonden, behalve de URI van uw winkel en uw toestemming om hierover te communiceren. Uw privégegevens en die van uw klanten worden niet gedeeld.",
+			"description3": "Uw bijdrage wordt gebruikt voor anonieme statistieken over het aantal be-BOP-gebruikers (dat niet automatisch wordt gevolgd omdat wij privacy en toestemming respecteren), en om af en toe communicatie- en promotiecampagnes te voeren over wereldwijd ingezette be-BOPs. Een eerste notificatie wordt verzonden naar de Nostr-bot van be-BOP.io, vervolgens wekelijks zolang uw be-BOP actief is. U kunt dit regelmatige bericht later uitschakelen in <a href=\"/admin/seo\" class=\"underline font-semibold\">/admin/SEO</a>.",
+			"question": "Accepteert u om het bestaan van uw be-BOP te delen?",
+			"acceptButton": "Delen",
+			"declineButton": "Herinner me over 30 dagen",
+			"accepted": {
+				"thankYou": "Bedankt dat u ervoor heeft gekozen om het bestaan van uw winkel te delen met be-BOP.io voor statistische en promotionele doeleinden!",
+				"message": "Er worden geen gegevens naar be-BOP.io SA verzonden, behalve de URL van uw winkel en uw toestemming om hierover te communiceren. U kunt naar <a href=\"/admin/seo\" class=\"underline font-semibold text-blue-600 hover:text-blue-800\">/admin/seo</a> gaan om deze optionele telemetrie uit te schakelen.",
+				"autoHideCountdown": "Dit bericht verdwijnt over {seconds} seconden..."
+			},
+			"declined": {
+				"respect": "We respecteren uw keuze om geen informatie over uw winkel te delen.",
+				"reaskCountdown": "Dit bericht wordt verborgen over {seconds} seconden...",
+				"reask": "We zullen u over 30 dagen opnieuw vragen. U kunt de herinnering echter direct weigeren door op de knop te klikken",
+				"hideButton": "Vraag het me nooit meer"
+			}
+		},
+		"seo": {
+			"checkboxLabel": "Beacon-signaal naar be-BOP.io Nostr-bot inschakelen om het bestaan van uw winkel te delen",
+			"infoBlock": "Deze instelling bepaalt of uw winkel periodieke signalen naar be-BOP.io verzendt. We waarderen privacy: alleen uw winkel-URL en de be-BOP-softwareversie worden gedeeld. Er worden geen persoonlijke gegevens of klantgegevens verzonden. Dit helpt ons bij het debuggen en laat ons zien dat de be-BOP-gemeenschap groeit."
+		}
 	}
 }

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -772,5 +772,32 @@
 	},
 	"widget": {
 		"specification": "Especificações"
+	},
+	"telemetry": {
+		"banner": {
+			"aWordFrom": "Uma palavra de",
+			"title": "Uma palavra de be-BOP:",
+			"description1": "Para apoiar gratuitamente o software be-BOP, pode tornar pública a existência da sua loja.",
+			"description2": "Nenhum dado será enviado para be-BOP.io SA, exceto o URI da sua loja e o seu consentimento para comunicar sobre ela. As suas informações privadas e as informações dos seus clientes não serão partilhadas.",
+			"description3": "A sua partilha será utilizada para estatísticas anónimas sobre o número de utilizadores be-BOP (que não é rastreado automaticamente porque respeitamos a privacidade e o consentimento), e para realizar ocasionalmente campanhas de comunicação e promoção sobre os be-BOPs implementados em todo o mundo. Uma primeira notificação será enviada para o bot Nostr de be-BOP.io, depois semanalmente enquanto o seu be-BOP estiver ativo. Pode posteriormente desativar esta mensagem regular em <a href=\"/admin/seo\" class=\"underline font-semibold\">/admin/SEO</a>.",
+			"question": "Aceita partilhar a existência do seu be-BOP?",
+			"acceptButton": "Partilhar",
+			"declineButton": "Lembrar-me em 30 dias",
+			"accepted": {
+				"thankYou": "Obrigado por escolher partilhar a existência da sua loja com be-BOP.io para fins estatísticos e promocionais!",
+				"message": "Nenhum dado será enviado para be-BOP.io SA, exceto o URL da sua loja e o seu consentimento para comunicar sobre ela. Pode ir a <a href=\"/admin/seo\" class=\"underline font-semibold text-blue-600 hover:text-blue-800\">/admin/seo</a> para desativar esta telemetria opcional.",
+				"autoHideCountdown": "Esta mensagem desaparecerá em {seconds} segundos..."
+			},
+			"declined": {
+				"respect": "Respeitamos a sua escolha de não partilhar informações sobre a sua loja.",
+				"reaskCountdown": "Esta mensagem será ocultada em {seconds} segundos...",
+				"reask": "Voltaremos a perguntar-lhe em 30 dias. No entanto, pode recusar diretamente o lembrete clicando no botão",
+				"hideButton": "Nunca mais me perguntar"
+			}
+		},
+		"seo": {
+			"checkboxLabel": "Ativar sinal beacon para o bot Nostr de be-BOP.io para partilhar a existência da sua loja",
+			"infoBlock": "Esta configuração controla se a sua loja envia sinais periódicos para be-BOP.io. Valorizamos a privacidade: apenas o URL da sua loja e a versão do software be-BOP são partilhados. Nenhum dado pessoal ou de clientes é transmitido. Isto ajuda-nos com a depuração e mostra-nos que a comunidade be-BOP está a crescer."
+		}
 	}
 }

--- a/src/routes/(app)/admin[[hash=admin_hash]]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+page.server.ts
@@ -6,6 +6,7 @@ import { adminPrefix } from '$lib/server/admin';
 import { CUSTOMER_ROLE_ID } from '$lib/types/User';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { rootDir } from '$lib/server/root-dir.js';
+import { enableTelemetry, disableTelemetry } from '$lib/server/telemetry-helpers';
 
 export async function load({ url, locals }) {
 	if (!locals.user) {
@@ -38,13 +39,58 @@ export async function load({ url, locals }) {
 
 	try {
 		const files = fs.readdirSync(docsPath).filter((file) => file.endsWith('.md'));
+		const telemetryConfig = runtimeConfig.telemetry;
+
+		// Show banner if:
+		// 1. Never configured (first time) OR
+		// 2. Beacon disabled AND has reminder date AND date has passed
+		// Note: nextPrompt=null means "never ask again" (don't show banner)
+		const showTelemetryBanner =
+			!telemetryConfig ||
+			(!telemetryConfig.enabled &&
+				telemetryConfig.nextPrompt !== null &&
+				new Date() >= telemetryConfig.nextPrompt);
+
 		return {
 			files,
 			lang: result.lang,
-			adminWelcomMessage: runtimeConfig.adminWelcomMessage
+			adminWelcomMessage: runtimeConfig.adminWelcomMessage,
+			showTelemetryBanner
 		};
 	} catch (err) {
 		console.error(`Error reading files from docs/${result.lang}`, err);
 		throw error(404, `Unable to load documentation files for "${result.lang}"`);
 	}
 }
+
+const TELEMETRY_CHOICES = ['accept', 'decline', 'hide'] as const;
+
+export const actions = {
+	telemetry: async ({ request }) => {
+		const formData = await request.formData();
+
+		const schema = z.object({
+			choice: z.enum(TELEMETRY_CHOICES)
+		});
+
+		const { choice } = schema.parse({
+			choice: formData.get('choice')
+		});
+
+		switch (choice) {
+			case 'accept':
+				await enableTelemetry({ forceBeaconNow: true, source: 'admin banner' });
+				break;
+			case 'decline':
+				await disableTelemetry({ neverAskAgain: false, source: 'admin banner' });
+				break;
+			case 'hide':
+				await disableTelemetry({ neverAskAgain: true, source: 'admin banner' });
+				break;
+			default:
+				choice satisfies never;
+		}
+
+		return { success: true };
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { PUBLIC_VERSION } from '$env/static/public';
 	import { page } from '$app/stores';
+	import TelemetryBanner from '$lib/components/TelemetryBanner.svelte';
 
 	export let data;
 	$: lang = new URL($page.url).searchParams.get('lang') || 'en';
@@ -17,6 +18,10 @@
 	<p>
 		<em class="whitespace-pre-line">{data.adminWelcomMessage}</em>
 	</p>
+
+	{#if data.showTelemetryBanner}
+		<TelemetryBanner adminPrefix={data.adminPrefix} />
+	{/if}
 
 	<h1 class="text-xl">be-BOP version & updates</h1>
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/seo/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/seo/+page.server.ts
@@ -1,8 +1,14 @@
 import { collections } from '$lib/server/database';
 import { runtimeConfig } from '$lib/server/runtime-config.js';
 import { z } from 'zod';
+import { enableTelemetry, disableTelemetry } from '$lib/server/telemetry-helpers';
 
-export async function load() {}
+export async function load() {
+	return {
+		hideFromSearchEngines: runtimeConfig.hideFromSearchEngines,
+		enableBeaconSignal: runtimeConfig.telemetry?.enabled ?? false
+	};
+}
 
 export const actions = {
 	update: async function ({ request }) {
@@ -10,21 +16,33 @@ export const actions = {
 
 		const result = z
 			.object({
-				hideFromSearchEngines: z.boolean({ coerce: true })
+				hideFromSearchEngines: z.boolean({ coerce: true }),
+				enableBeaconSignal: z.boolean({ coerce: true })
 			})
 			.parse({
-				hideFromSearchEngines: formData.get('hideFromSearchEngines')
+				hideFromSearchEngines: formData.get('hideFromSearchEngines'),
+				enableBeaconSignal: formData.get('enableBeaconSignal')
 			});
+
+		const now = new Date();
 
 		await collections.runtimeConfig.updateOne(
 			{ _id: 'hideFromSearchEngines' },
 			{
-				$set: { data: result.hideFromSearchEngines, updatedAt: new Date() },
-				$setOnInsert: { createdAt: new Date() }
+				$set: { data: result.hideFromSearchEngines, updatedAt: now },
+				$setOnInsert: { createdAt: now }
 			},
 			{ upsert: true }
 		);
 		runtimeConfig.hideFromSearchEngines = result.hideFromSearchEngines;
+
+		if (result.enableBeaconSignal) {
+			await enableTelemetry({ source: 'SEO Config' });
+		} else {
+			const neverAskAgain = runtimeConfig.telemetry?.nextPrompt === null;
+			await disableTelemetry({ neverAskAgain, source: 'SEO Config' });
+		}
+
 		return {
 			success: 'SEO configuration updated.'
 		};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/seo/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/seo/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+	import { useI18n } from '$lib/i18n';
+
 	export let data;
 	export let form;
+
+	const { t } = useI18n();
 </script>
 
 <h1 class="text-2xl">SEO Config</h1>
@@ -17,5 +21,21 @@
 		/>
 		Hide from search engines
 	</label>
+
+	<div class="flex flex-col gap-2">
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				name="enableBeaconSignal"
+				class="form-checkbox"
+				checked={data.enableBeaconSignal}
+			/>
+			{t('telemetry.seo.checkboxLabel')}
+		</label>
+		<div class="ml-6 p-3 bg-gray-50 border border-gray-200 rounded text-sm text-gray-700">
+			{t('telemetry.seo.infoBlock')}
+		</div>
+	</div>
+
 	<input type="submit" value="Update" class="btn body-mainCTA self-start" />
 </form>


### PR DESCRIPTION
Shop owners can now voluntarily share their shop's existence with be-BOP.io for platform statistics and promotion. A banner appears on the admin homepage asking for consent with three options: accept (sends periodic beacons every 6-8 days), decline for 30 days, or decline permanently.

Key features:
- Privacy-first: opt-in only, minimal data (shop URL + version)
- Encrypted transmission via Nostr protocol
- Manageable from SEO settings page
- Countdown animations for better UX
- i18n support (en, fr)