### PR TITLE
🦋 Add pool status icons to POS interface

### DIFF
--- a/src/lib/server/orderTab.ts
+++ b/src/lib/server/orderTab.ts
@@ -72,11 +72,11 @@ export async function getOrCreateOrderTab({ slug }: { slug: string }): Promise<O
 }
 
 export async function orderTabNotEmptyAndFullyPaid({ slug }: { slug: string }): Promise<boolean> {
-	const returned = await getOrCreateOrderTab({ slug });
-	const items = returned.items;
-	if (items.length === 0) {
+	const returned = await collections.orderTabs.findOne({ slug });
+	if (!returned || returned.items.length === 0) {
 		return false;
 	}
+	const items = returned.items;
 	if (!items.map((item) => item.orderId).every(Boolean)) {
 		// At least one of the items is not associated to an order.
 		return false;

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -242,6 +242,8 @@ const baseConfig = {
 	contactModesForceOption: false,
 	posTouchTag: [] as Tag['_id'][],
 	posTabGroups: defaultPosTabGroups(),
+	posPoolEmptyIcon: '✅' as string | undefined,
+	posPoolOccupiedIcon: '⏳' as string | undefined,
 	posUseSelectForTags: false,
 	posPrefillTermOfUse: false,
 	posTapToPay: {

--- a/src/lib/types/OrderTab.ts
+++ b/src/lib/types/OrderTab.ts
@@ -21,3 +21,8 @@ export interface OrderTab extends Timestamps {
 	items: Array<OrderTabItem>;
 	printHistory?: PrintHistoryEntry[];
 }
+
+export interface OrderTabPoolStatus {
+	slug: string;
+	itemsCount: number;
+}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
@@ -1,7 +1,7 @@
 import { adminPrefix } from '$lib/server/admin';
 import { collections } from '$lib/server/database';
 import { ALL_PAYMENT_PROCESSORS } from '$lib/server/payment-methods.js';
-import { runtimeConfig } from '$lib/server/runtime-config';
+import { runtimeConfig, defaultConfig } from '$lib/server/runtime-config';
 import type { Tag } from '$lib/types/Tag';
 import { set } from '$lib/utils/set';
 import { error, redirect } from '@sveltejs/kit';
@@ -36,6 +36,10 @@ export const load = async ({}) => {
 		tags: tags.filter((tag) => tag._id !== 'pos-favorite'),
 		posTouchTag: runtimeConfig.posTouchTag,
 		posTabGroups: runtimeConfig.posTabGroups,
+		posPoolEmptyIcon: runtimeConfig.posPoolEmptyIcon,
+		posPoolOccupiedIcon: runtimeConfig.posPoolOccupiedIcon,
+		defaultEmptyPoolIcon: defaultConfig.posPoolEmptyIcon,
+		defaultFullPoolIcon: defaultConfig.posPoolOccupiedIcon,
 		posUseSelectForTags: runtimeConfig.posUseSelectForTags,
 		posPrefillTermOfUse: runtimeConfig.posPrefillTermOfUse,
 		posDisplayOrderQrAfterPayment: runtimeConfig.posDisplayOrderQrAfterPayment,
@@ -86,6 +90,8 @@ export const actions: Actions = {
 					})
 					.array(),
 				posTouchTag: z.string().array(),
+				posPoolEmptyIcon: z.string().optional(),
+				posPoolOccupiedIcon: z.string().optional(),
 				tapToPayOnActivationUrl: z.string().trim().optional(),
 				tapToPayProvider: z.string().optional(),
 				posSession: z
@@ -135,6 +141,13 @@ export const actions: Actions = {
 		runtimeConfig.posTouchTag = result.posTouchTag;
 		await persistConfigElement('posTabGroups', result.posTabGroups);
 		runtimeConfig.posTabGroups = result.posTabGroups;
+		const posPoolEmptyIcon = result.posPoolEmptyIcon === '' ? undefined : result.posPoolEmptyIcon;
+		const posPoolOccupiedIcon =
+			result.posPoolOccupiedIcon === '' ? undefined : result.posPoolOccupiedIcon;
+		await persistConfigElement('posPoolEmptyIcon', posPoolEmptyIcon);
+		runtimeConfig.posPoolEmptyIcon = posPoolEmptyIcon;
+		await persistConfigElement('posPoolOccupiedIcon', posPoolOccupiedIcon);
+		runtimeConfig.posPoolOccupiedIcon = posPoolOccupiedIcon;
 		await persistConfigElement('posUseSelectForTags', result.posUseSelectForTags);
 		runtimeConfig.posUseSelectForTags = result.posUseSelectForTags;
 		await persistConfigElement('posQrCodeAfterPayment', posQrCodeAfterPayment);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
@@ -12,6 +12,8 @@
 			label: data.tags.find((tag) => tag._id === tagId)?.name ?? tagId
 		})) ?? [];
 	let tabGroups = data.posTabGroups;
+	let posPoolEmptyIcon = data.posPoolEmptyIcon || '';
+	let posPoolOccupiedIcon = data.posPoolOccupiedIcon || '';
 
 	$: serializedTags = JSON.stringify(selectedTags.map((tag) => tag.value));
 	$: serializedTabGroups = JSON.stringify(tabGroups);
@@ -178,6 +180,27 @@
 			checked={data.posUseSelectForTags}
 		/>
 		{t('pos.useSelectForTags')}
+	</label>
+
+	<label class="form-label">
+		Pool name label for non-empty pools
+		<small class="text-gray-600"
+			>If empty, default icon will be shown: {data.defaultFullPoolIcon}</small
+		>
+		<input
+			type="text"
+			name="posPoolOccupiedIcon"
+			class="form-input"
+			bind:value={posPoolOccupiedIcon}
+		/>
+	</label>
+
+	<label class="form-label">
+		Pool name label for empty pools
+		<small class="text-gray-600"
+			>If empty, default icon will be shown: {data.defaultEmptyPoolIcon}</small
+		>
+		<input type="text" name="posPoolEmptyIcon" class="form-input" bind:value={posPoolEmptyIcon} />
 	</label>
 
 	<!-- svelte-ignore a11y-label-has-associated-control -->

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -358,7 +358,11 @@
 					{#if tabGroup.tabs.length > 0}
 						<div class="grid grid-cols-3 gap-2">
 							{#each tabGroup.tabs as tab, tabIndex}
-								{@const isActive = tabSlug === sluggifyTab(data.posTabGroups, groupIndex, tabIndex)}
+								{@const tabSlugComputed = sluggifyTab(data.posTabGroups, groupIndex, tabIndex)}
+								{@const isActive = tabSlug === tabSlugComputed}
+								{@const orderTab = data.allOrderTabs.find((t) => t.slug === tabSlugComputed)}
+								{@const isEmpty = !orderTab || (orderTab.itemsCount ?? 0) === 0}
+								{@const icon = isEmpty ? data.posPoolEmptyIcon : data.posPoolOccupiedIcon}
 								<button
 									class="touchScreen-product-cta text-3xl min-h-[5rem] w-60 rounded-md py-2"
 									class:ring-4={isActive}
@@ -368,7 +372,7 @@
 									style="background-color: {tab.color}"
 									on:click={() => selectTab(groupIndex, tabIndex)}
 								>
-									{tab.label ?? `${tabGroup.name} ${tabIndex + 1}`}
+									{tab.label ?? `${tabGroup.name} ${tabIndex + 1}`} <span class="ml-2">{icon}</span>
 								</button>
 							{/each}
 						</div>


### PR DESCRIPTION
POS operators can now see at a glance which pools (table groups) are empty vs occupied. Icons appear after the pool name in the selection modal - by default, ✅ for empty and  ⏳ for occupied pools.

- New settings under /admin/pos → "Touchscreen PoS interface"
- Customizable icons via text inputs (emoji, unicode, or plain text)

Empty pools (no items) display one icon, occupied pools display another - helping staff quickly identify available seating.
 
Closes #2190