### PR TITLE
Fix 422 error when changing payment method to non-POS types

### DIFF
--- a/src/routes/(app)/checkout/+page.server.ts
+++ b/src/routes/(app)/checkout/+page.server.ts
@@ -326,7 +326,7 @@ export const actions = {
 			paymentMethod === 'point-of-sale'
 				? z
 						.object({
-							posSubtype: z.string().optional()
+							posSubtype: z.string().nullable().optional()
 						})
 						.parse(Object.fromEntries(formData)).posSubtype
 				: undefined;

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/+page.server.ts
@@ -44,7 +44,7 @@ export const actions = {
 		const parsed = z
 			.object({
 				method: z.enum(ALL_PAYMENT_METHODS),
-				posSubtype: z.string().optional()
+				posSubtype: z.string().nullable().optional()
 			})
 			.parse({
 				method: formData.get('method'),


### PR DESCRIPTION
Allow null posSubtype for payment methods without subtypes