### PR TITLE
🦋 PoS split payment by items & shares

### DIFF
--- a/src/lib/components/OrderSummary.svelte
+++ b/src/lib/components/OrderSummary.svelte
@@ -255,12 +255,17 @@
 	{#each validDeposits as payment}
 		<div class="py-3 flex flex-col">
 			<div class="flex justify-between">
-				<span class="text-xl"
-					><span title={t('checkout.paymentMethod.' + payment.method)}
-						>{PAYMENT_METHOD_EMOJI[payment.method]}</span
-					>
-					- {payment.status === 'paid' ? t('order.depositPaid') : t('order.depositToPay')}
-				</span>
+				<div class="flex flex-col">
+					<span class="text-xl"
+						><span title={t('checkout.paymentMethod.' + payment.method)}
+							>{PAYMENT_METHOD_EMOJI[payment.method]}</span
+						>
+						- {payment.status === 'paid' ? t('order.depositPaid') : t('order.depositToPay')}
+					</span>
+					{#if payment.status === 'pending'}
+						<span class="text-sm text-gray-500">pending</span>
+					{/if}
+				</div>
 				<PriceTag
 					class="text-2xl"
 					amount={payment.currencySnapshot.main.price.amount}
@@ -277,8 +282,8 @@
 		</div>
 	{/each}
 
-	{#if orderAmountWithNoPaymentsCreated(order)}
-		{@const remaining = orderAmountWithNoPaymentsCreated(order)}
+	{#if orderAmountWithNoPaymentsCreated(order, { ignorePendingPayments: true })}
+		{@const remaining = orderAmountWithNoPaymentsCreated(order, { ignorePendingPayments: true })}
 		<div class="py-3 flex flex-col">
 			<div class="flex justify-between">
 				<span class="text-xl">{t('order.restToPay')}</span>

--- a/src/lib/components/PosPaymentMethodSelector.svelte
+++ b/src/lib/components/PosPaymentMethodSelector.svelte
@@ -1,0 +1,36 @@
+<script context="module" lang="ts">
+	import type { PaymentMethod } from '$lib/server/payment-methods';
+
+	export type PaymentOption = {
+		method: PaymentMethod;
+		subtype: string | null;
+		label: string;
+		icon: string;
+	};
+</script>
+
+<script lang="ts">
+	export let paymentOptions: PaymentOption[] = [];
+	export let selectedIndex = 0;
+
+	$: if (selectedIndex >= paymentOptions.length) {
+		selectedIndex = 0;
+	}
+</script>
+
+{#if paymentOptions.length > 0}
+	<div class="grid grid-cols-4 gap-2">
+		{#each paymentOptions as option, i}
+			<button
+				type="button"
+				class="p-3 rounded text-center {selectedIndex === i
+					? 'bg-blue-600 text-white'
+					: 'bg-blue-100'}"
+				on:click={() => (selectedIndex = i)}
+			>
+				<div class="text-3xl">{option.icon}</div>
+				<div class="text-sm truncate">{option.label}</div>
+			</button>
+		{/each}
+	</div>
+{/if}

--- a/src/lib/components/PosPaymentsList.svelte
+++ b/src/lib/components/PosPaymentsList.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import PriceTag from '$lib/components/PriceTag.svelte';
+	import type { Currency } from '$lib/types/Currency';
+	import { useI18n } from '$lib/i18n';
+
+	const { t } = useI18n();
+
+	export let payments: Array<{
+		number: number;
+		amount: number;
+		currency: Currency;
+		isPaid: boolean;
+		status: string;
+		method: string;
+		createdAt: Date;
+		paidAt?: Date;
+		orderId?: string;
+	}>;
+	export let title: string;
+	export let bgClass = 'bg-gray-100';
+	export let returnTo: string | undefined = undefined;
+
+	function getPaymentLink(payment: (typeof payments)[0]): string | undefined {
+		if (!payment.orderId) {
+			return undefined;
+		}
+		const base = `/order/${payment.orderId}`;
+		return returnTo ? `${base}?returnTo=${encodeURIComponent(returnTo)}` : base;
+	}
+</script>
+
+{#if payments.length > 0}
+	<div class="{bgClass} rounded-lg p-4">
+		<h3 class="font-semibold text-3xl mb-3">{title}</h3>
+		<div class="space-y-2">
+			{#each payments as payment}
+				{@const link = getPaymentLink(payment)}
+				<div class="flex items-center justify-between">
+					<div class="flex-1">
+						<div class="flex items-center gap-3 text-2xl">
+							{#if link}
+								<a href={link} class="font-semibold text-blue-600 underline">
+									Payment {payment.number}:
+								</a>
+							{:else}
+								<span class="font-semibold">Payment {payment.number}:</span>
+							{/if}
+							<span class="font-bold">
+								<PriceTag amount={payment.amount} currency={payment.currency} />
+							</span>
+							{#if payment.isPaid}
+								<span class="text-green-600 text-3xl">✅</span>
+							{:else if payment.status === 'pending'}
+								<span class="text-orange-600 text-3xl">⏳</span>
+							{:else}
+								<span class="text-gray-400 text-3xl">⏸</span>
+							{/if}
+						</div>
+						<div class="text-lg text-gray-600 mt-1">
+							{t(`checkout.paymentMethod.${payment.method}`)} •
+							{new Date(payment.paidAt || payment.createdAt).toLocaleTimeString('en-GB', {
+								hour: '2-digit',
+								minute: '2-digit'
+							})}
+						</div>
+					</div>
+					{#if link}
+						<a href={link} class="bg-blue-600 text-white font-bold px-4 py-2 rounded text-xl">
+							View
+						</a>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/PosSplitItemRow.svelte
+++ b/src/lib/components/PosSplitItemRow.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { useI18n } from '$lib/i18n';
+	import PriceTag from '$lib/components/PriceTag.svelte';
+	import type { Currency } from '$lib/types/Currency';
+
+	export let item: {
+		product: {
+			name: string;
+			price: { currency: Currency };
+		};
+		internalNote?: {
+			value: string;
+		};
+	};
+	export let quantity: number;
+	export let priceInfo: { amount: number; currency: Currency };
+	export let vatRate: number;
+
+	// Controls
+	export let showInternalNote = true;
+	export let controls: 'none' | 'move-to-cart' | 'return-to-pool' = 'none';
+	export let isComplete = false;
+
+	// Callbacks
+	export let onMoveOne: (() => void) | undefined = undefined;
+	export let onMoveAll: (() => void) | undefined = undefined;
+	export let onReturnOne: (() => void) | undefined = undefined;
+	export let onReturnAll: (() => void) | undefined = undefined;
+
+	const { t } = useI18n();
+</script>
+
+<div class="py-3 border-b border-gray-300">
+	<div class="flex items-center gap-2 mb-2">
+		{#if controls === 'return-to-pool'}
+			<div class="flex gap-2">
+				<button
+					class="text-orange-600 hover:text-orange-700 font-bold text-3xl leading-none"
+					on:click={onReturnAll}
+				>
+					⏪
+				</button>
+				<button
+					class="border-4 border-orange-600 hover:border-orange-700 text-orange-600 hover:text-orange-700 font-bold text-2xl leading-none px-3 py-1 rounded"
+					on:click={onReturnOne}
+				>
+					➖
+				</button>
+			</div>
+		{/if}
+
+		<div class="flex-1 text-2xl font-bold">
+			{quantity} X {item.product.name.toUpperCase()}
+		</div>
+
+		{#if controls === 'move-to-cart'}
+			<div class="flex gap-2">
+				{#if isComplete}
+					<div class="text-3xl text-green-600">✅</div>
+				{:else}
+					<button
+						class="border-4 border-blue-600 hover:border-blue-700 text-blue-600 hover:text-blue-700 font-bold text-2xl leading-none px-3 py-1 rounded"
+						on:click={onMoveOne}
+					>
+						➕
+					</button>
+					<button
+						class="text-blue-600 hover:text-blue-700 font-bold text-3xl leading-none"
+						on:click={onMoveAll}
+					>
+						⏩
+					</button>
+				{/if}
+			</div>
+		{/if}
+
+		{#if isComplete && controls === 'none'}
+			<div class="text-3xl text-green-600">✅</div>
+		{/if}
+	</div>
+
+	{#if showInternalNote && item.internalNote?.value}
+		<div class="text-xl text-gray-600 mb-2">+{item.internalNote.value}</div>
+	{/if}
+
+	<div class="grid grid-cols-4 w-full items-center justify-around text-xl">
+		<div>{t('pos.split.exclVat')}</div>
+		<PriceTag amount={priceInfo.amount} currency={priceInfo.currency} main />
+		<div>{t('pos.split.vatRate', { rate: vatRate })}</div>
+		<PriceTag amount={(priceInfo.amount * vatRate) / 100} currency={priceInfo.currency} main />
+	</div>
+</div>

--- a/src/lib/components/PosSplitTotalSection.svelte
+++ b/src/lib/components/PosSplitTotalSection.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { useI18n } from '$lib/i18n';
+	import PriceTag from '$lib/components/PriceTag.svelte';
+	import type { Currency } from '$lib/types/Currency';
+
+	export let totalExcl: number;
+	export let totalIncl: number;
+	export let currency: Currency;
+	export let vatRates: number[];
+
+	const { t } = useI18n();
+</script>
+
+<div class="flex flex-col border-t border-gray-300 py-6 w-fit">
+	<h2 class="text-3xl underline uppercase">{t('cart.total')}</h2>
+	<div class="grid grid-cols-2 gap-4 grid-rows-2 justify-start">
+		<div class="text-2xl">{t('pos.split.exclVat')}</div>
+		<PriceTag amount={totalExcl} {currency} main class="text-2xl" />
+		<div class="text-2xl">
+			{t('pos.split.inclVat', {
+				rates: vatRates.map((rate) => `${rate}%`).join(', ')
+			})}
+		</div>
+		<PriceTag amount={totalIncl} {currency} main class="text-2xl" />
+	</div>
+</div>

--- a/src/lib/components/ProductWidget/ProductWidgetPOS.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetPOS.svelte
@@ -34,6 +34,10 @@
 				alert(t('pos.touch.maxQuantityReached', { max: Number(result.data.maxQuantity) }));
 				return;
 			}
+			if (result.type === 'failure' && result.data?.error === 'sharesPaymentStarted') {
+				alert(t('pos.split.completeSharesFirst'));
+				return;
+			}
 			invalidate(UrlDependency.orderTab(tabSlug));
 		};
 	}}

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -157,6 +157,8 @@ const indexes: Array<[Collection<any>, IndexSpecification, CreateIndexesOptions?
 	[collections.orders, { 'payments.invoice.number': 1 }, { unique: true, sparse: true }],
 	[collections.orders, { 'payments.status': 1 }],
 	[collections.orders, { status: 1, 'payments.status': 1 }],
+	[collections.orders, { orderTabId: 1, status: 1 }, { sparse: true }],
+	[collections.orders, { orderTabId: 1, splitMode: 1, status: 1 }, { sparse: true }],
 	[collections.orders, { orderLabelIds: 1 }, { sparse: true }],
 	[collections.digitalFiles, { productId: 1 }],
 	[collections.digitalFiles, { secret: 1 }, { unique: true, sparse: true }],
@@ -217,7 +219,8 @@ const indexes: Array<[Collection<any>, IndexSpecification, CreateIndexesOptions?
 	[collections.posPaymentSubtypes, { sortOrder: 1 }],
 	[collections.posPaymentSubtypes, { disabled: 1 }],
 	[collections.posSessions, { status: 1, openedAt: -1 }],
-	[collections.posSessions, { closedAt: -1 }]
+	[collections.posSessions, { closedAt: -1 }],
+	[collections.orderTabs, { slug: 1 }, { unique: true }]
 ];
 
 export async function createIndexes() {

--- a/src/lib/server/orderTab.test.ts
+++ b/src/lib/server/orderTab.test.ts
@@ -93,7 +93,8 @@ describe('addProductToOrderTab', () => {
 		}
 		const deleteRes = await collections.carts.deleteMany({ user: { email } });
 		expect(deleteRes.deletedCount).toBe(1);
-		await clearAbandonedCartsAndOrdersFromTab(tabSlug);
+		const tabForCleanup = await getOrCreateOrderTab({ slug: tabSlug });
+		await clearAbandonedCartsAndOrdersFromTab(tabForCleanup);
 		const orderTab2 = await getOrCreateOrderTab({ slug: tabSlug });
 		for (const item of orderTab2.items) {
 			expect(item.cartId).toEqual(undefined);

--- a/src/lib/server/orderTab.ts
+++ b/src/lib/server/orderTab.ts
@@ -1,9 +1,9 @@
-import { OrderTab } from '$lib/types/OrderTab';
-import { ObjectId } from 'mongodb';
+import { OrderTab, type CheckoutOrderTabParams } from '$lib/types/OrderTab';
+import { ObjectId, type ClientSession } from 'mongodb';
 import { collections } from './database';
 import { filterNullish } from '$lib/utils/fillterNullish';
-import { UserIdentifier } from '$lib/types/UserIdentifier';
 import { Order } from '$lib/types/Order';
+import { error } from '@sveltejs/kit';
 
 function mkOrderTab(slug: string): OrderTab {
 	return {
@@ -15,56 +15,63 @@ function mkOrderTab(slug: string): OrderTab {
 	};
 }
 
-export async function clearAbandonedCartsAndOrdersFromTab(slug: string): Promise<void> {
-	const returned = await collections.orderTabs.findOne({ slug });
-	if (!returned) {
+export async function clearAbandonedCartsAndOrdersFromTab(tab: OrderTab): Promise<void> {
+	const referencedOrderIds = filterNullish(tab.items.map((item) => item.orderId));
+	const referencedCartIds = filterNullish(tab.items.map((item) => item.cartId));
+
+	if (referencedOrderIds.length === 0 && referencedCartIds.length === 0) {
 		return;
 	}
-	const referencedOrderIds = filterNullish(returned.items.map((item) => item.orderId));
-	const referencedCartIds = filterNullish(returned.items.map((item) => item.cartId));
 
-	const [acceptedOrders, acceptedCartIds] = await Promise.all([
+	const [acceptedOrderIds, acceptedCartIds] = await Promise.all([
 		collections.orders
 			.find({ _id: { $in: referencedOrderIds }, status: { $in: ['pending', 'paid'] } })
 			.project({ _id: 1 })
-			.toArray(),
+			.toArray()
+			.then((orders) => new Set(orders.map((o) => o._id.toString()))),
 		collections.carts
 			.find({ _id: { $in: referencedCartIds } })
 			.project({ _id: 1 })
 			.toArray()
+			.then((carts) => new Set(carts.map((c) => c._id.toString())))
 	]);
 
-	const rejectedOrderIds = referencedOrderIds.filter(
-		(id) => !acceptedOrders.some((order) => order._id.toString() === id)
-	);
-	if (rejectedOrderIds.length > 0) {
-		await collections.orderTabs.updateMany(
-			{ _id: returned._id },
-			{ $unset: { 'items.$[elem].orderId': 1 } },
-			{ arrayFilters: [{ 'elem.orderId': { $in: rejectedOrderIds } }] }
-		);
-	}
+	const rejectedOrderIds = referencedOrderIds.filter((id) => !acceptedOrderIds.has(id));
+	const rejectedCartIds = referencedCartIds.filter((id) => !acceptedCartIds.has(id));
 
-	const rejectedCartIds = referencedCartIds.filter(
-		(id) => !acceptedCartIds.some((cart) => cart._id.toString() === id)
-	);
-	if (rejectedCartIds.length > 0) {
-		await collections.orderTabs.updateMany(
-			{ _id: returned._id },
-			{ $unset: { 'items.$[elem].cartId': 1 } },
-			{ arrayFilters: [{ 'elem.cartId': { $in: rejectedCartIds } }] }
-		);
-	}
+	await Promise.all([
+		...(rejectedOrderIds.length > 0
+			? [
+					collections.orderTabs.updateMany(
+						{ _id: tab._id },
+						{ $unset: { 'items.$[elem].orderId': 1 } },
+						{ arrayFilters: [{ 'elem.orderId': { $in: rejectedOrderIds } }] }
+					)
+			  ]
+			: []),
+		...(rejectedCartIds.length > 0
+			? [
+					collections.orderTabs.updateMany(
+						{ _id: tab._id },
+						{ $unset: { 'items.$[elem].cartId': 1 } },
+						{ arrayFilters: [{ 'elem.cartId': { $in: rejectedCartIds } }] }
+					)
+			  ]
+			: [])
+	]);
 }
 
 export async function getOrCreateOrderTab({ slug }: { slug: string }): Promise<OrderTab> {
 	const returned = await collections.orderTabs.findOne({ slug });
+
 	if (returned === null) {
 		const newOrderTab = mkOrderTab(slug);
 		const insertResult = await collections.orderTabs.insertOne(newOrderTab);
+
 		if (!insertResult.acknowledged || insertResult.insertedId !== newOrderTab._id) {
 			throw new Error('Failed to create order tab');
 		}
+
 		return newOrderTab;
 	} else {
 		return returned;
@@ -93,46 +100,89 @@ export async function concludeOrderTab({ slug }: { slug: string }) {
 	await collections.orderTabs.deleteOne({ slug });
 }
 
-export async function checkoutOrderTab({ slug, user }: { slug: string; user: UserIdentifier }) {
+export async function checkoutOrderTab({
+	slug,
+	user,
+	splitMode,
+	itemQuantities
+}: CheckoutOrderTabParams) {
 	const orderTab = await getOrCreateOrderTab({ slug });
-	const cartItems = orderTab.items.map((line) => ({
-		_id: line._id.toString(),
-		productId: line.productId,
-		quantity: line.quantity,
-		internalNote: line.internalNote,
-		chosenVariations: line.chosenVariations
-	}));
+
+	// Build cart items
+	const cartItems = itemQuantities
+		? Array.from(itemQuantities.entries()).map(([itemId, qty]) => {
+				const tabItem = orderTab.items.find((i) => i._id.toString() === itemId);
+				if (!tabItem) {
+					const availableItems = orderTab.items.map((i) => i._id.toString());
+					console.error('Item not found in orderTab:', {
+						requestedItemId: itemId,
+						availableItems
+					});
+					throw error(400, 'Item not found in order tab');
+				}
+				return {
+					_id: itemId,
+					productId: tabItem.productId,
+					quantity: qty,
+					internalNote: tabItem.internalNote,
+					chosenVariations: tabItem.chosenVariations
+				};
+		  })
+		: orderTab.items.map((line) => ({
+				_id: line._id.toString(),
+				productId: line.productId,
+				quantity: line.quantity,
+				internalNote: line.internalNote,
+				chosenVariations: line.chosenVariations
+		  }));
+
 	const createResult = await collections.carts.insertOne({
 		_id: new ObjectId(),
 		items: cartItems,
 		orderTabSlug: slug,
+		orderTabId: orderTab._id,
+		...(splitMode && { splitMode }),
 		updatedAt: new Date(),
 		createdAt: new Date(),
 		user
 	});
-	const cart = await collections.carts.findOne({ _id: createResult.insertedId });
-	if (!createResult.acknowledged || !cart) {
+
+	if (!createResult.acknowledged) {
 		throw new Error('Failed to create cart');
 	}
+
+	// Link items to cartId
 	await collections.orderTabs.updateOne(
 		{ _id: orderTab._id },
 		{ $set: { 'items.$[elem].cartId': createResult.insertedId } },
-		{ arrayFilters: [{ 'elem._id': { $in: cart.items.map((item) => new ObjectId(item._id)) } }] }
+		{ arrayFilters: [{ 'elem._id': { $in: cartItems.map((item) => new ObjectId(item._id)) } }] }
 	);
 }
 
 export async function addToOrderTab(params: {
 	tabSlug: string;
 	productId: string;
-}): Promise<{ success: true } | { success: false; error: string; maxQuantity: number }> {
+}): Promise<{ success: true } | { success: false; error: string; maxQuantity?: number }> {
 	const orderTab = await getOrCreateOrderTab({ slug: params.tabSlug });
 
-	const existingLineIndex = orderTab.items.findIndex(
-		(item) => !item.cartId && !item.orderId && item.productId === params.productId
-	);
+	const sharesOrder = await collections.orders.findOne({
+		orderTabId: orderTab._id,
+		splitMode: 'shares',
+		payments: { $elemMatch: { status: 'paid' } }
+	});
+	if (sharesOrder) {
+		return { success: false, error: 'sharesPaymentStarted' };
+	}
 
-	const currentQuantity = existingLineIndex !== -1 ? orderTab.items[existingLineIndex].quantity : 0;
-	const newQuantity = currentQuantity + 1;
+	const poolStartedPayments = orderTab.items.some((i) => i.originalQuantity !== undefined);
+	const existingItem = orderTab.items
+		// Exclude items already in a cart since they're being processed
+		.filter((i) => !i.cartId)
+		// Exclude items already in an order unless they're fully paid (quantity === 0) and can be reused
+		.filter((i) => !i.orderId || i.quantity === 0)
+		.find((i) => i.productId === params.productId);
+
+	const newQuantity = (existingItem?.quantity ?? 0) + 1;
 
 	const product = await collections.products.findOne({ _id: params.productId });
 	if (product?.maxQuantityPerOrder && newQuantity > product.maxQuantityPerOrder) {
@@ -143,20 +193,23 @@ export async function addToOrderTab(params: {
 		};
 	}
 
-	if (existingLineIndex !== -1) {
-		orderTab.items[existingLineIndex].quantity = newQuantity;
+	if (existingItem) {
+		existingItem.quantity = newQuantity;
+		if (existingItem.originalQuantity !== undefined) {
+			existingItem.originalQuantity += 1;
+		}
+		delete existingItem.orderId; // Reactivate item if it was fully paid
 	} else {
 		orderTab.items.push({
 			_id: new ObjectId(),
 			productId: params.productId,
-			quantity: 1
+			quantity: 1,
+			...(poolStartedPayments && { originalQuantity: 1 })
 		});
 	}
 
 	await collections.orderTabs.updateOne({ _id: orderTab._id }, { $set: { items: orderTab.items } });
-	return {
-		success: true
-	};
+	return { success: true };
 }
 
 export async function removeFromOrderTab(params: {
@@ -174,4 +227,83 @@ export async function removeFromOrderTab(params: {
 
 export async function removeOrderTab(params: { tabSlug: string }): Promise<void> {
 	await collections.orderTabs.deleteOne({ slug: params.tabSlug });
+}
+
+export async function handleOrderTabAfterPayment({
+	order,
+	session
+}: {
+	order: Order;
+	session?: ClientSession;
+}) {
+	if (!order.orderTabSlug) {
+		return;
+	}
+
+	const { orderTabSlug } = order;
+
+	const lastPaidPayment = [...order.payments].reverse().find((p) => p.status === 'paid');
+	if (!lastPaidPayment) {
+		return;
+	}
+
+	const paymentId = lastPaidPayment._id.toString();
+
+	const orderTab = await collections.orderTabs.findOne(
+		{ slug: orderTabSlug },
+		{ projection: { items: 1, processedPayments: 1 }, session }
+	);
+	if (orderTab?.processedPayments?.includes(paymentId)) {
+		return;
+	}
+
+	const hasOriginalQuantity = orderTab?.items.some((i) => i.originalQuantity !== undefined);
+	if (!hasOriginalQuantity && orderTab) {
+		const setOriginalOps = orderTab.items.map((item) => ({
+			updateOne: {
+				filter: { slug: orderTabSlug, 'items._id': item._id },
+				update: { $set: { 'items.$.originalQuantity': item.quantity } }
+			}
+		}));
+
+		if (setOriginalOps.length > 0) {
+			await collections.orderTabs.bulkWrite(setOriginalOps, { session });
+		}
+	}
+
+	if (order.splitMode === 'items') {
+		const bulkOps = order.items
+			.filter((item) => item._id)
+			.map((item) => {
+				const tabItem = orderTab?.items.find((i) => item._id && i._id.equals(item._id));
+				const currentQuantity = tabItem?.quantity || 0;
+
+				const updateFields: Record<string, unknown> = {
+					$inc: { 'items.$.quantity': -item.quantity }
+				};
+
+				if (currentQuantity === item.quantity) {
+					updateFields.$set = {
+						'items.$.orderId': order._id
+					};
+				}
+
+				return {
+					updateOne: {
+						filter: { slug: orderTabSlug, 'items._id': item._id },
+						update: updateFields
+					}
+				};
+			});
+
+		if (bulkOps.length > 0) {
+			await collections.orderTabs.bulkWrite(bulkOps, { session });
+		}
+	}
+
+	await collections.orderTabs.updateOne(
+		{ slug: orderTabSlug },
+		{ $addToSet: { processedPayments: paymentId } },
+		{ session }
+	);
 }

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -678,6 +678,8 @@
 			"notAvailableYet": "Not available yet",
 			"tabHeader": "Tab {slug}",
 			"tabToPayNow": "Tab {slug} (to pay now)",
+			"pool": "POOL",
+			"poolRemainingToPay": "POOL (remaining to be paid)",
 			"exclVat": "excl. VAT",
 			"inclVat": "incl. VAT {rates}",
 			"vatRate": "VAT {rate}%",
@@ -687,10 +689,23 @@
 			"shares": "shares",
 			"itemize": "itemize",
 			"return": "Return",
+			"continueSplit": "Continue split ({mode})",
 			"paySelected": "Pay selected",
 			"includingVatIncluded": "Including (VAT included):",
 			"tagProducts": "Tag \"{name}\" products",
-			"otherProducts": "Other products"
+			"otherProducts": "Other products",
+			"selectItems": "Please select items to pay",
+			"splitByShares": "Split by shares",
+			"enterNumberOfParts": "Enter number of parts",
+			"manualAmount": "Manual amount",
+			"ok": "OK",
+			"payRemaining": "Pay Remaining",
+			"totalAlreadyPaid": "Total already paid (incl. VAT)",
+			"remainingToPay": "Remaining to pay (incl. VAT)",
+			"allPaid": "All is paid",
+			"completeSharesFirst": "You have already started paying for the pool through \"Split (shares)\" payments. Please complete all payments and close the pool first. ",
+			"closePool": "Close pool",
+			"globalTicket": "Global ticket"
 		}
 	},
 	"product": {

--- a/src/lib/types/Cart.ts
+++ b/src/lib/types/Cart.ts
@@ -30,4 +30,6 @@ export interface Cart extends Timestamps {
 		chosenVariations?: Record<string, string>;
 	}>;
 	orderTabSlug?: string;
+	orderTabId?: ObjectId;
+	splitMode?: 'items' | 'shares';
 }

--- a/src/lib/types/OrderTab.ts
+++ b/src/lib/types/OrderTab.ts
@@ -1,6 +1,7 @@
 import type { ObjectId } from 'mongodb';
 import type { Timestamps } from './Timestamps';
 import type { User } from './User';
+import type { UserIdentifier } from './UserIdentifier';
 import type { PrintHistoryEntry } from './PrintHistoryEntry';
 
 export interface OrderTabItem {
@@ -9,6 +10,7 @@ export interface OrderTabItem {
 	orderId?: string;
 	productId: string;
 	quantity: number;
+	originalQuantity?: number;
 	internalNote?: { value: string; updatedAt: Date; updatedById?: User['_id'] };
 	chosenVariations?: Record<string, string>;
 	printStatus?: 'pending' | 'acknowledged';
@@ -19,6 +21,7 @@ export interface OrderTab extends Timestamps {
 	_id: ObjectId;
 	slug: string;
 	items: Array<OrderTabItem>;
+	processedPayments?: string[];
 	printHistory?: PrintHistoryEntry[];
 }
 
@@ -26,3 +29,26 @@ export interface OrderTabPoolStatus {
 	slug: string;
 	itemsCount: number;
 }
+
+export type CheckoutOrderTabParams =
+	| {
+			slug: string;
+			user: UserIdentifier;
+			// Split by items: both parameters required
+			splitMode: 'items';
+			itemQuantities: Map<string, number>;
+	  }
+	| {
+			slug: string;
+			user: UserIdentifier;
+			// Split by shares: only splitMode
+			splitMode: 'shares';
+			itemQuantities?: never;
+	  }
+	| {
+			slug: string;
+			user: UserIdentifier;
+			// Regular checkout: neither parameter
+			splitMode?: never;
+			itemQuantities?: never;
+	  };

--- a/src/routes/(app)/order/[id]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/+page.server.ts
@@ -95,6 +95,7 @@ export async function load({ params, depends, locals }) {
 
 	return {
 		order,
+		splitMode: order.splitMode,
 		paymentMethods: methods,
 		tapToPay,
 		posSubtypes,

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { invalidate } from '$app/navigation';
-	import { page } from '$app/stores';
+	import { navigating, page } from '$app/stores';
 	import OrderSummary from '$lib/components/OrderSummary.svelte';
 	import PriceTag from '$lib/components/PriceTag.svelte';
 	import Trans from '$lib/components/Trans.svelte';
@@ -39,6 +39,10 @@
 		const interval = setInterval(() => {
 			currentDate = new Date();
 
+			if ($navigating) {
+				return;
+			}
+
 			if (
 				data.order.status === 'pending' ||
 				data.order.payments.some((p) => p.invoice?.number === FAKE_ORDER_INVOICE_NUMBER)
@@ -63,7 +67,9 @@
 	let ticketIframe: HTMLIFrameElement | null = null;
 	let ticketReady = false;
 
-	$: remainingAmount = orderAmountWithNoPaymentsCreated(data.order);
+	$: remainingAmount = orderAmountWithNoPaymentsCreated(data.order, {
+		ignorePendingPayments: true
+	});
 	let disableInfoChange = true;
 	function confirmCancel(event: Event) {
 		if (!confirm(t('order.confirmCancel'))) {
@@ -891,6 +897,14 @@
 								>{t('order.note.seeText')}</a
 							>
 							{#if data.order.orderTabSlug}
+								{#if data.splitMode}
+									<a
+										href="/pos/touch/tab/{data.order.orderTabSlug}/split?mode={data.splitMode}"
+										class="btn lg:w-auto w-full btn-black self-end"
+									>
+										{t('pos.split.continueSplit', { mode: data.splitMode })}
+									</a>
+								{/if}
 								<a
 									href="/pos/touch/tab/{data.order.orderTabSlug}"
 									class="btn lg:w-auto w-full btn-gray self-end"

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -195,6 +195,8 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 			chosenVariations: item.chosenVariations
 		})),
 		orderTabSlug: order.orderTabSlug,
+		cartId: order.cartId?.toString(),
+		splitMode: order.splitMode,
 		shippingPrice: order.shippingPrice && {
 			amount: order.shippingPrice.amount,
 			currency: order.shippingPrice.currency

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -35,7 +35,7 @@
 		filter === 'all'
 			? data.products
 			: data.products.filter((product) => product.tagIds?.includes(filter));
-	$: items = data.orderTab.items;
+	$: items = data.orderTab.items.filter((item) => item.quantity > 0);
 	$: priceInfo = computePriceInfo(items, {
 		bebopCountry: data.vatCountry,
 		deliveryFees: { amount: 0, currency: UNDERLYING_CURRENCY },

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
@@ -1,8 +1,22 @@
 import { ItemForPriceInfo, ProductForPriceInfo } from '$lib/cart';
 import { collections } from '$lib/server/database';
-import { clearAbandonedCartsAndOrdersFromTab, getOrCreateOrderTab } from '$lib/server/orderTab';
+import { ObjectId } from 'mongodb';
+import {
+	clearAbandonedCartsAndOrdersFromTab,
+	getOrCreateOrderTab,
+	checkoutOrderTab
+} from '$lib/server/orderTab';
 import { OrderTab } from '$lib/types/OrderTab';
 import { UrlDependency } from '$lib/types/UrlDependency';
+import { removeUserCarts } from '$lib/server/cart';
+import { userIdentifier } from '$lib/server/user';
+import { fail, redirect, error } from '@sveltejs/kit';
+import { z } from 'zod';
+import { createOrder, addOrderPayment } from '$lib/server/orders';
+import { orderRemainingToPay } from '$lib/types/Order';
+import { CURRENCY_UNIT } from '$lib/types/Currency';
+import { runtimeConfig } from '$lib/server/runtime-config';
+import { paymentMethods, type PaymentMethod } from '$lib/server/payment-methods';
 
 type Locale = App.Locals['language'];
 type ProductProjection = ProductForPriceInfo & { name: string };
@@ -14,7 +28,9 @@ type HydratedTabItem = {
 	};
 	product: Omit<ProductProjection, 'vatProfileId'> & { vatProfileId?: string };
 	quantity: number;
+	originalQuantity?: number;
 	tabItemId: string;
+	orderId?: string;
 };
 
 async function hydratedOrderItems(
@@ -50,27 +66,249 @@ async function hydratedOrderItems(
 					},
 					product: { ...product, vatProfileId: product.vatProfileId?.toString() },
 					quantity: item.quantity,
-					tabItemId: item._id.toString()
+					originalQuantity: item.originalQuantity,
+					tabItemId: item._id.toString(),
+					orderId: item.orderId
 				};
 			}
 		})
 		.filter((item): item is NonNullable<typeof item> => item !== undefined);
 }
 
-async function getHydratedOrderTab(locale: Locale, tabSlug: string) {
-	const tab = await getOrCreateOrderTab({ slug: tabSlug });
+async function getHydratedOrderTab(locale: Locale, tab: OrderTab) {
 	return { slug: tab.slug, items: await hydratedOrderItems(locale, tab.items) };
 }
 
 export const load = async ({ depends, locals, params }) => {
 	const tabSlug = params.orderTabSlug;
-	await clearAbandonedCartsAndOrdersFromTab(tabSlug);
-	const orderTab = await getHydratedOrderTab(locals.language, tabSlug);
+	const tab = await getOrCreateOrderTab({ slug: tabSlug });
+
+	const [orderTab, allPoolOrders, posSubtypes] = await Promise.all([
+		getHydratedOrderTab(locals.language, tab),
+		collections.orders
+			.find({
+				orderTabId: tab._id,
+				status: { $in: ['pending', 'paid'] }
+			})
+			.toArray(),
+		collections.posPaymentSubtypes
+			.find({ disabled: { $ne: true } })
+			.sort({ sortOrder: 1 })
+			.toArray(),
+		clearAbandonedCartsAndOrdersFromTab(tab)
+	]);
+
 	depends(UrlDependency.orderTab(tabSlug));
 
+	const sharesOrder = allPoolOrders.find((o) => o.splitMode === 'shares');
+
+	let paymentCounter = 1;
+	const allPayments = allPoolOrders.flatMap((order) =>
+		order.payments.map((payment) => ({
+			splitMode: order.splitMode as 'items' | 'shares',
+			number: paymentCounter++,
+			amount: payment.currencySnapshot.main.price.amount,
+			currency: payment.currencySnapshot.main.price.currency,
+			status: payment.status,
+			isPaid: payment.status === 'paid',
+			createdAt: payment.createdAt || new Date(),
+			paidAt: payment.paidAt,
+			method: payment.method,
+			orderId: order._id
+		}))
+	);
+
+	let sharesOrderData = null;
+
+	if (allPayments.length > 0) {
+		// Use sharesOrder for remaining calculation if exists, otherwise use first order's currency
+		const referenceOrder = sharesOrder ?? allPoolOrders[0];
+		const currency = referenceOrder.currencySnapshot.main.totalPrice.currency;
+		const remainingToPay = sharesOrder ? orderRemainingToPay(sharesOrder) : null;
+
+		const totalAlreadyPaid = allPayments
+			.filter((p) => p.isPaid)
+			.reduce((sum, p) => sum + p.amount, 0);
+
+		sharesOrderData = {
+			_id: sharesOrder?._id ?? null,
+			currency,
+			totalPrice: sharesOrder?.currencySnapshot.main.totalPrice.amount ?? null,
+			totalAlreadyPaid,
+			remainingToPay,
+			isFullyPaid: sharesOrder
+				? remainingToPay === 0 ||
+				  (remainingToPay !== null && remainingToPay < CURRENCY_UNIT[currency])
+				: false,
+			payments: allPayments
+		};
+	}
+
 	orderTab.items satisfies ItemForPriceInfo[];
+
+	const methods = paymentMethods({ hasPosOptions: true, includePOS: true });
+
 	return {
 		orderTab,
-		tabSlug
+		tabSlug,
+		sharesOrder: sharesOrderData,
+		availablePaymentMethods: methods,
+		paymentSubtypes: posSubtypes.map((s) => ({
+			slug: s.slug,
+			name: s.name,
+			parentMethod: 'point-of-sale' as PaymentMethod
+		}))
 	};
+};
+
+const itemQuantitiesSchema = z.array(z.tuple([z.string(), z.number().positive()]));
+
+const sharePaymentSchema = z.discriminatedUnion('mode', [
+	z.object({
+		mode: z.literal('equal'),
+		shares: z.coerce.number().int().min(2)
+	}),
+	z.object({
+		mode: z.literal('custom-amount'),
+		customAmount: z.coerce.number().positive()
+	})
+]);
+
+export const actions = {
+	checkoutTabPartial: async ({ request, locals, params }) => {
+		const formData = await request.formData();
+		const user = userIdentifier(locals);
+
+		let itemQuantities: Map<string, number> | null = null;
+		if (formData.has('itemQuantities')) {
+			try {
+				itemQuantities = new Map(
+					itemQuantitiesSchema.parse(JSON.parse(formData.get('itemQuantities') as string))
+				);
+				if (!itemQuantities.size) {
+					return fail(400, { error: 'No items selected' });
+				}
+			} catch (err) {
+				return fail(400, { error: err instanceof Error ? err.message : 'Invalid item data' });
+			}
+		}
+
+		const paymentParams = sharePaymentSchema.safeParse(Object.fromEntries(formData));
+
+		if (itemQuantities || paymentParams.success) {
+			const splitMode: 'items' | 'shares' = itemQuantities ? 'items' : 'shares';
+
+			const selectedMethod = (formData.get('paymentMethod') as PaymentMethod) || 'point-of-sale';
+			const selectedSubtype = formData.get('subtype') as string | null;
+
+			const orderTab = await getOrCreateOrderTab({ slug: params.orderTabSlug });
+
+			let order =
+				splitMode === 'shares'
+					? await collections.orders.findOne({
+							orderTabId: orderTab._id,
+							splitMode: 'shares',
+							status: { $in: ['pending', 'paid'] }
+					  })
+					: null;
+
+			if (!order) {
+				await removeUserCarts(user);
+
+				if (splitMode === 'items' && itemQuantities) {
+					await checkoutOrderTab({
+						slug: params.orderTabSlug,
+						user,
+						splitMode,
+						itemQuantities
+					});
+				} else if (splitMode === 'shares') {
+					await checkoutOrderTab({ slug: params.orderTabSlug, user, splitMode });
+				}
+
+				const cart = await collections.carts.findOne({
+					orderTabSlug: params.orderTabSlug,
+					orderTabId: orderTab._id,
+					splitMode
+				});
+				if (!cart) {
+					console.error('Cart creation failed for orderTab:', {
+						orderTabSlug: params.orderTabSlug,
+						orderTabId: orderTab._id
+					});
+					throw error(500, 'Failed to create cart for split payment');
+				}
+
+				const products = await collections.products
+					.find({ _id: { $in: cart.items.map((i) => i.productId) } })
+					.toArray();
+
+				const productById = new Map(products.map((p) => [p._id.toString(), p]));
+				const items = cart.items.map((cartItem) => {
+					const product = productById.get(cartItem.productId.toString());
+					if (!product) {
+						throw new Error(`Product ${cartItem.productId} not found`);
+					}
+
+					return {
+						_id: cartItem._id ? new ObjectId(cartItem._id) : undefined,
+						quantity: cartItem.quantity,
+						product,
+						internalNote: cartItem.internalNote,
+						chosenVariations: cartItem.chosenVariations
+					};
+				});
+
+				const orderId = await createOrder(items, null, {
+					locale: locals.language,
+					user,
+					userVatCountry: runtimeConfig.vatCountry,
+					shippingAddress: null,
+					cart
+				});
+
+				order = await collections.orders.findOne({ _id: orderId });
+				if (!order) {
+					throw new Error('Failed to create order');
+				}
+			}
+
+			const remainingToPay = orderRemainingToPay(order);
+			// Division may produce non-integer (e.g. 10/6 = 1.666...)
+			// Rounded to currency precision in addOrderPayment() → toCurrency()
+			const amountToPay =
+				splitMode === 'items'
+					? order.currencySnapshot.main.totalPrice.amount // full amount
+					: paymentParams.success && paymentParams.data.mode === 'equal'
+					? remainingToPay / paymentParams.data.shares
+					: paymentParams.success && paymentParams.data.mode === 'custom-amount'
+					? Math.min(paymentParams.data.customAmount, remainingToPay)
+					: order.currencySnapshot.main.totalPrice.amount;
+
+			await addOrderPayment(
+				order,
+				selectedMethod,
+				{
+					amount: amountToPay,
+					currency: order.currencySnapshot.main.totalPrice.currency
+				},
+				{
+					ignorePendingPayments: true,
+					...(selectedSubtype && { posSubtype: selectedSubtype })
+				}
+			);
+
+			const returnUrl = `/pos/touch/tab/${params.orderTabSlug}/split?mode=${splitMode}`;
+			throw redirect(303, `/order/${order._id}?returnTo=${encodeURIComponent(returnUrl)}`);
+		}
+
+		// Invalid request - neither itemQuantities nor valid payment params
+		return fail(400, { error: 'Invalid request: missing itemQuantities or payment params' });
+	},
+
+	closePool: async ({ params }) => {
+		const { concludeOrderTab } = await import('$lib/server/orderTab');
+		await concludeOrderTab({ slug: params.orderTabSlug });
+		throw redirect(303, `/pos/touch/tab/${params.orderTabSlug}`);
+	}
 };

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
@@ -1,232 +1,605 @@
 <script lang="ts">
 	import { computePriceInfo } from '$lib/cart';
 	import PriceTag from '$lib/components/PriceTag.svelte';
+	import PosSplitTotalSection from '$lib/components/PosSplitTotalSection.svelte';
+	import PosPaymentsList from '$lib/components/PosPaymentsList.svelte';
+	import PosSplitItemRow from '$lib/components/PosSplitItemRow.svelte';
+	import PrintableTicket from '$lib/components/PrintableTicket.svelte';
 	import { useI18n } from '$lib/i18n';
-	import { UNDERLYING_CURRENCY } from '$lib/types/Currency.js';
+	import { UNDERLYING_CURRENCY, type Currency } from '$lib/types/Currency.js';
+	import { toCurrency } from '$lib/utils/toCurrency';
+	import { PAYMENT_METHOD_EMOJI } from '$lib/types/Order';
+	import type { PaymentMethod } from '$lib/server/payment-methods';
+	import { page } from '$app/stores';
+	import { enhance } from '$app/forms';
+	import PosPaymentMethodSelector, {
+		type PaymentOption
+	} from '$lib/components/PosPaymentMethodSelector.svelte';
+
+	const { t } = useI18n();
+
+	// Constants
+	const DEFAULT_SHARES_COUNT = 10;
+	const POS_SPLIT_SHARES_MAX_NUMS = 9;
 
 	export let data;
 	const tabSlug = data.tabSlug;
 	$: tab = data.orderTab;
-	$: tabItemsPriceInfo = computePriceInfo(tab.items, {
+
+	// Payment method selector
+	type PaymentSubtype = { slug: string; name: string; parentMethod: PaymentMethod };
+
+	function buildPaymentOptions(
+		methods: PaymentMethod[],
+		subtypes: PaymentSubtype[]
+	): PaymentOption[] {
+		const subtypesByParent = subtypes.reduce((map, subtype) => {
+			if (!map.has(subtype.parentMethod)) {
+				map.set(subtype.parentMethod, []);
+			}
+			const existing = map.get(subtype.parentMethod);
+			if (existing) {
+				existing.push(subtype);
+			}
+			return map;
+		}, new Map<PaymentMethod, PaymentSubtype[]>());
+
+		return methods
+			.filter((method) => method !== 'free')
+			.flatMap((method): PaymentOption[] => {
+				const methodSubtypes = subtypesByParent.get(method);
+				if (methodSubtypes?.length) {
+					return methodSubtypes.map((subtype) => ({
+						method: subtype.parentMethod,
+						subtype: subtype.slug,
+						label: subtype.name,
+						icon: PAYMENT_METHOD_EMOJI[subtype.parentMethod]
+					}));
+				}
+				return [
+					{
+						method,
+						subtype: null,
+						label: t(`checkout.paymentMethod.${method}`),
+						icon: PAYMENT_METHOD_EMOJI[method]
+					}
+				];
+			});
+	}
+
+	$: paymentOptions = buildPaymentOptions(
+		data.availablePaymentMethods ?? [],
+		data.paymentSubtypes ?? []
+	);
+
+	let selectedPaymentIndex = 0;
+	$: selectedPayment = paymentOptions[selectedPaymentIndex] ?? paymentOptions[0];
+
+	// Price calculation config (DRY: используется 3 раза)
+	$: priceConfig = {
 		bebopCountry: data.vatCountry,
-		deliveryFees: { amount: 0, currency: UNDERLYING_CURRENCY },
+		deliveryFees: { amount: 0, currency: UNDERLYING_CURRENCY as Currency },
 		freeProductUnits: {},
 		userCountry: data.countryCode,
 		vatExempted: data.vatExempted,
 		vatNullOutsideSellerCountry: data.vatNullOutsideSellerCountry,
 		vatSingleCountry: data.vatSingleCountry,
 		vatProfiles: data.vatProfiles
-	});
+	};
 
-	/**
-	 * This symbol borrows the indexing of the tab items and contains the
-	 * quantities of each item.
-	 */
+	$: tabItemsPriceInfo = computePriceInfo(tab.items, priceConfig);
+
+	// Reset cart when tab reloads or pool is fully paid
 	let splitTabQuantities = data.orderTab.items.map(() => 0);
-	$: {
-		if (tab.items) {
-			splitTabQuantities = data.orderTab.items.map(() => 0);
-		}
+	$: if (tab.items || isPoolFullyPaid) {
+		splitTabQuantities = tab.items.map(() => 0);
 	}
-	$: splitTabItems = tab.items.map((item, i) => ({ ...item, quantity: splitTabQuantities[i] }));
-	$: splitTabPriceInfo = computePriceInfo(splitTabItems, {
-		bebopCountry: data.vatCountry,
-		deliveryFees: { amount: 0, currency: UNDERLYING_CURRENCY },
-		freeProductUnits: {},
-		userCountry: data.countryCode,
-		vatExempted: data.vatExempted,
-		vatNullOutsideSellerCountry: data.vatNullOutsideSellerCountry,
-		vatSingleCountry: data.vatSingleCountry,
-		vatProfiles: data.vatProfiles
-	});
 
-	let rightPannel: 'menu' | 'split-items' | 'split-shares' = 'menu';
-	let itemAction: (index: number) => void = () => {};
-	let rightPannelItemAction: (index: number) => void = () => {};
-	function rightPannelMenu() {
-		rightPannel = 'menu';
-		itemAction = () => {};
-		rightPannelItemAction = () => {};
+	$: splitTabItems = tab.items.map((item, i) => ({ ...item, quantity: splitTabQuantities[i] }));
+	$: splitTabPriceInfo = computePriceInfo(splitTabItems, priceConfig);
+
+	$: hasOriginalQuantities = tab.items.some((item) => item.originalQuantity !== undefined);
+
+	let isPoolFullyPaid: boolean;
+	$: {
+		const allZero = tab.items.every((item) => item.quantity === 0);
+		isPoolFullyPaid = data.sharesOrder?._id
+			? data.sharesOrder.isFullyPaid && hasOriginalQuantities
+			: hasOriginalQuantities && allZero;
 	}
-	function rightPannelSplitItems() {
+
+	// Pool fully paid calculations (based on original quantities)
+	$: itemsWithOriginalQuantities = tab.items.map((item) => ({
+		...item,
+		quantity: item.originalQuantity ?? item.quantity
+	}));
+	$: originalQuantitiesPriceInfo = computePriceInfo(itemsWithOriginalQuantities, priceConfig);
+	$: originalTabTotalWithVat = originalQuantitiesPriceInfo.partialPriceWithVat;
+
+	$: poolTotals =
+		isPoolFullyPaid && hasOriginalQuantities
+			? computePoolTotals(originalQuantitiesPriceInfo)
+			: null;
+
+	$: poolCurrency = tab.items[0]?.product.price.currency ?? UNDERLYING_CURRENCY;
+	$: poolVatRates = [...new Set(originalQuantitiesPriceInfo.vatRates)];
+
+	const modeParam = $page.url.searchParams.get('mode');
+	let rightPannel: 'menu' | 'split-items' | 'split-shares' =
+		modeParam === 'items' ? 'split-items' : modeParam === 'shares' ? 'split-shares' : 'menu';
+
+	let fromCashInAll = false;
+
+	$: if (isPoolFullyPaid && rightPannel === 'menu') {
 		rightPannel = 'split-items';
-		itemAction = (index: number) => {
-			const maxQty = data.orderTab.items[index].quantity;
-			const currQty = splitTabQuantities[index];
-			const newQty = Math.min(currQty + 1, maxQty);
-			if (newQty !== currQty) {
-				splitTabQuantities[index] = newQty;
-			}
-		};
-		rightPannelItemAction = (index: number) => {
-			const currQty = splitTabQuantities[index];
-			const newQty = Math.max(currQty - 1, 0);
-			if (newQty !== currQty) {
-				splitTabQuantities[index] = newQty;
-			}
-		};
 	}
-	function rightPannelSplitShares() {
-		if (true) {
-			alert(t('pos.split.notAvailableYet'));
-			return;
+
+	$: if (rightPannel === 'menu') {
+		fromCashInAll = false;
+	}
+
+	function moveOneToCart(index: number) {
+		const maxQty = data.orderTab.items[index].quantity;
+		const currQty = splitTabQuantities[index];
+		const newQty = Math.min(currQty + 1, maxQty);
+		if (newQty !== currQty) {
+			splitTabQuantities[index] = newQty;
 		}
-		rightPannel = 'split-shares';
 	}
-	function checkoutSplitPayment() {
-		alert(t('pos.split.notAvailableYet'));
-		return;
+
+	function moveAllToCart(index: number) {
+		const maxQty = data.orderTab.items[index].quantity;
+		splitTabQuantities[index] = maxQty;
 	}
-	const { t } = useI18n();
+
+	function returnOneToPool(index: number) {
+		const currQty = splitTabQuantities[index];
+		const newQty = Math.max(currQty - 1, 0);
+		if (newQty !== currQty) {
+			splitTabQuantities[index] = newQty;
+		}
+	}
+
+	function returnAllToPool(index: number) {
+		splitTabQuantities[index] = 0;
+	}
+
+	// Utility: Calculate item display data (price, quantity, VAT) for PosSplitItemRow
+	function getItemDisplayData(
+		item: (typeof tab.items)[0],
+		index: number,
+		priceInfo: typeof tabItemsPriceInfo,
+		quantityOverride?: number
+	) {
+		const qty = quantityOverride ?? item.quantity;
+		const pricePerItem = priceInfo.perItem[index];
+		const unitPrice = item.quantity > 0 ? pricePerItem.amount / item.quantity : 0;
+		const vatRate = priceInfo.vatRates[index];
+
+		return {
+			quantity: qty,
+			priceInfo: { amount: unitPrice * qty, currency: pricePerItem.currency },
+			vatRate
+		};
+	}
+
+	function computePoolTotals(priceInfo: typeof tabItemsPriceInfo) {
+		return priceInfo.perItem.reduce(
+			(acc, perItem, i) => {
+				const itemVat = perItem.amount * (priceInfo.vatRates[i] / 100);
+				return {
+					excl: acc.excl + perItem.amount,
+					vat: acc.vat + itemVat,
+					incl: acc.incl + perItem.amount + itemVat
+				};
+			},
+			{ excl: 0, vat: 0, incl: 0 }
+		);
+	}
+
+	let sharesInput = DEFAULT_SHARES_COUNT;
+	let customAmountInput = 0;
+	let showCustomShares = false;
+	let showCustomAmount = false;
+
+	$: itemQuantitiesJson = JSON.stringify(
+		tab.items
+			.map((item, i) => [item.tabItemId, splitTabQuantities[i]])
+			.filter(([, qty]) => Number(qty) > 0)
+	);
+
+	function validateItemsCheckout(event: SubmitEvent) {
+		if (itemQuantitiesJson === '[]') {
+			event.preventDefault();
+			alert(t('pos.split.selectItems'));
+		}
+	}
+
+	// Print functionality
+	let printing = false;
+
+	// Beautify tabSlug for display: "table-3" → "Table 3"
+	$: poolLabel = tabSlug
+		.split('-')
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ');
+
+	function handlePrintGlobalTicket() {
+		printing = true;
+		setTimeout(() => {
+			window.print();
+			printing = false;
+		}, 100);
+	}
 </script>
 
 <div class="flex flex-col h-screen justify-between">
 	<main class="mb-auto flex-grow min-h-min overflow-y-auto">
 		<div class="grid grid-cols-2 gap-4 h-full">
 			<div class="touchScreen-ticket-menu flex flex-col justify-between p-3 h-full overflow-y-auto">
-				{#if tab.items.length}
+				{#if poolTotals}
 					<div>
-						<h3 class="font-semibold text-3xl">{t('pos.split.tabHeader', { slug: tab.slug })}</h3>
+						<h3 class="font-semibold text-3xl">{t('pos.split.pool')}</h3>
 						{#each tab.items as item, i}
-							{@const itemPrice = tabItemsPriceInfo.perItem[i]}
-							{@const itemVatRate = tabItemsPriceInfo.vatRates[i]}
-							<div class="flex flex-col py-3 gap-4">
-								<button
-									class="text-start text-2xl w-full justify-between"
-									on:click={() => itemAction(i)}
-								>
-									{item.quantity} X {item.product.name.toUpperCase()}<br />
-									{item.internalNote?.value ? '+' + item.internalNote.value : ''}
-									<div class="grid grid-cols-4 w-full items-center justify-around text-xl">
-										<div>{t('pos.split.exclVat')}</div>
-										<PriceTag amount={itemPrice.amount} currency={itemPrice.currency} main />
-										<div>{t('pos.split.vatRate', { rate: itemVatRate })}</div>
-										<PriceTag
-											amount={(itemPrice.amount * itemVatRate) / 100}
-											currency={itemPrice.currency}
-											main
-										/>
-									</div>
-								</button><br />
-							</div>
+							{@const displayData = getItemDisplayData(
+								item,
+								i,
+								tabItemsPriceInfo,
+								item.originalQuantity ?? item.quantity
+							)}
+
+							<PosSplitItemRow {item} {...displayData} showInternalNote={false} controls="none" />
 						{/each}
 					</div>
-					<div class="flex flex-col border-t border-gray-300 py-6 w-fit">
-						<h2 class="text-3xl underline uppercase">{t('cart.total')}</h2>
-						<div class="grid grid-cols-2 gap-4 grid-rows-2 justify-start">
-							<div class="text-2xl">{t('pos.split.exclVat')}</div>
-							<PriceTag
-								amount={tabItemsPriceInfo.partialPrice}
-								currency={tabItemsPriceInfo.currency}
-								main
-								class="text-2xl"
+					<PosSplitTotalSection
+						totalExcl={poolTotals.excl}
+						totalIncl={poolTotals.incl}
+						currency={poolCurrency}
+						vatRates={poolVatRates}
+					/>
+				{:else if tab.items.length}
+					<div>
+						<h3 class="font-semibold text-3xl">
+							{t('pos.split.tabHeader', { slug: tab.slug })}
+						</h3>
+						{#each tab.items as item, i}
+							{@const remainingQty = item.quantity - (splitTabQuantities[i] || 0)}
+							{@const displayData = getItemDisplayData(item, i, tabItemsPriceInfo, remainingQty)}
+							{@const allMovedToCart = remainingQty === 0}
+
+							<PosSplitItemRow
+								{item}
+								{...displayData}
+								controls={rightPannel === 'split-items' && !isPoolFullyPaid
+									? 'move-to-cart'
+									: 'none'}
+								isComplete={allMovedToCart}
+								onMoveOne={() => moveOneToCart(i)}
+								onMoveAll={() => moveAllToCart(i)}
 							/>
-							<div class="text-2xl">
-								{t('pos.split.inclVat', {
-									rates: tabItemsPriceInfo.vat.map((vat) => `${vat.rate}%`).join(', ')
-								})}
-							</div>
-							<PriceTag
-								amount={tabItemsPriceInfo.partialPriceWithVat}
-								currency={tabItemsPriceInfo.currency}
-								main
-								class="text-2xl"
-							/>
-						</div>
+						{/each}
 					</div>
+					<PosSplitTotalSection
+						totalExcl={tabItemsPriceInfo.partialPrice}
+						totalIncl={tabItemsPriceInfo.partialPriceWithVat}
+						currency={tabItemsPriceInfo.currency}
+						vatRates={tabItemsPriceInfo.vat.map((vat) => vat.rate)}
+					/>
 				{:else}
 					<p>{t('cart.empty')}</p>
 				{/if}
 			</div>
-			<div class="h-full">
+			<div
+				class="h-full {rightPannel === 'split-items'
+					? 'bg-blue-50'
+					: rightPannel === 'split-shares'
+					? 'bg-yellow-50'
+					: ''}"
+			>
 				{#if rightPannel === 'menu'}
 					<div class="flex flex-col h-full gap-4">
-						<form
-							action="/pos?/checkoutTab"
-							class="flex-1 flex justify-center bg-green-800 hover:bg-green-900"
-							method="POST"
-						>
-							<input type="hidden" name="tabSlug" value={tabSlug} />
-							<button class="text-white font-bold py-2 px-4 text-6xl" type="submit">
-								{t('pos.split.cashIn')}<br />({t('pos.split.all')})
-							</button>
-						</form>
 						<button
-							class="flex-1 bg-blue-800 hover:bg-blue-900 text-white font-bold py-2 px-4 text-6xl"
-							on:click={rightPannelSplitShares}
+							class="flex-1 bg-green-800 hover:bg-green-900 text-white font-bold py-2 px-4 text-6xl"
+							on:click={() => ((fromCashInAll = true), (rightPannel = 'split-shares'))}
+						>
+							{t('pos.split.cashIn')}<br />({t('pos.split.all')})
+						</button>
+						<button
+							class="flex-1 bg-yellow-800 hover:bg-yellow-900 text-white font-bold py-2 px-4 text-6xl"
+							on:click={() => ((fromCashInAll = false), (rightPannel = 'split-shares'))}
 						>
 							{t('pos.split.split')}<br />({t('pos.split.shares')})
 						</button>
 						<button
-							class="flex-1 bg-yellow-800 hover:bg-yellow-900 text-white font-bold py-2 px-4 text-6xl"
-							on:click={rightPannelSplitItems}
+							class="flex-1 py-2 px-4 text-6xl font-bold disabled:cursor-not-allowed disabled:text-gray-700 {data.sharesOrder?.payments.some(
+								(p) => p.splitMode === 'shares' && p.isPaid
+							)
+								? 'bg-gray-400'
+								: 'bg-blue-800 hover:bg-blue-900 text-white'}"
+							on:click={() => (rightPannel = 'split-items')}
+							disabled={data.sharesOrder?.payments.some(
+								(p) => p.splitMode === 'shares' && p.isPaid
+							)}
 						>
 							{t('pos.split.split')}<br />({t('pos.split.itemize')})
+							{#if data.sharesOrder?.payments.some((p) => p.splitMode === 'shares' && p.isPaid)}
+								<div class="text-sm mt-2" style="color: #864D0F;">
+									<span class="text-2xl">⚠️</span>
+									{t('pos.split.completeSharesFirst')}
+								</div>
+							{/if}
 						</button>
 					</div>
 				{:else if rightPannel === 'split-items'}
-					<div class="touchScreen-ticket-menu flex flex-col justify-between p-3 h-full">
+					<div
+						class="touchScreen-ticket-menu flex flex-col justify-between p-3 h-full overflow-y-auto"
+					>
 						<div>
 							<h3 class="font-semibold text-3xl">
-								{t('pos.split.tabToPayNow', { slug: tab.slug })}
+								{isPoolFullyPaid
+									? t('pos.split.poolRemainingToPay')
+									: t('pos.split.tabToPayNow', { slug: tab.slug })}
 							</h3>
 							{#each splitTabItems as item, i}
-								{@const itemPrice = splitTabPriceInfo.perItem[i]}
-								{@const itemVatRate = splitTabPriceInfo.vatRates[i]}
-								<div class="flex flex-col py-3 gap-4">
-									<button
-										class="text-start text-2xl w-full justify-between"
-										on:click={() => rightPannelItemAction(i)}
-									>
-										{item.quantity} X {item.product.name.toUpperCase()}<br />
-										{item.internalNote?.value ? '+' + item.internalNote.value : ''}
-										<div class="grid grid-cols-4 w-full items-center justify-around text-xl">
-											<div>{t('pos.split.exclVat')}</div>
-											<PriceTag amount={itemPrice.amount} currency={itemPrice.currency} main />
-											<div>{t('pos.split.vatRate', { rate: itemVatRate })}</div>
-											<PriceTag
-												amount={(itemPrice.amount * itemVatRate) / 100}
-												currency={itemPrice.currency}
-												main
-											/>
-										</div>
-									</button><br />
-								</div>
+								{@const qtyInCart = splitTabQuantities[i] || 0}
+								{#if isPoolFullyPaid || qtyInCart > 0}
+									{@const displayData = getItemDisplayData(
+										item,
+										i,
+										splitTabPriceInfo,
+										isPoolFullyPaid ? 0 : qtyInCart
+									)}
+
+									<PosSplitItemRow
+										{item}
+										{...displayData}
+										controls={isPoolFullyPaid ? 'none' : 'return-to-pool'}
+										isComplete={isPoolFullyPaid}
+										onReturnOne={() => returnOneToPool(i)}
+										onReturnAll={() => returnAllToPool(i)}
+									/>
+								{/if}
 							{/each}
 						</div>
-						<div class="flex flex-col border-t border-gray-300 py-6 w-fit">
-							<h2 class="text-3xl underline uppercase">{t('cart.total')}</h2>
-							<div class="grid grid-cols-2 gap-4 grid-rows-2 justify-start">
-								<div class="text-2xl">{t('pos.split.exclVat')}</div>
-								<PriceTag
-									amount={splitTabPriceInfo.partialPrice}
-									currency={splitTabPriceInfo.currency}
-									main
-									class="text-2xl"
-								/>
-								<div class="text-2xl">
-									{t('pos.split.inclVat', {
-										rates: splitTabPriceInfo.vat.map((vat) => `${vat.rate}%`).join(', ')
-									})}
-								</div>
-								<PriceTag
-									amount={splitTabPriceInfo.partialPriceWithVat}
-									currency={splitTabPriceInfo.currency}
-									main
-									class="text-2xl"
+						<PosSplitTotalSection
+							totalExcl={splitTabPriceInfo.partialPrice}
+							totalIncl={splitTabPriceInfo.partialPriceWithVat}
+							currency={splitTabPriceInfo.currency}
+							vatRates={splitTabPriceInfo.vat.map((vat) => vat.rate)}
+						/>
+
+						<!-- Payment method selector (hidden when pool is fully paid) -->
+						{#if !isPoolFullyPaid}
+							<div class="mt-6">
+								<PosPaymentMethodSelector
+									{paymentOptions}
+									bind:selectedIndex={selectedPaymentIndex}
 								/>
 							</div>
-						</div>
+						{/if}
 					</div>
 				{:else if rightPannel === 'split-shares'}
-					@@TODO: Split shares
+					<div class="flex flex-col h-full gap-4 p-4 overflow-y-auto">
+						{#if !data.sharesOrder?.isFullyPaid}
+							<PosPaymentMethodSelector
+								{paymentOptions}
+								bind:selectedIndex={selectedPaymentIndex}
+							/>
+
+							<div class="grid grid-cols-3 gap-3">
+								{#each Array.from({ length: POS_SPLIT_SHARES_MAX_NUMS }, (_, i) => i + 1) as num}
+									<form method="POST" action="?/checkoutTabPartial" use:enhance>
+										<input type="hidden" name="paymentMethod" value={selectedPayment?.method} />
+										{#if selectedPayment?.subtype}
+											<input type="hidden" name="subtype" value={selectedPayment.subtype} />
+										{/if}
+										{#if num === 1}
+											<input type="hidden" name="mode" value="custom-amount" />
+											<input
+												type="hidden"
+												name="customAmount"
+												value={data.sharesOrder?._id
+													? data.sharesOrder.remainingToPay
+													: tabItemsPriceInfo.partialPriceWithVat}
+											/>
+										{:else}
+											<input type="hidden" name="mode" value="equal" />
+											<input type="hidden" name="shares" value={num} />
+										{/if}
+										<button
+											type="submit"
+											class="{num === 1 && fromCashInAll
+												? 'bg-green-800'
+												: 'bg-yellow-800'} text-white font-bold text-4xl p-4 rounded w-full"
+										>
+											{num}
+										</button>
+									</form>
+								{/each}
+							</div>
+
+							<form method="POST" action="?/checkoutTabPartial" use:enhance>
+								<input type="hidden" name="paymentMethod" value={selectedPayment?.method} />
+								{#if selectedPayment?.subtype}
+									<input type="hidden" name="subtype" value={selectedPayment.subtype} />
+								{/if}
+								<input type="hidden" name="mode" value="custom-amount" />
+								<input
+									type="hidden"
+									name="customAmount"
+									value={data.sharesOrder?._id
+										? data.sharesOrder.remainingToPay
+										: originalTabTotalWithVat -
+										  toCurrency(
+												UNDERLYING_CURRENCY,
+												data.sharesOrder?.totalAlreadyPaid ?? 0,
+												poolCurrency
+										  )}
+								/>
+								<button
+									type="submit"
+									class="w-full bg-green-800 text-white font-bold py-4 text-3xl rounded"
+								>
+									{t('pos.split.payRemaining') || 'Pay Remaining'}
+								</button>
+							</form>
+
+							<button
+								class="w-full bg-yellow-800 text-white font-bold py-4 text-3xl rounded"
+								on:click={() => (showCustomShares = !showCustomShares)}
+							>
+								{t('pos.split.enterNumberOfParts')}
+							</button>
+
+							{#if showCustomShares}
+								<div class="flex gap-2">
+									<input
+										type="number"
+										bind:value={sharesInput}
+										min="2"
+										class="flex-1 text-3xl p-2 border rounded"
+									/>
+									<form
+										method="POST"
+										action="?/checkoutTabPartial"
+										use:enhance
+										on:submit={() => (showCustomShares = false)}
+									>
+										<input type="hidden" name="paymentMethod" value={selectedPayment?.method} />
+										{#if selectedPayment?.subtype}
+											<input type="hidden" name="subtype" value={selectedPayment.subtype} />
+										{/if}
+										<input type="hidden" name="mode" value="equal" />
+										<input type="hidden" name="shares" bind:value={sharesInput} />
+										<button type="submit" class="bg-green-800 text-white px-8 text-3xl rounded">
+											{t('pos.split.ok')}
+										</button>
+									</form>
+								</div>
+							{/if}
+
+							<button
+								class="w-full bg-yellow-800 text-white font-bold py-4 text-3xl rounded"
+								on:click={() => (showCustomAmount = !showCustomAmount)}
+							>
+								{t('pos.split.manualAmount')}
+							</button>
+
+							{#if showCustomAmount}
+								<div class="flex gap-2">
+									<input
+										type="number"
+										bind:value={customAmountInput}
+										min="0"
+										max={tabItemsPriceInfo.partialPriceWithVat}
+										step="0.01"
+										class="flex-1 text-3xl p-2 border rounded"
+									/>
+									<form
+										method="POST"
+										action="?/checkoutTabPartial"
+										use:enhance
+										on:submit={() => (showCustomAmount = false)}
+									>
+										<input type="hidden" name="paymentMethod" value={selectedPayment?.method} />
+										{#if selectedPayment?.subtype}
+											<input type="hidden" name="subtype" value={selectedPayment.subtype} />
+										{/if}
+										<input type="hidden" name="mode" value="custom-amount" />
+										<input type="hidden" name="customAmount" bind:value={customAmountInput} />
+										<button type="submit" class="bg-green-800 text-white px-8 text-3xl rounded">
+											{t('pos.split.ok')}
+										</button>
+									</form>
+								</div>
+							{/if}
+						{/if}
+
+						{#if data.sharesOrder}
+							<div class="bg-gray-100 p-6 rounded-lg space-y-3">
+								<div class="text-3xl font-semibold">{t('pos.split.totalAlreadyPaid')}</div>
+								<div class="text-4xl font-bold">
+									<PriceTag
+										amount={isPoolFullyPaid
+											? originalTabTotalWithVat
+											: data.sharesOrder.totalAlreadyPaid}
+										currency={isPoolFullyPaid ? UNDERLYING_CURRENCY : data.sharesOrder.currency}
+										main
+									/>
+								</div>
+
+								<div class="border-t-2 border-gray-300 my-3"></div>
+
+								{#if data.sharesOrder.isFullyPaid}
+									<div class="text-4xl font-bold text-green-600">{t('pos.split.allPaid')} ✅</div>
+								{:else}
+									{@const remaining =
+										data.sharesOrder.remainingToPay ??
+										originalTabTotalWithVat -
+											toCurrency(
+												UNDERLYING_CURRENCY,
+												data.sharesOrder.totalAlreadyPaid,
+												data.sharesOrder.currency
+											)}
+									<div class="text-3xl font-semibold">{t('pos.split.remainingToPay')}</div>
+									<div class="text-4xl font-bold text-red-600">
+										<PriceTag
+											amount={remaining}
+											currency={data.sharesOrder.remainingToPay !== null
+												? data.sharesOrder.currency
+												: UNDERLYING_CURRENCY}
+											main
+										/>
+									</div>
+								{/if}
+							</div>
+						{/if}
+
+						{#if data.sharesOrder?.payments && data.sharesOrder.payments.length > 0}
+							{@const itemsPayments = data.sharesOrder.payments.filter(
+								(p) => p.splitMode === 'items'
+							)}
+							{@const sharesPayments = data.sharesOrder.payments.filter(
+								(p) => p.splitMode === 'shares'
+							)}
+
+							<PosPaymentsList
+								payments={itemsPayments}
+								title="Split by items"
+								bgClass="bg-white border-2 border-blue-300"
+								returnTo={`/pos/touch/tab/${tabSlug}/split?mode=shares`}
+							/>
+
+							<PosPaymentsList
+								payments={sharesPayments}
+								title="Split by shares"
+								bgClass="bg-gray-100"
+								returnTo={`/pos/touch/tab/${tabSlug}/split?mode=shares`}
+							/>
+						{/if}
+					</div>
 				{/if}
 			</div>
 		</div>
 	</main>
 	<footer class="shrink-0">
 		<div class="grid grid-cols-2 gap-4 mt-2">
-			{#if rightPannel === 'menu'}
+			{#if isPoolFullyPaid}
+				<button
+					class="bg-blue-800 hover:bg-blue-900 uppercase text-3xl text-white p-4 text-center"
+					on:click={handlePrintGlobalTicket}
+				>
+					{t('pos.split.globalTicket')}
+				</button>
+				<form method="POST" action="?/closePool" use:enhance>
+					<button
+						type="submit"
+						class="bg-green-800 hover:bg-green-900 uppercase text-3xl text-white p-4 text-center w-full"
+					>
+						{t('pos.split.closePool')}
+					</button>
+				</form>
+			{:else if rightPannel === 'menu'}
 				<a
 					class="touchScreen-action-cancel uppercase text-3xl text-white p-4 text-center"
 					href="/pos/touch/tab/{tabSlug}"
@@ -236,19 +609,59 @@
 			{:else}
 				<button
 					class="touchScreen-action-cancel uppercase text-3xl text-white p-4 text-center"
-					on:click={rightPannelMenu}
+					on:click={() => (rightPannel = 'menu')}
 				>
 					{t('pos.split.return')}
 				</button>
 			{/if}
-			{#if rightPannel === 'split-items' && splitTabPriceInfo.partialPriceWithVat > 0}
-				<button
-					class="touchScreen-action-cta uppercase text-3xl text-white p-4 text-center"
-					on:click={checkoutSplitPayment}
+			{#if rightPannel === 'split-items' && !isPoolFullyPaid}
+				<form
+					method="POST"
+					action="?/checkoutTabPartial"
+					use:enhance
+					on:submit={validateItemsCheckout}
 				>
-					{t('pos.split.paySelected')}
-				</button>
+					<input type="hidden" name="itemQuantities" value={itemQuantitiesJson} />
+					<input type="hidden" name="paymentMethod" value={selectedPayment?.method} />
+					{#if selectedPayment?.subtype}
+						<input type="hidden" name="subtype" value={selectedPayment.subtype} />
+					{/if}
+					<button
+						type="submit"
+						class="uppercase text-3xl p-4 text-center w-full {splitTabPriceInfo.partialPriceWithVat >
+						0
+							? 'touchScreen-action-cta'
+							: 'bg-gray-400 text-white cursor-not-allowed'}"
+						disabled={splitTabPriceInfo.partialPriceWithVat === 0}
+					>
+						{t('pos.split.paySelected')}
+					</button>
+				</form>
 			{/if}
 		</div>
 	</footer>
 </div>
+
+{#if printing && poolTotals}
+	<PrintableTicket
+		{poolLabel}
+		generatedAt={new Date()}
+		tagGroups={[
+			{
+				tagNames: [],
+				items: tab.items.map((item) => ({
+					product: { name: item.product.name },
+					quantity: item.originalQuantity ?? item.quantity,
+					variations: [],
+					notes: []
+				}))
+			}
+		]}
+		priceInfo={{
+			itemPrices: originalQuantitiesPriceInfo.perItem,
+			total: poolTotals.incl,
+			vatRate: poolVatRates[0] ?? 0,
+			currency: poolCurrency
+		}}
+	/>
+{/if}

--- a/src/routes/style/variables.css/+server.ts
+++ b/src/routes/style/variables.css/+server.ts
@@ -31,7 +31,13 @@ export const GET = async ({}) => {
 
 function generateVariables(themeData: ThemeData) {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const { name, ...validated } = themeValidator.parse(themeData);
+	const parseResult = themeValidator.safeParse(themeData);
+	if (!parseResult.success) {
+		console.error('[CSS VARIABLES] Theme validation failed:', parseResult.error.errors);
+		return { nonColors: {}, darkModeColors: {}, lightModeColors: {} };
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { name, ...validated } = parseResult.data;
 	const flattened = flatten(validated) as Record<string, string>;
 
 	const nonColors: Record<string, string> = {};


### PR DESCRIPTION
Restaurant POS now supports splitting shared table bills (pools) into partial payments using two flexible modes:

- **"Split by items"**: Select specific products from pool (e.g., "3 burgers, 2 beers") → creates separate order with individual receipt
- **"Split by shares"**: Divide total into N equal parts or custom amounts (e.g., "table of 7, each pays 1/7th") → all payments accumulate on one order
- Choose payment method directly in PoS split interface. Visual selector with icons for cards, cash, etc. Works in both split modes
- Real-time visual feedback as items move between pool and cart
- Payment history tracking shows what's paid and what remains
- Flexible workflow: can start with Split by items and split remaining part with shares

Fixes issue #1968