### PR TITLE
🦋 Make POS payment detail optionally required per subtype

### DIFF
--- a/src/lib/types/PosPaymentSubtype.ts
+++ b/src/lib/types/PosPaymentSubtype.ts
@@ -12,5 +12,6 @@ export interface PosPaymentSubtype extends Timestamps {
 		onActivationUrl?: string;
 	};
 	disabled?: boolean;
+	paymentDetailRequired?: boolean;
 	sortOrder: number;
 }

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos-payments/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos-payments/+page.svelte
@@ -98,7 +98,6 @@
 							<button
 								type="button"
 								class="btn btn-sm"
-								disabled={subtype.slug === 'cash'}
 								on:click={() => {
 									editingSubtype = subtype;
 									showCreateForm = false;
@@ -184,6 +183,7 @@
 					bind:value={nameInput}
 					placeholder="e.g. Cash, Check, External POS Terminal"
 					required
+					disabled={editingSubtype?.slug === 'cash'}
 				/>
 			</label>
 
@@ -220,7 +220,7 @@
 					class="form-input"
 					rows="2"
 					placeholder="Optional description for admin reference"
-					>{editingSubtype?.description || ''}</textarea
+					disabled={editingSubtype?.slug === 'cash'}>{editingSubtype?.description || ''}</textarea
 				>
 			</label>
 
@@ -243,6 +243,7 @@
 							urlInput = '';
 						}
 					}}
+					disabled={editingSubtype?.slug === 'cash'}
 				>
 					<option value="">Not used</option>
 					{#each data.availableProcessors as proc}
@@ -266,12 +267,26 @@
 					class="form-input"
 					bind:value={urlInput}
 					placeholder="e.g. https://open.paynow-app.com"
-					disabled={tapToPayUrlDisabled}
+					disabled={tapToPayUrlDisabled || editingSubtype?.slug === 'cash'}
 				/>
 				<p class="text-xs text-gray-500 mt-1">
 					Deep link to open the payment terminal app (e.g. Paynow for Stripe)
 				</p>
 			</label>
+
+			<!-- Payment Detail Required checkbox (only for edit) -->
+			{#if editingSubtype}
+				<label class="checkbox-label flex items-center gap-2">
+					<input
+						type="checkbox"
+						name="paymentDetailRequired"
+						class="form-checkbox"
+						value="true"
+						checked={editingSubtype.paymentDetailRequired}
+					/>
+					<span>Make payment detail mandatory</span>
+				</label>
+			{/if}
 
 			<!-- Disabled checkbox (only for edit) -->
 			{#if editingSubtype && editingSubtype.slug !== 'cash'}

--- a/src/routes/(app)/order/[id]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/+page.server.ts
@@ -89,7 +89,8 @@ export async function load({ params, depends, locals }) {
 	).map((subtype) => ({
 		slug: subtype.slug,
 		name: subtype.name,
-		description: subtype.description
+		description: subtype.description,
+		paymentDetailRequired: subtype.paymentDetailRequired
 	}));
 
 	return {

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -466,6 +466,11 @@
 										<Spinner class="w-36" />
 									</form>
 								{:else}
+									{@const posSubtype =
+										payment.method === 'point-of-sale' && payment.posSubtype
+											? data.posSubtypes?.find((s) => s.slug === payment.posSubtype)
+											: null}
+									{@const detailRequired = posSubtype?.paymentDetailRequired ?? false}
 									<form
 										action="{orderStaffActionBaseUrl}/payment/{payment.id}?/cancel"
 										method="post"
@@ -495,7 +500,7 @@
 												class="form-input grow mx-2"
 												type="text"
 												name="detail"
-												required
+												required={detailRequired}
 												placeholder="Detail (card transaction ID, or point-of-sale payment method)"
 											/>
 										{/if}


### PR DESCRIPTION
Admins can now control whether the payment detail field is mandatory for each POS payment subtype. A new checkbox "Make payment detail mandatory" in /admin/pos-payments allows toggling this per subtype. By default, the field is optional for better UX.

This lets merchants require transaction details only where needed (e.g. card terminals) while keeping it optional for cash payments.

Closes #2197