### PR TITLE
🦋 Add VAT calculator to bulk price change screen

### DIFF
--- a/src/lib/components/ProductVATCalcRow.svelte
+++ b/src/lib/components/ProductVATCalcRow.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import {
+		CURRENCIES,
+		SATOSHIS_PER_BTC,
+		computePriceForStorage,
+		FRACTION_DIGITS_PER_CURRENCY
+	} from '$lib/types/Currency';
+	import type { Price } from '$lib/types/Order';
+
+	export let productId: string;
+	export let productName: string;
+	export let initialPrice: Price;
+	export let displayVATCalculator: boolean;
+
+	let priceAmountVATIncluded = initialPrice.amount;
+	let vatRate = 0;
+	let currency = initialPrice.currency;
+
+	$: priceExcludedVAT = computePriceForStorage(
+		(100 * priceAmountVATIncluded) / (100 + vatRate),
+		currency
+	);
+
+	function formatPriceForInput(price: Price): string {
+		const precision = price.precision ?? FRACTION_DIGITS_PER_CURRENCY[price.currency];
+		return price.amount
+			.toLocaleString('en', {
+				maximumFractionDigits: precision,
+				minimumFractionDigits: 0
+			})
+			.replace(/,/g, '');
+	}
+
+	function handleInputChange(event: Event) {
+		const target = event.target as HTMLInputElement;
+		const newPrice = target.value;
+
+		if (newPrice && parseFloat(newPrice) < 1 / SATOSHIS_PER_BTC) {
+			target.setCustomValidity('Price ' + productId + ' must be greater than 1 SAT');
+			target.reportValidity();
+			return;
+		} else {
+			target.setCustomValidity('');
+		}
+	}
+</script>
+
+<h2 class="text-2xl">{productName}</h2>
+{#if displayVATCalculator}
+	<div class="gap-4 mx-4 flex flex-col md:flex-row">
+		<label class="w-full">
+			Price amount (VAT included)
+			<input
+				class="form-input"
+				type="number"
+				bind:value={priceAmountVATIncluded}
+				step="any"
+				required
+			/>
+		</label>
+
+		<label class="w-full">
+			VAT (for VAT excluded price calculation)
+			<input class="form-input" type="number" bind:value={vatRate} step="any" />
+		</label>
+
+		<label class="w-full">
+			Price amount (VAT excluded)
+			<input
+				class="form-input"
+				type="number"
+				name="{productId}.price"
+				step="any"
+				value={formatPriceForInput(priceExcludedVAT)}
+				readonly
+				required
+			/>
+		</label>
+
+		<label class="w-full">
+			Price currency
+			<select name="{productId}.currency" class="form-input" bind:value={currency}>
+				{#each CURRENCIES as curr}
+					<option value={curr} selected={currency === curr}>
+						{curr}
+					</option>
+				{/each}
+			</select>
+		</label>
+	</div>
+{:else}
+	<div class="gap-4 mx-4 flex flex-col md:flex-row">
+		<label class="w-full">
+			Price amount
+			<input
+				class="form-input"
+				type="number"
+				name="{productId}.price"
+				placeholder="Price"
+				step="any"
+				value={initialPrice.amount
+					.toLocaleString('en', { maximumFractionDigits: 8 })
+					.replace(/,/g, '')}
+				on:input={handleInputChange}
+				required
+			/>
+		</label>
+
+		<label class="w-full">
+			Price currency
+			<select name="{productId}.currency" class="form-input" bind:value={currency}>
+				{#each CURRENCIES as curr}
+					<option value={curr} selected={currency === curr}>
+						{curr}
+					</option>
+				{/each}
+			</select>
+		</label>
+	</div>
+{/if}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/prices/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/prices/+page.svelte
@@ -1,57 +1,31 @@
 <script lang="ts">
-	import { CURRENCIES, SATOSHIS_PER_BTC } from '$lib/types/Currency';
+	import ProductVATCalcRow from '$lib/components/ProductVATCalcRow.svelte';
 
 	export let data;
 
-	function handleInputChange(event: Event) {
-		const target = event.target as HTMLInputElement;
-		const productId = target.name;
-		const newPrice = target.value;
-
-		if (newPrice && parseFloat(newPrice) < 1 / SATOSHIS_PER_BTC) {
-			target.setCustomValidity('Price ' + productId + ' must be greater than 1 SAT');
-			target.reportValidity();
-			return;
-		} else {
-			target.setCustomValidity('');
-		}
-	}
+	let displayVATCalculator = false;
 </script>
 
 <h1 class="text-3xl">Bulk Price Change</h1>
 
+<label class="checkbox-label">
+	<input
+		class="form-checkbox"
+		type="checkbox"
+		name="vatCalculator"
+		bind:checked={displayVATCalculator}
+	/>
+	Display VAT calculator
+</label>
+
 <form class="flex flex-col gap-2" method="post">
 	{#each data.products as product}
-		<h2 class="text-2xl">{product.name}</h2>
-		<div class="gap-4 mx-4 flex flex-col md:flex-row">
-			<label class="w-full">
-				Price amount
-				<input
-					class="form-input"
-					type="number"
-					name="{product._id}.price"
-					placeholder="Price"
-					step="any"
-					value={product.price.amount
-						.toLocaleString('en', { maximumFractionDigits: 8 })
-						.replace(/,/g, '')}
-					on:input={handleInputChange}
-					required
-				/>
-			</label>
-
-			<label class="w-full">
-				Price currency
-
-				<select name="{product._id}.currency" class="form-input">
-					{#each CURRENCIES as currency}
-						<option value={currency} selected={product.price.currency === currency}>
-							{currency}
-						</option>
-					{/each}
-				</select>
-			</label>
-		</div>
+		<ProductVATCalcRow
+			productId={product._id}
+			productName={product.name}
+			initialPrice={product.price}
+			{displayVATCalculator}
+		/>
 	{/each}
 	<button class="btn btn-black self-start mt-4" type="submit">Update</button>
 </form>


### PR DESCRIPTION
Admins can now use an optional VAT calculator when bulk-editing product prices.
Enable the "Display VAT calculator" checkbox to input VAT-included prices and VAT rates, and the system automatically calculates the correct VAT-excluded price to store in the database.

This helps admins set prices that result in round numbers after VAT application (e.g., input 5.00 CHF with 8.1% VAT → stores 4.6253 CHF → displays as 5.00 CHF with VAT to customers).

Closes #2191