### PR TITLE
🦋 Add external product URL support in CMS widgets

### DIFF
--- a/src/lib/components/CmsDesign.svelte
+++ b/src/lib/components/CmsDesign.svelte
@@ -34,6 +34,12 @@
 	import { get } from '$lib/utils/get';
 
 	export let products: CmsProduct[];
+	export let externalProducts: Array<
+		import('$lib/components/ProductWidget/ProductWidgetProduct').ProductWidgetProduct & {
+			externalUrl: string;
+			pictures: import('$lib/types/Picture').Picture[];
+		}
+	> = [];
 	export let pictures: CmsPicture[];
 	export let challenges: CmsChallenge[];
 	export let tokens: CmsTokens;
@@ -66,6 +72,9 @@
 	);
 
 	$: productById = Object.fromEntries(products.map((product) => [product._id, product]));
+	$: externalProductById = Object.fromEntries(
+		externalProducts.map((product) => [product.externalUrl, product])
+	);
 	$: digitalFilesByProduct = Object.fromEntries(
 		digitalFiles.map((digitalFile) => [digitalFile.productId, digitalFile])
 	);
@@ -147,17 +156,30 @@
 <div class={tokens.mobile ? 'hidden lg:contents' : 'contents'}>
 	<div class={classNames}>
 		{#each tokens.desktop as token}
-			{#if token.type === 'productWidget' && productById[token.slug]}
-				<ProductWidget
-					product={productById[token.slug]}
-					pictures={picturesByProduct[token.slug] ?? []}
-					hasDigitalFiles={digitalFilesByProduct[token.slug] !== null}
-					displayOption={token.display}
-					canBuy={hasPosOptions
-						? productById[token.slug].actionSettings.retail.canBeAddedToBasket
-						: productById[token.slug].actionSettings.eShop.canBeAddedToBasket}
-					class="not-prose my-5"
-				/>
+			{#if token.type === 'productWidget'}
+				{#if token.slug && productById[token.slug]}
+					<ProductWidget
+						product={productById[token.slug]}
+						pictures={picturesByProduct[token.slug] ?? []}
+						hasDigitalFiles={digitalFilesByProduct[token.slug] !== null}
+						displayOption={token.display}
+						canBuy={hasPosOptions
+							? productById[token.slug].actionSettings.retail.canBeAddedToBasket
+							: productById[token.slug].actionSettings.eShop.canBeAddedToBasket}
+						class="not-prose my-5"
+					/>
+				{:else if token.externalUrl && externalProductById[token.externalUrl]}
+					{@const externalProduct = externalProductById[token.externalUrl]}
+					<ProductWidget
+						product={externalProduct}
+						pictures={externalProduct.pictures ?? []}
+						hasDigitalFiles={false}
+						displayOption={token.display}
+						canBuy={false}
+						externalUrl={token.externalUrl}
+						class="not-prose my-5"
+					/>
+				{/if}
 			{:else if token.type === 'tagProducts' && productsByTag(token.slug)}
 				{#each productsByTag(token.slug, token.by ?? '', token.sort) as product}
 					<ProductWidget
@@ -260,17 +282,30 @@
 	<div class="contents lg:hidden">
 		<div class={classNames}>
 			{#each tokens.mobile as token}
-				{#if token.type === 'productWidget' && productById[token.slug]}
-					<ProductWidget
-						product={productById[token.slug]}
-						pictures={picturesByProduct[token.slug] ?? []}
-						hasDigitalFiles={digitalFilesByProduct[token.slug] !== null}
-						displayOption={token.display}
-						canBuy={hasPosOptions
-							? productById[token.slug].actionSettings.retail.canBeAddedToBasket
-							: productById[token.slug].actionSettings.eShop.canBeAddedToBasket}
-						class="not-prose my-5"
-					/>
+				{#if token.type === 'productWidget'}
+					{#if token.slug && productById[token.slug]}
+						<ProductWidget
+							product={productById[token.slug]}
+							pictures={picturesByProduct[token.slug] ?? []}
+							hasDigitalFiles={digitalFilesByProduct[token.slug] !== null}
+							displayOption={token.display}
+							canBuy={hasPosOptions
+								? productById[token.slug].actionSettings.retail.canBeAddedToBasket
+								: productById[token.slug].actionSettings.eShop.canBeAddedToBasket}
+							class="not-prose my-5"
+						/>
+					{:else if token.externalUrl && externalProductById[token.externalUrl]}
+						{@const externalProduct = externalProductById[token.externalUrl]}
+						<ProductWidget
+							product={externalProduct}
+							pictures={externalProduct.pictures ?? []}
+							hasDigitalFiles={false}
+							displayOption={token.display}
+							canBuy={false}
+							externalUrl={token.externalUrl}
+							class="not-prose my-5"
+						/>
+					{/if}
 				{:else if token.type === 'tagProducts' && productsByTag(token.slug)}
 					{#each productsByTag(token.slug) as product}
 						<ProductWidget

--- a/src/lib/components/CmsPage.svelte
+++ b/src/lib/components/CmsPage.svelte
@@ -31,6 +31,12 @@
 		}[];
 	};
 	export let products: CmsProduct[];
+	export let externalProducts: Array<
+		import('$lib/components/ProductWidget/ProductWidgetProduct').ProductWidgetProduct & {
+			externalUrl: string;
+			pictures: import('$lib/types/Picture').Picture[];
+		}
+	> = [];
 	export let pictures: CmsPicture[];
 	export let challenges: CmsChallenge[];
 	export let tokens: CmsTokens;
@@ -67,6 +73,7 @@
 {#if cmsPage.fullScreen}
 	<CmsDesign
 		{products}
+		{externalProducts}
 		{pictures}
 		{challenges}
 		{tokens}
@@ -95,6 +102,7 @@
 		{/if}
 		<CmsDesign
 			{products}
+			{externalProducts}
 			{pictures}
 			{challenges}
 			{tokens}

--- a/src/lib/components/Picture.svelte
+++ b/src/lib/components/Picture.svelte
@@ -112,10 +112,18 @@
 		width={picture.storage.formats[0].width}
 		height={picture.storage.formats[0].height}
 		src={picture.storage.formats
-			.map((format) => `/picture/raw/${picture?._id}/format/${format.width}?v=1 ${format.width}w`)
+			.map((format) =>
+				format.url
+					? `${format.url} ${format.width}w`
+					: `/picture/raw/${picture?._id}/format/${format.width}?v=1 ${format.width}w`
+			)
 			.join(', ')}
 		srcset={picture.storage.formats
-			.map((format) => `/picture/raw/${picture?._id}/format/${format.width}?v=1 ${format.width}w`)
+			.map((format) =>
+				format.url
+					? `${format.url} ${format.width}w`
+					: `/picture/raw/${picture?._id}/format/${format.width}?v=1 ${format.width}w`
+			)
 			.join(', ')}
 		sizes={sizeHint !== null ? `${sizeHint}px` : undefined}
 		class={className}

--- a/src/lib/components/ProductWidget.svelte
+++ b/src/lib/components/ProductWidget.svelte
@@ -16,6 +16,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canBuy: boolean;
+	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
 	export { className as class };
@@ -57,6 +58,7 @@
 		{product}
 		{pictures}
 		{hasDigitalFiles}
+		{externalUrl}
 		class={className}
 	/>
 </div>
@@ -67,6 +69,7 @@
 		{pictures}
 		{hasDigitalFiles}
 		{canAddToCart}
+		{externalUrl}
 		class={className}
 	/>
 </div>

--- a/src/lib/components/ProductWidget/ProductWidgetMobile.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetMobile.svelte
@@ -9,10 +9,13 @@
 	export let pictures: Picture[] | [];
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
+	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
 	export { className as class };
 	const { t } = useI18n();
+
+	$: productUrl = externalUrl ?? `/product/${product._id}`;
 </script>
 
 <div class="mx-auto tagWidget tagWidget-main flex flex-wrap rounded {className}">
@@ -20,13 +23,22 @@
 		<div class="flex-row justify-start">
 			<ProductType {product} {hasDigitalFiles} class="last:rounded-tr first:rounded-bl text-sm" />
 		</div>
-		<a href="/product/{product._id}">
+		<a
+			href={productUrl}
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<PictureComponent picture={pictures[0]} class="object-contain max-h-full max-w-full" />
 		</a>
 	</div>
 	<div class="grid flex-col gap-2 px-4 py-2 justify-end">
 		<div class="flex flex-col gap-2">
-			<a href="/product/{product._id}" class="flex flex-col">
+			<a
+				href={productUrl}
+				class="flex flex-col"
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<h2 class="text-2xl body-title">{product.name}</h2>
 			</a>
 
@@ -46,5 +58,17 @@
 				<span class="text-base mt-1">({t('product.horsTaxeShort')})</span>
 			</div>
 		</div>
+		{#if externalUrl}
+			<div class="px-4 pb-4">
+				<a
+					href={externalUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="btn cartPreview-mainCTA text-lg text-center w-full p-2"
+				>
+					{t('product.cta.view')}
+				</a>
+			</div>
+		{/if}
 	</div>
 </div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation0.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation0.svelte
@@ -11,10 +11,13 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
 	export { className as class };
 	const { t } = useI18n();
+
+	$: productUrl = externalUrl ?? `/product/${product._id}`;
 </script>
 
 <div
@@ -24,14 +27,24 @@
 		<ProductType {product} {hasDigitalFiles} class="last:rounded-tr first:rounded-bl pl-2" />
 	</div>
 	<div class="flex flex-col text-center">
-		<a href="/product/{product._id}" class="flex flex-col items-center">
+		<a
+			href={productUrl}
+			class="flex flex-col items-center"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<PictureComponent picture={pictures[0]} class="object-contain max-h-[174px] max-w-full" />
 		</a>
 	</div>
 
 	<div class="flex flex-col">
 		<div class="flex flex-row justify-between">
-			<a href="/product/{product._id}" class="flex flex-col items-center">
+			<a
+				href={productUrl}
+				class="flex flex-col items-center"
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<h2 class="text-2xl body-title">{product.name}</h2>
 			</a>
 
@@ -51,12 +64,28 @@
 				<span class="font-semibold">{t('product.vatExcluded')}</span>
 			</div>
 		</div>
-		<a href="/product/{product._id}" class="flex flex-col">
+		<a
+			href={productUrl}
+			class="flex flex-col"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<p class="mt-2">
 				{product.shortDescription}
 			</p>
 		</a>
-		{#if canAddToCart}
+		{#if externalUrl}
+			<div class="flex flex-row items-end justify-end">
+				<a
+					href={externalUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="btn cartPreview-mainCTA"
+				>
+					{t('product.cta.view')}
+				</a>
+			</div>
+		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation1.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation1.svelte
@@ -11,10 +11,13 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
 	export { className as class };
 	const { t } = useI18n();
+
+	$: productUrl = externalUrl ?? `/product/${product._id}`;
 </script>
 
 <div
@@ -24,14 +27,24 @@
 		<ProductType {product} {hasDigitalFiles} class="last:rounded-tr first:rounded-bl pl-2" />
 	</div>
 	<div class="flex flex-col text-center">
-		<a href="/product/{product._id}" class="flex flex-col items-center">
+		<a
+			href={productUrl}
+			class="flex flex-col items-center"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<PictureComponent picture={pictures[0]} class="object-contain max-h-[348px] max-w-full" />
 		</a>
 	</div>
 
 	<div class="flex flex-col">
 		<div class="flex flex-row justify-between">
-			<a href="/product/{product._id}" class="flex flex-col items-center">
+			<a
+				href={productUrl}
+				class="flex flex-col items-center"
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<h2 class="text-2xl body-title">{product.name}</h2>
 			</a>
 
@@ -51,13 +64,29 @@
 				<span class="font-semibold">{t('product.vatExcluded')}</span>
 			</div>
 		</div>
-		<a href="/product/{product._id}" class="flex flex-col">
+		<a
+			href={productUrl}
+			class="flex flex-col"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<p class="mt-2">
 				{product.shortDescription}
 			</p>
 		</a>
 
-		{#if canAddToCart}
+		{#if externalUrl}
+			<div class="flex flex-row items-end justify-end">
+				<a
+					href={externalUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="btn cartPreview-mainCTA"
+				>
+					{t('product.cta.view')}
+				</a>
+			</div>
+		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation2.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation2.svelte
@@ -11,10 +11,13 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
 	export { className as class };
 	const { t } = useI18n();
+
+	$: productUrl = externalUrl ?? `/product/${product._id}`;
 </script>
 
 <div
@@ -28,14 +31,24 @@
 				class="last:rounded-tr first:rounded-bl pl-2 text-sm"
 			/>
 		</div>
-		<a href="/product/{product._id}" class="-ml-6">
+		<a
+			href={productUrl}
+			class="-ml-6"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<PictureComponent picture={pictures[0]} class="object-contain max-h-[264px] max-w-[264px]" />
 		</a>
 	</div>
 
 	<div class="flex flex-col gap-2">
 		<div class="flex flex-col gap-2">
-			<a href="/product/{product._id}" class="flex flex-col">
+			<a
+				href={productUrl}
+				class="flex flex-col"
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<h2 class="text-2xl body-title">{product.name}</h2>
 			</a>
 
@@ -55,12 +68,28 @@
 				<span class="font-semibold">{t('product.vatExcluded')}</span>
 			</div>
 		</div>
-		<a href="/product/{product._id}" class="flex flex-col">
+		<a
+			href={productUrl}
+			class="flex flex-col"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<p class="mt-2 max-w-[500px]">
 				{product.shortDescription}
 			</p>
 		</a>
-		{#if canAddToCart}
+		{#if externalUrl}
+			<div class="flex flex-row items-end justify-end">
+				<a
+					href={externalUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="btn cartPreview-mainCTA"
+				>
+					{t('product.cta.view')}
+				</a>
+			</div>
+		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation3.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation3.svelte
@@ -11,10 +11,13 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
 	export { className as class };
 	const { t } = useI18n();
+
+	$: productUrl = externalUrl ?? `/product/${product._id}`;
 </script>
 
 <div
@@ -22,7 +25,12 @@
 >
 	<div class="flex flex-col gap-2 mb-4">
 		<div class="flex flex-col gap-2 justify-between">
-			<a href="/product/{product._id}" class="flex flex-col">
+			<a
+				href={productUrl}
+				class="flex flex-col"
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<h2 class="text-2xl body-title">{product.name}</h2>
 			</a>
 
@@ -42,12 +50,28 @@
 				<span class="font-semibold">{t('product.vatExcluded')}</span>
 			</div>
 		</div>
-		<a href="/product/{product._id}" class="flex flex-col">
+		<a
+			href={productUrl}
+			class="flex flex-col"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<p class="mt-2 max-w-[500px]">
 				{product.shortDescription}
 			</p>
 		</a>
-		{#if canAddToCart}
+		{#if externalUrl}
+			<div class="flex flex-row items-end justify-end">
+				<a
+					href={externalUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="btn cartPreview-mainCTA"
+				>
+					{t('product.cta.view')}
+				</a>
+			</div>
+		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>
@@ -61,7 +85,12 @@
 				class="last:rounded-tr first:rounded-bl pl-2 text-sm"
 			/>
 		</div>
-		<a href="/product/{product._id}" class="-mr-6">
+		<a
+			href={productUrl}
+			class="-mr-6"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<PictureComponent picture={pictures[0]} class="object-contain max-h-[264px] max-w-[264px]" />
 		</a>
 	</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation4.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation4.svelte
@@ -11,10 +11,13 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
 	export { className as class };
 	const { t } = useI18n();
+
+	$: productUrl = externalUrl ?? `/product/${product._id}`;
 </script>
 
 <div
@@ -28,14 +31,24 @@
 				class="last:rounded-tr first:rounded-bl pl-2 text-sm"
 			/>
 		</div>
-		<a href="/product/{product._id}" class="-mx-6">
+		<a
+			href={productUrl}
+			class="-mx-6"
+			target={externalUrl ? '_blank' : undefined}
+			rel={externalUrl ? 'noopener noreferrer' : undefined}
+		>
 			<PictureComponent picture={pictures[0]} sizes="264px" class="object-contain" />
 		</a>
 	</div>
 
 	<div class="flex flex-col gap-2">
 		<div class="flex flex-col gap-2 justify-between">
-			<a href="/product/{product._id}" class="flex flex-col">
+			<a
+				href={productUrl}
+				class="flex flex-col"
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<h2 class="text-2xl body-title">{product.name}</h2>
 			</a>
 
@@ -56,7 +69,18 @@
 			<span class="font-semibold">{t('product.vatExcluded')}</span>
 		</div>
 
-		{#if canAddToCart}
+		{#if externalUrl}
+			<div class="flex flex-row items-end justify-end">
+				<a
+					href={externalUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="btn cartPreview-mainCTA"
+				>
+					{t('product.cta.view')}
+				</a>
+			</div>
+		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation5.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation5.svelte
@@ -3,27 +3,53 @@
 	import PictureComponent from '../Picture.svelte';
 
 	import AddToCart from '../AddToCart.svelte';
+	import { useI18n } from '$lib/i18n';
 	import type { ProductWidgetProduct } from './ProductWidgetProduct';
 
 	let className = '';
 	export { className as class };
+	const { t } = useI18n();
 
 	export let product: ProductWidgetProduct;
 	export let pictures: Picture[] | [];
 	export let canAddToCart: boolean;
+	export let externalUrl: string | undefined = undefined;
 	let pictureId = 0;
+
+	$: productUrl = externalUrl ?? `/product/${product._id}`;
 </script>
 
 <div class="flex flex-row gap-4 {className}">
 	<div class="flex flex-row w-full tagWidget tagWidget-main grow pr-5">
 		<div class="p-4 grow-[2] w-2/3">
-			<a href="/product/{product._id}">
+			<a
+				href={productUrl}
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<h2 class="text-2xl font-bold mb-2 body-title">{product.name}</h2>
 			</a>
-			<a href="/product/{product._id}">
+			<a
+				href={productUrl}
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<p class="mb-4">{product.shortDescription}</p>
 			</a>
-			{#if canAddToCart}
+			{#if externalUrl}
+				<div class="relative">
+					<div class="flex flex-wrap gap-6">
+						<a
+							href={externalUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="btn cartPreview-mainCTA text-xl text-center w-full md:w-[150px] p-1"
+						>
+							{t('product.cta.view')}
+						</a>
+					</div>
+				</div>
+			{:else if canAddToCart}
 				<div class="relative">
 					<div class="flex flex-wrap gap-6">
 						<AddToCart
@@ -39,7 +65,11 @@
 		</div>
 
 		<div class="grow">
-			<a href="/product/{product._id}">
+			<a
+				href={productUrl}
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<PictureComponent picture={pictures[pictureId]} class="h-[280px] ml-auto object-contain" />
 			</a>
 		</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation6.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation6.svelte
@@ -3,16 +3,21 @@
 	import PictureComponent from '../Picture.svelte';
 
 	import AddToCart from '../AddToCart.svelte';
+	import { useI18n } from '$lib/i18n';
 	import type { ProductWidgetProduct } from './ProductWidgetProduct';
 
 	let className = '';
 	export { className as class };
+	const { t } = useI18n();
 
 	export let product: ProductWidgetProduct;
 	export let pictures: Picture[] | [];
 	export let canAddToCart: boolean;
+	export let externalUrl: string | undefined = undefined;
 
 	let pictureId = 0;
+
+	$: productUrl = externalUrl ?? `/product/${product._id}`;
 </script>
 
 <div class="flex flex-row gap-4 {className}">
@@ -36,18 +41,43 @@
 
 	<div class="flex flex-row w-full tagWidget tagWidget-main pl-5">
 		<div class="grow">
-			<a href="/product/{product._id}">
+			<a
+				href={productUrl}
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<PictureComponent picture={pictures[pictureId]} class="h-[280px] mr-auto object-contain" />
 			</a>
 		</div>
 		<div class="p-4 grow-[2] w-2/3">
-			<a href="/product/{product._id}">
+			<a
+				href={productUrl}
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<h2 class="text-2xl font-bold body-title mb-2">{product.name}</h2>
 			</a>
-			<a href="/product/{product._id}">
+			<a
+				href={productUrl}
+				target={externalUrl ? '_blank' : undefined}
+				rel={externalUrl ? 'noopener noreferrer' : undefined}
+			>
 				<p class="mb-4">{product.shortDescription}</p>
 			</a>
-			{#if canAddToCart}
+			{#if externalUrl}
+				<div class="relative">
+					<div class="flex flex-wrap gap-6">
+						<a
+							href={externalUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="btn cartPreview-mainCTA text-xl text-center w-full md:w-[150px] p-1"
+						>
+							{t('product.cta.view')}
+						</a>
+					</div>
+				</div>
+			{:else if canAddToCart}
 				<div class="relative">
 					<div class="flex flex-wrap gap-6">
 						<AddToCart

--- a/src/lib/server/cms.ts
+++ b/src/lib/server/cms.ts
@@ -1,6 +1,8 @@
 import type { Challenge } from '$lib/types/Challenge';
 import type { DigitalFile } from '$lib/types/DigitalFile';
 import type { Product } from '$lib/types/Product';
+import type { Picture } from '$lib/types/Picture';
+import type { Currency } from '$lib/types/Currency';
 import { trimPrefix } from '$lib/utils/trimPrefix';
 import { trimSuffix } from '$lib/utils/trimSuffix';
 import { JSDOM } from 'jsdom';
@@ -17,6 +19,12 @@ import type { Leaderboard } from '$lib/types/Leaderboard';
 import type { ScheduleEventBooked } from '$lib/types/Schedule';
 import { groupBy } from '$lib/utils/group-by';
 import { subMinutes } from 'date-fns';
+import { z } from 'zod';
+import type { ProductWidgetProduct } from '$lib/components/ProductWidget/ProductWidgetProduct';
+export type ExternalProductData = ProductWidgetProduct & {
+	externalUrl: string;
+	pictures: Picture[];
+};
 
 const window = new JSDOM('').window;
 
@@ -29,6 +37,118 @@ purify.addHook('afterSanitizeAttributes', function (node) {
 		node.setAttribute('rel', 'noopener');
 	}
 });
+
+// Zod schema for external product picture validation
+const externalPictureSchema = z.object({
+	_id: z.string(),
+	name: z.string(),
+	storage: z.object({
+		original: z.object({
+			key: z.string(),
+			width: z.number(),
+			height: z.number(),
+			size: z.number(),
+			url: z.string().optional()
+		}),
+		formats: z.array(
+			z.object({
+				key: z.string(),
+				width: z.number(),
+				height: z.number(),
+				size: z.number(),
+				url: z.string().optional()
+			})
+		)
+	})
+});
+
+// Zod schema for external product data validation
+const externalProductSchema = z.object({
+	name: z.string(),
+	shortDescription: z.string(),
+	price: z.object({
+		amount: z.number(),
+		currency: z.string()
+	}),
+	pictures: z.array(externalPictureSchema).optional()
+});
+
+async function fetchExternalProduct(url: string): Promise<ExternalProductData | null> {
+	try {
+		// Parse URL to extract base and slug
+		const urlObj = new URL(url);
+		const pathMatch = urlObj.pathname.match(/\/product\/([^\/]+)/);
+
+		if (!pathMatch) {
+			console.error(
+				`[fetchExternalProduct] Invalid product URL format (expected /product/[slug]): ${url}`
+			);
+			return null;
+		}
+
+		const slug = pathMatch[1];
+		const apiUrl = `${urlObj.origin}/api/product/${slug}`;
+
+		const response = await fetch(apiUrl, {
+			headers: { Accept: 'application/json' },
+			signal: AbortSignal.timeout(5000) // 5s timeout
+		});
+
+		if (!response.ok) {
+			console.error(
+				`[fetchExternalProduct] Failed to fetch ${apiUrl}: ${response.status} ${response.statusText}`
+			);
+			return null;
+		}
+
+		const rawData = await response.json();
+
+		// Runtime validation with Zod
+		const parseResult = externalProductSchema.safeParse(rawData);
+
+		if (!parseResult.success) {
+			console.error('[fetchExternalProduct] Invalid external product data:', parseResult.error);
+			return null;
+		}
+
+		// Map to ProductWidgetProduct with safe defaults
+		// Use slug from URL as _id - we don't rely on external API's _id
+		const result = {
+			_id: slug,
+			name: parseResult.data.name,
+			shortDescription: parseResult.data.shortDescription,
+			price: {
+				amount: parseResult.data.price.amount,
+				currency: parseResult.data.price.currency as Currency
+			},
+			externalUrl: url,
+			pictures: (parseResult.data.pictures ?? []) as Picture[],
+			// Required ProductWidgetProduct fields with safe defaults
+			preorder: false,
+			availableDate: undefined,
+			shipping: false,
+			type: 'resource' as const,
+			actionSettings: {
+				eShop: { visible: true, canBeAddedToBasket: false },
+				retail: { visible: false, canBeAddedToBasket: false },
+				googleShopping: { visible: false },
+				nostr: { visible: false, canBeAddedToBasket: false }
+			},
+			stock: { available: 999999, total: 999999, reserved: 0 },
+			isTicket: false,
+			hasSellDisclaimer: false,
+			payWhatYouWant: false,
+			bookingSpec: undefined,
+			hasVariations: false
+		};
+
+		return result;
+	} catch (err) {
+		console.error('[fetchExternalProduct] Error fetching external product:', err);
+		return null;
+	}
+}
+
 type TokenObject =
 	| {
 			type: 'html';
@@ -36,7 +156,8 @@ type TokenObject =
 	  }
 	| {
 			type: 'productWidget';
-			slug: string;
+			slug?: string;
+			externalUrl?: string;
 			display: string | undefined;
 			raw: string;
 	  }
@@ -119,8 +240,18 @@ export async function cmsFromContent(
 	},
 	locals: Partial<PickDeep<App.Locals, 'user.hasPosOptions' | 'language' | 'email' | 'sso'>>
 ) {
+	/**
+	 * Matches product widget syntax in CMS content:
+	 * - [Product=slug] for local products
+	 * - [Product=https://example.com/product/slug] for external products
+	 * - [Product=slug display=img-5] or [Product=slug?display=img-5] for display options
+	 *
+	 * Named groups:
+	 * - slug: either full URL (http/https) or local slug (unicode letters, digits, _, -)
+	 * - display: optional display variant (img-0 through img-6)
+	 */
 	const PRODUCT_WIDGET_REGEX =
-		/\[Product=(?<slug>[\p{L}\d_-]+)(?:[?\s]display=(?<display>[a-z0-9-]+))?\]/giu;
+		/\[Product=(?<slug>https?:\/\/[^\s\]]+|[\p{L}\d_-]+)(?:[?\s]display=(?<display>[a-z0-9-]+))?\]/giu;
 	const CHALLENGE_WIDGET_REGEX = /\[Challenge=(?<slug>[a-z0-9-]+)\]/giu;
 	const LEADERBOARD_WIDGET_REGEX = /\[Leaderboard=(?<slug>[a-z0-9-]+)\]/giu;
 	const SLIDER_WIDGET_REGEX =
@@ -144,6 +275,7 @@ export async function cmsFromContent(
 		/\[Schedule=(?<slug>[\p{L}\d_:-]+)(?:[?\s]display=(?<display>(main|main-light|list|calendar)))?\]/giu;
 
 	const productSlugs = new Set<string>();
+	const externalProductUrls = new Set<string>();
 	const challengeSlugs = new Set<string>();
 	const sliderSlugs = new Set<string>();
 	const tagSlugs = new Set<string>();
@@ -194,13 +326,30 @@ export async function cmsFromContent(
 			if (match.groups?.slug) {
 				switch (match.type) {
 					case 'productWidget':
-						productSlugs.add(match.groups.slug);
-						token.push({
-							type: 'productWidget',
-							slug: match.groups.slug,
-							display: match.groups?.display,
-							raw: match[0]
-						});
+						const slugOrUrl = match.groups.slug;
+						if (slugOrUrl.startsWith('http://') || slugOrUrl.startsWith('https://')) {
+							// External product URL
+							const url = new URL(slugOrUrl);
+							const displayOption = url.searchParams.get('display') || match.groups?.display;
+							url.searchParams.delete('display');
+
+							externalProductUrls.add(url.href);
+							token.push({
+								type: 'productWidget',
+								externalUrl: url.href,
+								display: displayOption,
+								raw: match[0]
+							});
+						} else {
+							// Local product slug
+							productSlugs.add(slugOrUrl);
+							token.push({
+								type: 'productWidget',
+								slug: slugOrUrl,
+								display: match.groups?.display,
+								raw: match[0]
+							});
+						}
 						break;
 					case 'challengeWidget':
 						challengeSlugs.add(match.groups.slug);
@@ -390,6 +539,13 @@ export async function cmsFromContent(
 	const allProductsLead = leaderboards
 		.flatMap((leaderboard) => leaderboard.progress || [])
 		.map((progressItem) => progressItem.productId);
+
+	const externalProducts: ExternalProductData[] =
+		externalProductUrls.size > 0
+			? (await Promise.all([...externalProductUrls].map(fetchExternalProduct))).filter(
+					(p): p is ExternalProductData => p !== null
+			  )
+			: [];
 
 	const [
 		products,
@@ -633,6 +789,7 @@ export async function cmsFromContent(
 		challenges,
 		sliders,
 		products,
+		externalProducts,
 		tags,
 		specifications,
 		contactForms,

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -784,7 +784,8 @@
 			"details": "Details",
 			"donate": "Jetzt spenden",
 			"preorder": "Jetzt vorbestellen",
-			"subscribe": "Jetzt abonnieren"
+			"subscribe": "Jetzt abonnieren",
+			"view": "Produkt ansehen"
 		},
 		"deposit": {
 			"payFullPrice": "Jetzt den vollen Preis bezahlen",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -784,7 +784,8 @@
 			"details": "Details",
 			"donate": "Donate now",
 			"preorder": "Pre-order now",
-			"subscribe": "Subscribe now"
+			"subscribe": "Subscribe now",
+			"view": "View Product"
 		},
 		"deposit": {
 			"payFullPrice": "Pay full price now",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -784,7 +784,8 @@
 			"details": "Detalles",
 			"donate": "Donar",
 			"preorder": "Preordenar",
-			"subscribe": "Suscribirse"
+			"subscribe": "Suscribirse",
+			"view": "Ver producto"
 		},
 		"deposit": {
 			"payFullPrice": "Pagar el precio completo ahora",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -784,7 +784,8 @@
 			"details": "Détails",
 			"donate": "Faire un don",
 			"preorder": "Précommander",
-			"subscribe": "S'abonner"
+			"subscribe": "S'abonner",
+			"view": "Voir le produit"
 		},
 		"deposit": {
 			"payFullPrice": "Payez la totalité maintenant",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -784,7 +784,8 @@
 			"details": "Dettagli",
 			"donate": "Fa' un offerta ora",
 			"preorder": "Preordina ora ",
-			"subscribe": "Sottoscrivi ora"
+			"subscribe": "Sottoscrivi ora",
+			"view": "Vedi prodotto"
 		},
 		"deposit": {
 			"payFullPrice": "Paga il prezzo integrale ora",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -784,7 +784,8 @@
 			"details": "Details",
 			"donate": "Doneer nu",
 			"preorder": "Bestel nu vooraf",
-			"subscribe": "Abonneer nu"
+			"subscribe": "Abonneer nu",
+			"view": "Bekijk product"
 		},
 		"deposit": {
 			"payFullPrice": "Betaal nu de volledige prijs",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -784,7 +784,8 @@
 			"details": "Detalhes",
 			"donate": "Doar agora",
 			"preorder": "Pré-encomendar agora",
-			"subscribe": "Subscrever agora"
+			"subscribe": "Subscrever agora",
+			"view": "Ver produto"
 		},
 		"deposit": {
 			"payFullPrice": "Pagar o preço total agora",

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -12,6 +12,7 @@
 		sliders={data.cmsData.sliders}
 		tags={data.cmsData.tags}
 		products={data.cmsData.products}
+		externalProducts={data.cmsData.externalProducts}
 		pictures={data.cmsData.pictures}
 		digitalFiles={data.cmsData.digitalFiles}
 		hasPosOptions={data.hasPosOptions}

--- a/src/routes/(app)/[slug]/+page.svelte
+++ b/src/routes/(app)/[slug]/+page.svelte
@@ -10,6 +10,7 @@
 	sliders={data.cmsData.sliders}
 	tags={data.cmsData.tags}
 	products={data.cmsData.products}
+	externalProducts={data.cmsData.externalProducts}
 	pictures={data.cmsData.pictures}
 	digitalFiles={data.cmsData.digitalFiles}
 	hasPosOptions={data.hasPosOptions}

--- a/src/routes/(app)/[slug]/[sub]/[...catchall]/+page.svelte
+++ b/src/routes/(app)/[slug]/[sub]/[...catchall]/+page.svelte
@@ -10,6 +10,7 @@
 	sliders={data.cmsData.sliders}
 	tags={data.cmsData.tags}
 	products={data.cmsData.products}
+	externalProducts={data.cmsData.externalProducts}
 	pictures={data.cmsData.pictures}
 	digitalFiles={data.cmsData.digitalFiles}
 	hasPosOptions={data.hasPosOptions}

--- a/src/routes/(app)/api/product/[slug]/+server.ts
+++ b/src/routes/(app)/api/product/[slug]/+server.ts
@@ -1,0 +1,74 @@
+import { collections } from '$lib/server/database';
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { ORIGIN } from '$lib/server/env-config';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const { slug } = params;
+
+	const product = await collections.products.findOne(
+		{ _id: slug, 'actionSettings.eShop.visible': true },
+		{
+			projection: {
+				_id: 1,
+				name: 1,
+				shortDescription: 1,
+				price: 1
+			}
+		}
+	);
+
+	if (!product) {
+		throw error(404, 'Product not found');
+	}
+
+	// Get pictures by productId (not from product.pictures field)
+	const pictures = await collections.pictures
+		.find({ productId: product._id })
+		.sort({ order: 1, createdAt: 1 })
+		.toArray();
+
+	// Add full URLs to picture formats for cross-instance access
+	const picturesWithUrls = pictures.map((picture) => ({
+		...picture,
+		storage: {
+			...picture.storage,
+			original: {
+				...picture.storage.original,
+				url: `${ORIGIN}/picture/raw/${picture._id}/format/${picture.storage.original.width}`
+			},
+			formats: picture.storage.formats.map((format) => ({
+				...format,
+				url: `${ORIGIN}/picture/raw/${picture._id}/format/${format.width}`
+			}))
+		}
+	}));
+
+	return json(
+		{
+			_id: product._id,
+			name: product.name,
+			shortDescription: product.shortDescription,
+			price: product.price,
+			pictures: picturesWithUrls
+		},
+		{
+			headers: {
+				'Access-Control-Allow-Origin': '*',
+				'Access-Control-Allow-Methods': 'GET, OPTIONS',
+				'Access-Control-Allow-Headers': 'Content-Type',
+				'Cache-Control': 'public, max-age=300' // 5 minutes cache
+			}
+		}
+	);
+};
+
+export const OPTIONS: RequestHandler = async () => {
+	return new Response(null, {
+		headers: {
+			'Access-Control-Allow-Origin': '*',
+			'Access-Control-Allow-Methods': 'GET, OPTIONS',
+			'Access-Control-Allow-Headers': 'Content-Type'
+		}
+	});
+};


### PR DESCRIPTION
CMS Product widgets now support external be-BOP product URLs with display variants:

- [Product=https://other-shop.com/product/slug]
- [Product=https://other-shop.com/product/slug display=img-5]
- [Product=https://other-shop.com/product/slug?display=img-5]

External products display with "View Product" button that opens in a new tab instead of "Add to cart". Product data is fetched from the external shop's /.well-known/product/{slug} endpoint.

Closes #1820