### PR TITLE
🦋 Multi-day bookings for daily rentals

### DIFF
--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -24,7 +24,7 @@ export type ProductForPriceInfo = {
 };
 
 export type ItemForPriceInfo = {
-	booking?: { start: Date; end: Date };
+	booking?: { start: Date; end: Date; bookedDates?: Date[] };
 	customPrice?: Price;
 	depositPercentage?: number;
 	discountPercentage?: number;
@@ -54,8 +54,9 @@ export function priceToBillForItem(
 			throw new Error('Item is a booking slot, but product is missing booking spec.');
 		}
 		unitsToAccount =
+			item.booking.bookedDates?.length ??
 			differenceInMinutes(item.booking.end, item.booking.start) /
-			item.product.bookingSpec.slotMinutes;
+				item.product.bookingSpec.slotMinutes;
 	} else {
 		unitsToAccount = item.quantity;
 	}

--- a/src/lib/components/OrderSummary.svelte
+++ b/src/lib/components/OrderSummary.svelte
@@ -15,6 +15,7 @@
 	import ProductType from './ProductType.svelte';
 	import IconInfo from './icons/IconInfo.svelte';
 	import type { PickDeep } from 'type-fest';
+	import { formatBookedDates } from '$lib/utils/formatBookedDates';
 
 	const { t, countryName, locale } = useI18n();
 
@@ -49,6 +50,7 @@
 				booking?: {
 					start: Date;
 					end: Date;
+					bookedDates?: Date[];
 				};
 			}
 		>;
@@ -129,13 +131,17 @@
 						{t('cart.quantity')}: {item.quantity}
 					{/if}
 					{#if item.booking}
-						{Intl.DateTimeFormat($locale, {
-							year: 'numeric',
-							month: 'short',
-							day: 'numeric',
-							hour: '2-digit',
-							minute: '2-digit'
-						}).formatRange(item.booking.start, item.booking.end)}
+						{#if item.booking.bookedDates?.length}
+							{formatBookedDates(item.booking.bookedDates)}
+						{:else}
+							{Intl.DateTimeFormat($locale, {
+								year: 'numeric',
+								month: 'short',
+								day: 'numeric',
+								hour: '2-digit',
+								minute: '2-digit'
+							}).formatRange(item.booking.start, item.booking.end)}
+						{/if}
 					{/if}
 				</div>
 			</div>

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -1182,6 +1182,17 @@
 								</select>
 							</label>
 
+							<label class="form-label">
+								Max bookable days (0 = unlimited)
+								<input
+									type="number"
+									name="bookingSpec.maxBookableDays"
+									class="form-input"
+									min="0"
+									value={product.bookingSpec?.maxBookableDays ?? 0}
+								/>
+							</label>
+
 							<div>
 								<p class="text-sm font-medium text-gray-700 mb-2">Weekly schedule:</p>
 								<div class="grid gap-2" style="grid-template-columns: min-content 1fr 1fr;">

--- a/src/lib/components/ScheduleWidget/ScheduleWidgetCalendar.svelte
+++ b/src/lib/components/ScheduleWidget/ScheduleWidgetCalendar.svelte
@@ -10,7 +10,10 @@
 		subMonths,
 		addMonths,
 		isSameDay,
-		addMinutes
+		addMinutes,
+		startOfDay,
+		differenceInDays,
+		isWithinInterval
 	} from 'date-fns';
 	import type { ScheduleEvent, Schedule } from '$lib/types/Schedule';
 	import { useI18n } from '$lib/i18n';
@@ -26,6 +29,9 @@
 	let className = '';
 	export let isDayDisabled: (date: Date) => boolean = () => false;
 	export let selectedDate = new Date();
+	export let rangeMode = false;
+	export let selectedEndDate: Date | null = null;
+	export let maxRangeDays = 0;
 	export { className as class };
 
 	const { t, locale } = useI18n();
@@ -94,8 +100,34 @@
 	}
 
 	function selectDate(date: Date) {
-		selectedDate = new Date(date);
+		if (isDayDisabled(date)) {
+			return;
+		}
+
+		const newDate = new Date(date);
+
+		if (!rangeMode || !selectedDate || selectedEndDate || isSameDay(date, selectedDate)) {
+			selectedDate = newDate;
+			selectedEndDate = null;
+			return;
+		}
+
+		if (maxRangeDays > 0 && Math.abs(differenceInDays(date, selectedDate)) + 1 > maxRangeDays) {
+			return;
+		}
+
+		[selectedDate, selectedEndDate] =
+			date < selectedDate ? [newDate, new Date(selectedDate)] : [selectedDate, newDate];
 	}
+
+	const isInRange = (day: Date) =>
+		rangeMode &&
+		selectedDate &&
+		selectedEndDate &&
+		isWithinInterval(startOfDay(day), {
+			start: startOfDay(selectedDate),
+			end: startOfDay(selectedEndDate)
+		});
 
 	onMount(() => {
 		generateCalendar();
@@ -113,7 +145,9 @@
 		</a>
 	</div>
 {/if}
-<div class="max-w-md mx-auto p-4 eventCalendar eventCalendar-main shadow-md rounded-lg {className}">
+<div
+	class="max-w-md mx-auto p-4 eventCalendar eventCalendar-main shadow-md rounded-lg min-w-[340px] min-h-[400px] {className}"
+>
 	<div class="flex items-center justify-between mb-4">
 		<button on:click={prevMonth} type="button" class="py-2 eventCalendar-navCTA btn rounded-full"
 			>&lt;</button
@@ -137,17 +171,27 @@
 
 	<div class="grid grid-cols-7 text-center mt-1">
 		{#each days as day}
+			{@const disabled = isDayDisabled(day)}
+			{@const inRange = isInRange(day)}
+			{@const isToday = isSameDay(day, new Date())}
+			{@const isStart = selectedDate && isSameDay(day, selectedDate)}
+			{@const isEnd = rangeMode && selectedEndDate && isSameDay(day, selectedEndDate)}
+			{@const isOtherMonth = day.getMonth() !== currentDate.getMonth()}
+			{@const customColorEvents = hasCustomColorEvents(day)}
 			<button
 				type="button"
 				on:click={() => selectDate(day)}
+				{disabled}
 				class="p-2 m-1 rounded-full
-					{isSameDay(day, new Date()) ? 'eventCalendar-currentDate font-bold' : ''}
+					{isToday ? 'eventCalendar-currentDate font-bold' : ''}
 					{isEventDay(day) ? 'eventCalendar-hasEvent font-bold' : ''}
-					{selectedDate && isSameDay(day, selectedDate) ? ' ring-2 ring-black' : ''}
-					{format(day, 'M') !== format(currentDate, 'M') || isDayDisabled(day) ? ' text-gray-400' : ''}"
-				style="background-color:{!!hasCustomColorEvents(day) &&
-				hasCustomColorEvents(day).length === 1
-					? hasCustomColorEvents(day)[0].calendarColor
+					{isStart || isEnd ? 'ring-2 ring-black' : ''}
+					{inRange ? (disabled ? 'bg-gray-100' : 'bg-blue-100') : ''}
+					{disabled || isOtherMonth ? 'text-gray-300' : ''}
+					{inRange && disabled ? 'text-gray-400' : ''}
+					{disabled ? 'cursor-not-allowed' : 'hover:bg-gray-100 cursor-pointer'}"
+				style="background-color:{customColorEvents.length === 1
+					? customColorEvents[0].calendarColor
 					: ''}"
 			>
 				{format(day, 'd')}

--- a/src/lib/server/cart.ts
+++ b/src/lib/server/cart.ts
@@ -13,7 +13,7 @@ import type { Cart } from '$lib/types/Cart';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import { userQuery } from './user';
 import { removeEmpty } from '$lib/utils/removeEmpty';
-import { addMinutes } from 'date-fns';
+import { addDays, addMinutes } from 'date-fns';
 import type { Currency } from '$lib/types/Currency';
 import { toCurrency } from '$lib/utils/toCurrency';
 import { sum } from '$lib/utils/sum';
@@ -104,6 +104,7 @@ export async function addToCartInDb(
 		booking?: {
 			time: Date;
 			durationMinutes: number;
+			bookedDates?: Date[];
 		};
 		lineId?: string;
 		cart?: Cart;
@@ -233,7 +234,10 @@ export async function addToCartInDb(
 				product.bookingSpec && {
 					booking: {
 						start: params.booking.time,
-						end: addMinutes(params.booking.time, params.booking.durationMinutes)
+						end: params.booking.bookedDates?.length
+							? addDays(params.booking.bookedDates[params.booking.bookedDates.length - 1], 1)
+							: addMinutes(params.booking.time, params.booking.durationMinutes),
+						...(params.booking.bookedDates?.length && { bookedDates: params.booking.bookedDates })
 					}
 				})
 		});

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -11,11 +11,12 @@ import { collections, withTransaction } from './database';
 import {
 	Duration,
 	add,
+	addDays,
 	addHours,
 	addMinutes,
 	differenceInMinutes,
 	differenceInSeconds,
-	endOfDay,
+	eachDayOfInterval,
 	isSameDay,
 	max,
 	startOfDay,
@@ -667,7 +668,9 @@ export async function createOrder(
 			if (item.booking.end <= item.booking.start) {
 				throw error(400, `Product ${item.product.name} booking end time is before start time`);
 			}
-			const durationMinutes = differenceInMinutes(item.booking.end, item.booking.start);
+			const durationMinutes = item.booking.bookedDates?.length
+				? item.booking.bookedDates.length * item.product.bookingSpec.slotMinutes
+				: differenceInMinutes(item.booking.end, item.booking.start);
 
 			if (durationMinutes < item.product.bookingSpec.slotMinutes) {
 				throw error(
@@ -1019,7 +1022,8 @@ export async function createOrder(
 							_id: item.booking._id,
 							productId: item.product._id,
 							start: item.booking.start,
-							end: item.booking.end as Date | null
+							end: item.booking.end as Date | null,
+							bookedDates: item.booking.bookedDates
 					  }
 					: undefined
 			)
@@ -1070,44 +1074,62 @@ export async function createOrder(
 				}
 				const startDay = startOfDay(startTime);
 				const endTime = toZonedTime(time.end, bookingSpec.schedule.timezone);
-				const endDay = endOfDay(subSeconds(endTime, 1)); // Sub-seconds to allow booking until midnight
+				const endDay = startOfDay(subSeconds(endTime, 1)); // Use startOfDay for comparison, sub-seconds to handle midnight
 
-				if (!isSameDay(startDay, endDay)) {
-					throw error(
-						400,
-						`Product ${productById[productId].name} booking time range must be on the same day`
+				const getDayOfWeek = (date: Date) => dayList[(date.getDay() + 6) % 7];
+
+				if (is24HourSlot) {
+					const daysToValidate = time.bookedDates?.length
+						? time.bookedDates.map((d) => startOfDay(toZonedTime(d, bookingSpec.schedule.timezone)))
+						: eachDayOfInterval({ start: startDay, end: endDay });
+					const unavailable = daysToValidate.find(
+						(day) => !bookingSpec.schedule[getDayOfWeek(day)]
 					);
-				}
+					if (unavailable) {
+						throw error(
+							400,
+							`Product ${productById[productId].name} is not available on ${getDayOfWeek(
+								unavailable
+							)}`
+						);
+					}
+				} else {
+					if (!isSameDay(startDay, endDay)) {
+						throw error(
+							400,
+							`Product ${productById[productId].name} booking time range must be on the same day`
+						);
+					}
 
-				const dayOfWeek = dayList[(startDay.getDay() + 6) % 7];
+					const dayOfWeek = getDayOfWeek(startDay);
+					const daySpec = bookingSpec.schedule[dayOfWeek];
 
-				const daySpec = bookingSpec.schedule[dayOfWeek];
+					if (!daySpec) {
+						throw error(
+							400,
+							`Product ${productById[productId].name} booking time range is not available on ${dayOfWeek}`
+						);
+					}
 
-				if (!daySpec) {
-					throw error(
-						400,
-						`Product ${productById[productId].name} booking time range is not available on ${dayOfWeek}`
-					);
-				}
+					const minutesStart = startTime.getMinutes() + startTime.getHours() * 60;
+					const minutesEnd = endTime.getMinutes() + endTime.getHours() * 60;
 
-				const minutesStart = startTime.getMinutes() + startTime.getHours() * 60;
-				const minutesEnd = endTime.getMinutes() + endTime.getHours() * 60;
-
-				if (minutesStart < timeToMinutes(daySpec.start)) {
-					throw error(
-						400,
-						`Product ${productById[productId].name} booking time range starts (${minutesToTime(
-							minutesStart
-						)}) before the scheduled opening time (${daySpec.start})`
-					);
-				}
-				if (minutesEnd > (daySpec.end === '00:00' ? timeToMinutes(daySpec.end) : 24 * 60)) {
-					throw error(
-						400,
-						`Product ${productById[productId].name} booking time range ends (${minutesToTime(
-							minutesEnd
-						)}) after the schedule closing time (${daySpec.end})`
-					);
+					if (minutesStart < timeToMinutes(daySpec.start)) {
+						throw error(
+							400,
+							`Product ${productById[productId].name} booking time range starts (${minutesToTime(
+								minutesStart
+							)}) before the scheduled opening time (${daySpec.start})`
+						);
+					}
+					if (minutesEnd > (daySpec.end === '00:00' ? timeToMinutes(daySpec.end) : 24 * 60)) {
+						throw error(
+							400,
+							`Product ${productById[productId].name} booking time range ends (${minutesToTime(
+								minutesEnd
+							)}) after the schedule closing time (${daySpec.end})`
+						);
+					}
 				}
 			}
 		}
@@ -1185,20 +1207,47 @@ export async function createOrder(
 			}
 		}
 
+		const createScheduleEvent = (
+			productId: string,
+			eventId: ObjectId,
+			beginsAt: Date,
+			endsAt: Date,
+			slugSuffix = ''
+		) => ({
+			_id: eventId,
+			title: '#' + orderNumber + ' - ' + productById[productId].name,
+			slug: productId + '-' + orderNumber + slugSuffix,
+			beginsAt,
+			endsAt,
+			scheduleId: productToScheduleId(productId),
+			orderId: orderId,
+			status: 'pending' as const,
+			orderCreated: false
+		});
+
 		await collections.scheduleEvents.insertMany(
 			Object.entries(bookingTimesPerProduct).flatMap(([productId, bookings]) =>
-				bookings.map((booking) => ({
-					_id: booking._id,
-					title: '#' + orderNumber + ' - ' + productById[productId].name,
-					slug: productId + '-' + orderNumber,
-					beginsAt: booking.start,
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					endsAt: booking.end!,
-					scheduleId: productToScheduleId(productId),
-					orderId: orderId,
-					status: 'pending',
-					orderCreated: false
-				}))
+				bookings.flatMap((booking) =>
+					booking.bookedDates?.length
+						? booking.bookedDates.map((date, index) =>
+								createScheduleEvent(
+									productId,
+									index === 0 ? booking._id : new ObjectId(),
+									date,
+									addDays(date, 1),
+									index > 0 ? '-' + index : ''
+								)
+						  )
+						: [
+								createScheduleEvent(
+									productId,
+									booking._id,
+									booking.start,
+									// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+									booking.end!
+								)
+						  ]
+				)
 			)
 		);
 	}
@@ -1213,6 +1262,7 @@ export async function createOrder(
 						.find({
 							scheduleId: productToScheduleId(productId),
 							status: { $in: ['pending', 'confirmed'] },
+							orderId: { $ne: orderId },
 							...(lastTime.end && {
 								beginsAt: {
 									$lt: lastTime.end
@@ -1225,10 +1275,7 @@ export async function createOrder(
 								{
 									endsAt: { $gt: times[0].start }
 								}
-							],
-							_id: {
-								$nin: times.map((t) => t._id)
-							}
+							]
 						})
 						.project<{
 							_id: Schedule['_id'];
@@ -1288,7 +1335,12 @@ export async function createOrder(
 					freeProductSources: item.freeProductSources,
 					...(item.product.bookingSpec &&
 						item.booking && {
-							booking: { start: item.booking.start, end: item.booking.end, _id: item.booking._id }
+							booking: {
+								start: item.booking.start,
+								end: item.booking.end,
+								_id: item.booking._id,
+								...(item.booking.bookedDates?.length && { bookedDates: item.booking.bookedDates })
+							}
 						}),
 					vatRate: priceInfo.vatRates[i],
 					currencySnapshot: {
@@ -1651,9 +1703,7 @@ export async function createOrder(
 	} catch (e) {
 		if (!isEmptyObject(bookingTimesPerProduct)) {
 			await collections.scheduleEvents.deleteMany({
-				_id: {
-					$in: Object.values(bookingTimesPerProduct).flatMap((times) => times.map((t) => t._id))
-				}
+				orderId: orderId
 			});
 		}
 		throw e;
@@ -2603,29 +2653,46 @@ function compareBookingsAndThrow(
 	productName: string,
 	withOld: boolean
 ): (
-	a: {
-		start: Date;
-		end?: Date | null;
-	},
-	b: { start: Date; end?: Date | null }
+	a: { start: Date; end?: Date | null; bookedDates?: Date[] },
+	b: { start: Date; end?: Date | null; bookedDates?: Date[] }
 ) => number {
 	return (a, b) => {
-		if (
-			a.start.getTime() <= b.start.getTime() &&
-			(a.end?.getTime() ?? Infinity) > b.start.getTime()
-		) {
-			throw error(
-				400,
-				`Product ${productName} has overlapping bookings ${
-					!withOld ? 'in your order' : 'with an existing booking'
-				}`
-			);
-		}
+		const timeRangeOverlaps = (s1: number, e1: number, s2: number, e2: number) =>
+			s1 < e2 && e1 > s2;
 
-		if (
-			b.start.getTime() <= a.start.getTime() &&
-			(b.end?.getTime() ?? Infinity) > a.start.getTime()
-		) {
+		const datesOverlapRange = (dates: Date[], rangeStart: number, rangeEnd: number) =>
+			dates.some((d) => {
+				const dayStart = d.getTime();
+				const dayEnd = addDays(d, 1).getTime();
+				return timeRangeOverlaps(dayStart, dayEnd, rangeStart, rangeEnd);
+			});
+
+		const aDates = a.bookedDates;
+		const bDates = b.bookedDates;
+
+		const hasOverlap = (() => {
+			if (aDates?.length && bDates?.length) {
+				const aDayStarts = aDates.map((d) => d.getTime());
+				return bDates.some((d) => aDayStarts.includes(d.getTime()));
+			}
+
+			if (aDates?.length) {
+				return datesOverlapRange(aDates, b.start.getTime(), b.end?.getTime() ?? Infinity);
+			}
+
+			if (bDates?.length) {
+				return datesOverlapRange(bDates, a.start.getTime(), a.end?.getTime() ?? Infinity);
+			}
+
+			return timeRangeOverlaps(
+				a.start.getTime(),
+				a.end?.getTime() ?? Infinity,
+				b.start.getTime(),
+				b.end?.getTime() ?? Infinity
+			);
+		})();
+
+		if (hasOverlap) {
 			throw error(
 				400,
 				`Product ${productName} has overlapping bookings ${

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -821,7 +821,14 @@
 				"other": "{count} minutes"
 			},
 			"time": "Time of day",
-			"timezone": "Time zone: {timeZone}"
+			"timezone": "Time zone: {timeZone}",
+			"selectDateRange": "Select start and end dates (click twice to select a range)",
+			"selectedDate": "Selected: {date}",
+			"selectedRange": "Selected: {start} to {end} ({days} days)",
+			"selectedRangeWithAvailable": "{totalDays} days selected, {availableDays} days available: {dates}",
+			"noAvailableDays": "No available days in selected range",
+			"maxRangeExceeded": "Maximum selection is {days} days",
+			"maxRangeInfo": "Maximum booking period: {days} days"
 		},
 		"checkBackLater": "Please check back later",
 		"cta": {

--- a/src/lib/types/Cart.ts
+++ b/src/lib/types/Cart.ts
@@ -22,6 +22,8 @@ export interface Cart extends Timestamps {
 		booking?: {
 			start: Date;
 			end: Date;
+			/** List of specific dates booked (for non-contiguous multi-day bookings) */
+			bookedDates?: Date[];
 		};
 		customPrice?: { amount: number; currency: Currency };
 		reservedUntil?: Date;

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -65,6 +65,8 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 		 * Number of minutes for the price of the product.
 		 */
 		slotMinutes: number;
+		/** Maximum number of calendar days selectable in a date range booking. 0 or undefined = unlimited. */
+		maxBookableDays?: number;
 		schedule: {
 			timezone: string; // eg "Europe/Berlin"
 			monday: {

--- a/src/lib/utils/formatBookedDates.ts
+++ b/src/lib/utils/formatBookedDates.ts
@@ -1,0 +1,36 @@
+import { format, differenceInDays, isSameDay } from 'date-fns';
+
+/**
+ *   [Jan 1] → "1 Jan 2025"
+ *   [Jan 1, Jan 2, Jan 3] → "1-3 Jan 2025"
+ *   [Jan 1, Jan 2, Jan 5] → "1-2 Jan, 5 Jan 2025"
+ *   [Dec 30, Dec 31, Jan 1] → "30-31 Dec 2024, 1 Jan 2025"
+ */
+export function formatBookedDates(dates: (Date | string)[]): string {
+	if (!dates.length) {
+		return '';
+	}
+	const parsed = dates.map((date) => (typeof date === 'string' ? new Date(date) : date));
+	if (parsed.length === 1) {
+		return format(parsed[0], 'd MMM yyyy');
+	}
+
+	return parsed
+		.reduce<Array<{ start: Date; end: Date }>>((ranges, date) => {
+			const last = ranges.at(-1);
+			last && differenceInDays(date, last.end) === 1
+				? (last.end = date)
+				: ranges.push({ start: date, end: date });
+			return ranges;
+		}, [])
+		.map((range, idx, arr) => {
+			const fmt = idx === arr.length - 1 ? 'd MMM yyyy' : 'd MMM';
+			return isSameDay(range.start, range.end)
+				? format(range.start, fmt)
+				: `${format(
+						range.start,
+						range.start.getMonth() !== range.end.getMonth() ? 'd MMM' : 'd'
+				  )}-${format(range.end, fmt)}`;
+		})
+		.join(', ');
+}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -72,6 +72,7 @@ export const productBaseSchema = () => ({
 				.int()
 				.min(1)
 				.max(24 * 60),
+			maxBookableDays: z.number({ coerce: true }).int().min(0).default(0),
 			schedule: z.object({
 				timezone: z.enum(Intl.supportedValuesOf('timeZone') as [string, ...string[]]),
 				monday: z

--- a/src/routes/(app)/cart/+page.svelte
+++ b/src/routes/(app)/cart/+page.svelte
@@ -16,6 +16,7 @@
 	import CmsDesign from '$lib/components/CmsDesign.svelte';
 	import { CUSTOMER_ROLE_ID } from '$lib/types/User';
 	import { toCurrency } from '$lib/utils/toCurrency.js';
+	import { formatBookedDates } from '$lib/utils/formatBookedDates.js';
 
 	export let data;
 
@@ -189,13 +190,17 @@
 							<p class="text-sm hidden lg:contents">{item.product.shortDescription}</p>
 							{#if item.booking}
 								<p>
-									{Intl.DateTimeFormat($locale, {
-										year: 'numeric',
-										month: 'short',
-										day: 'numeric',
-										hour: '2-digit',
-										minute: '2-digit'
-									}).formatRange(item.booking.start, item.booking.end)}
+									{#if item.booking.bookedDates?.length}
+										{formatBookedDates(item.booking.bookedDates)}
+									{:else}
+										{Intl.DateTimeFormat($locale, {
+											year: 'numeric',
+											month: 'short',
+											day: 'numeric',
+											hour: '2-digit',
+											minute: '2-digit'
+										}).formatRange(item.booking.start, item.booking.end)}
+									{/if}
 								</p>
 							{/if}
 							<div class="grow" />

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -17,6 +17,7 @@
 	import Trans from '$lib/components/Trans.svelte';
 	import CmsDesign from '$lib/components/CmsDesign.svelte';
 	import { trimPrefix } from '$lib/utils/trimPrefix.js';
+	import { formatBookedDates } from '$lib/utils/formatBookedDates.js';
 
 	export let data;
 	let submitting = false;
@@ -796,13 +797,17 @@
 								</div>
 								{#if item.product.bookingSpec && item.booking}
 									<p>
-										{Intl.DateTimeFormat($locale, {
-											year: 'numeric',
-											month: 'short',
-											day: 'numeric',
-											hour: '2-digit',
-											minute: '2-digit'
-										}).formatRange(item.booking.start, item.booking.end)}
+										{#if item.booking.bookedDates?.length}
+											{formatBookedDates(item.booking.bookedDates)}
+										{:else}
+											{Intl.DateTimeFormat($locale, {
+												year: 'numeric',
+												month: 'short',
+												day: 'numeric',
+												hour: '2-digit',
+												minute: '2-digit'
+											}).formatRange(item.booking.start, item.booking.end)}
+										{/if}
 									</p>
 								{:else}
 									<div>

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -157,7 +157,10 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 			booking: item.booking
 				? {
 						start: item.booking.start,
-						end: item.booking.end
+						end: item.booking.end,
+						...(item.booking.bookedDates?.length && {
+							bookedDates: item.booking.bookedDates
+						})
 				  }
 				: undefined,
 			product: {

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -18,7 +18,9 @@
 	import {
 		addDays,
 		addMinutes,
+		differenceInDays,
 		differenceInMinutes,
+		eachDayOfInterval,
 		format,
 		formatDistance,
 		isSameDay,
@@ -39,6 +41,9 @@
 	import { toZonedTime } from 'date-fns-tz';
 	import { RangeList } from '$lib/utils/range-list.js';
 	import { vatMultiplier } from '$lib/utils/vat';
+	import { formatBookedDates } from '$lib/utils/formatBookedDates';
+
+	const FULL_DAY_MINUTES = 1440;
 
 	export let data;
 
@@ -46,34 +51,73 @@
 	let loading = false;
 	let errorMessage = '';
 	let currentTime = Date.now();
-	let selectedDate = startOfDay(addDays(new Date(), 1));
+	const is24HourSlotInit = data.product.bookingSpec?.slotMinutes === FULL_DAY_MINUTES;
+	const searchStart = startOfDay(is24HourSlotInit ? new Date() : addDays(new Date(), 1));
+	const initialDate =
+		eachDayOfInterval({ start: searchStart, end: addDays(searchStart, 60) }).find(
+			(day) => computeDurations(day, data.scheduleEvents).length > 0
+		) ?? searchStart;
+	let selectedDate = initialDate;
+	let selectedEndDate: Date | null = is24HourSlotInit ? initialDate : null;
 	let time = '';
 	let durationMinutes = data.product.bookingSpec?.slotMinutes || 0;
 	const { t, locale, formatDistanceLocale } = useI18n();
 
-	function generateEvents(scheduledEvents: typeof data.scheduleEvents, cart: typeof data.cart) {
+	$: is24HourSlot = data.product.bookingSpec?.slotMinutes === FULL_DAY_MINUTES;
+
+	function getAvailableDatesInRange(
+		start: Date,
+		end: Date | null,
+		evts: Array<{ beginsAt: Date; endsAt?: Date }>
+	): Date[] {
+		return eachDayOfInterval({ start: startOfDay(start), end: startOfDay(end ?? start) }).filter(
+			(date) => computeDurations(date, evts).length > 0
+		);
+	}
+
+	$: availableDatesInRange = is24HourSlot
+		? getAvailableDatesInRange(selectedDate, selectedEndDate, events)
+		: [];
+
+	$: if (is24HourSlot && selectedDate && data.product.bookingSpec) {
+		durationMinutes = availableDatesInRange.length * data.product.bookingSpec.slotMinutes;
+		time = selectedDate.toISOString();
+	}
+
+	$: selectedRangeDays = selectedEndDate ? differenceInDays(selectedEndDate, selectedDate) + 1 : 1;
+
+	function mergeScheduledAndCartEvents(
+		scheduledEvents: typeof data.scheduleEvents,
+		cart: typeof data.cart
+	) {
 		return [
 			...scheduledEvents,
 			...cart.items
 				.filter((item) => item.product._id === data.product._id && item.booking)
-				.map((item) =>
-					item.booking
-						? {
-								beginsAt: item.booking.start,
-								endsAt: item.booking.end
-						  }
-						: null
+				.flatMap((item) =>
+					item.booking?.bookedDates?.length
+						? item.booking.bookedDates.map((date) => ({
+								beginsAt: date,
+								endsAt: addDays(date, 1)
+						  }))
+						: item.booking
+						? [{ beginsAt: item.booking.start, endsAt: item.booking.end }]
+						: []
 				)
-				.filter((item) => item !== null)
 		].sort((a, b) => a.beginsAt.getTime() - b.beginsAt.getTime());
 	}
 
-	$: events = generateEvents(data.scheduleEvents, data.cart);
+	$: events = mergeScheduledAndCartEvents(data.scheduleEvents, data.cart);
 
 	$: durations = computeDurations(selectedDate, events);
 	$: times = computeTimes(selectedDate, durationMinutes, events);
 
-	$: if (durations.length && durationMinutes > durations[durations.length - 1].duration) {
+	// For hourly slots, clamp duration to max available. Skip for 24h slots (range-based duration)
+	$: if (
+		!is24HourSlot &&
+		durations.length &&
+		durationMinutes > durations[durations.length - 1].duration
+	) {
 		durationMinutes = durations[durations.length - 1].duration;
 	}
 	$: if (times.length && !times.some((t) => t.date === time)) {
@@ -139,9 +183,32 @@
 		? data.product.actionSettings.retail.canBeAddedToBasket
 		: data.product.actionSettings.eShop.canBeAddedToBasket;
 
+	function getWeekDayFromDate(date: Date) {
+		return dayList[(date.getDay() + 6) % 7];
+	}
+
+	function isFullDaySchedule(endTime: string) {
+		return endTime === '00:00' || endTime === '23:59';
+	}
+
+	function getScheduleEndTime(date: Date, daySpec: { start: string; end: string }) {
+		const dateStr = format(date, 'yyyy-MM-dd');
+		if (isFullDaySchedule(daySpec.end)) {
+			return addDays(new Date(dateStr + ' 00:00'), 1);
+		}
+		return new Date(dateStr + ' ' + daySpec.end);
+	}
+
+	function getWorkingMinutesForDate(date: Date, daySpec: { start: string; end: string }) {
+		const dateStr = format(date, 'yyyy-MM-dd');
+		const scheduleStart = new Date(dateStr + ' ' + daySpec.start);
+		const scheduleEnd = getScheduleEndTime(date, daySpec);
+		return differenceInMinutes(scheduleEnd, scheduleStart);
+	}
+
 	function computeFreeIntervals(date: Date, events: Array<{ beginsAt: Date; endsAt?: Date }>) {
 		const now = new Date();
-		const weekDay = dayList[(date.getDay() + 6) % 7];
+		const weekDay = getWeekDayFromDate(date);
 		const spec = data.product.bookingSpec;
 
 		if (!spec) {
@@ -159,10 +226,7 @@
 		}
 
 		const start = new Date(format(date, 'yyyy-MM-dd') + ' ' + specForDay.start);
-		let end = new Date(format(date, 'yyyy-MM-dd') + ' ' + specForDay.end);
-		if (specForDay.end === '00:00' || specForDay.end === '23:59') {
-			end = addDays(new Date(format(date, 'yyyy-MM-dd') + ' 00:00'), 1);
-		}
+		const end = getScheduleEndTime(date, specForDay);
 
 		const relevantEvents = events
 			.map((e) => ({
@@ -184,12 +248,9 @@
 		}));
 
 		if (isSameDay(date, now)) {
-			const is24HourSlot = spec.slotMinutes === 1440;
-
 			if (is24HourSlot) {
 				return freeIntervals;
 			}
-
 			return freeIntervals.filter((interval) => interval.end > now);
 		}
 
@@ -207,6 +268,22 @@
 
 		if (!intervals.length) {
 			return [];
+		}
+
+		if (spec.slotMinutes === FULL_DAY_MINUTES) {
+			const dayOfWeek = getWeekDayFromDate(date);
+			const daySpec = spec.schedule[dayOfWeek];
+			if (!daySpec) {
+				return [];
+			}
+
+			const workingMinutes = getWorkingMinutesForDate(date, daySpec);
+			const freeMinutes = intervals.reduce(
+				(sum, int) => sum + differenceInMinutes(int.end, int.start),
+				0
+			);
+
+			return freeMinutes >= workingMinutes ? [{ duration: spec.slotMinutes }] : [];
 		}
 
 		const minutes = Math.max(
@@ -243,8 +320,6 @@
 			return [];
 		}
 
-		const is24HourSlot = spec.slotMinutes === 1440;
-
 		const times = intervals.flatMap((interval) => {
 			const start = interval.start;
 			const end = subMinutes(interval.end, durationMinutes);
@@ -268,7 +343,7 @@
 		}));
 	}
 
-	function addToCart() {
+	function addToCart(multiplier?: number) {
 		$productAddedToCart = {
 			product: data.product,
 			quantity,
@@ -287,7 +362,7 @@
 			discountPercentage:
 				data.discount?.mode === 'percentage' ? data.discount?.percentage : undefined,
 			...(data.product.bookingSpec && {
-				priceMultiplier: durationMinutes / data.product.bookingSpec.slotMinutes
+				priceMultiplier: multiplier ?? durationMinutes / data.product.bookingSpec.slotMinutes
 			})
 		};
 	}
@@ -295,7 +370,12 @@
 
 	let PWYWInput: HTMLInputElement | null = null;
 	let acceptRestriction = data.product.hasSellDisclaimer ? false : true;
-	$: wrongDay = data.product.bookingSpec ? durations.length === 0 : false;
+	// For 24-hour slots, check if date(s) selected; for hourly slots, check if durations available
+	$: wrongDay = data.product.bookingSpec
+		? is24HourSlot
+			? !selectedDate || computeDurations(selectedDate, events).length === 0
+			: durations.length === 0
+		: false;
 	function checkPWYW() {
 		if (!PWYWInput) {
 			return true;
@@ -343,6 +423,28 @@
 	$: if (data.product.hasVariations) {
 		customAmount = productPriceWithVariations(data.product, selectedVariations);
 	}
+	// Price calculation helpers
+	$: basePrice = data.product.hasVariations ? customAmount : data.product.price.amount;
+	$: bookingMultiplier = data.product.bookingSpec
+		? durationMinutes / data.product.bookingSpec.slotMinutes
+		: 1;
+	$: unitPrice = basePrice * bookingMultiplier;
+	$: unitPriceWithVat = unitPrice * vatMultiplier(vatRate);
+	$: discountMultiplier =
+		data.discount?.mode === 'percentage' && data.discount?.percentage
+			? 1 - data.discount.percentage / 100
+			: 1;
+	$: finalPrice = unitPrice * discountMultiplier;
+	$: finalPriceWithVat = unitPriceWithVat * discountMultiplier;
+
+	// Schedule calendar config
+	const calendarSchedule = {
+		_id: productToScheduleId(data.product._id),
+		events: [] as import('$lib/types/Schedule').ScheduleEvent[],
+		allowSubscription: false,
+		pastEventDelay: 0
+	};
+	$: isDayUnavailable = (date: Date) => computeDurations(date, events).length === 0;
 </script>
 
 <svelte:head>
@@ -482,41 +584,22 @@
 										? 'line-through'
 										: ''}"
 									short={!!data.discount}
-									amount={(data.product.hasVariations
-										? customAmount * vatMultiplier(vatRate)
-										: data.product.price.amount * vatMultiplier(vatRate)) *
-										(data.product.bookingSpec
-											? durationMinutes / data.product.bookingSpec.slotMinutes
-											: 1)}
+									amount={unitPriceWithVat}
 									main
 								/>
-								{#if data.discount && data.discount.mode === 'percentage'}
+								{#if data.discount?.mode === 'percentage'}
 									<PriceTag
 										currency={data.product.price.currency}
 										class="text-2xl lg:text-4xl truncate max-w-full"
 										short
-										amount={(data.product.hasVariations
-											? customAmount * vatMultiplier(vatRate)
-											: data.product.price.amount * vatMultiplier(vatRate)) *
-											(data.product.bookingSpec
-												? durationMinutes / data.product.bookingSpec.slotMinutes
-												: 1) *
-											(1 - data.discount.percentage / 100)}
+										amount={finalPriceWithVat}
 										main
 									/>
 								{/if}
 							</div>
 							<PriceTag
 								currency={data.product.price.currency}
-								amount={(data.product.hasVariations
-									? customAmount * vatMultiplier(vatRate)
-									: data.product.price.amount * vatMultiplier(vatRate)) *
-									(data.product.bookingSpec
-										? durationMinutes / data.product.bookingSpec.slotMinutes
-										: 1) *
-									(data.discount?.mode === 'percentage' && data.discount?.percentage
-										? 1 - data.discount.percentage / 100
-										: 1)}
+								amount={finalPriceWithVat}
 								secondary
 								class="text-xl"
 							/>
@@ -530,40 +613,25 @@
 										? 'line-through'
 										: ''}"
 									short={!!data.discount}
-									amount={(data.product.hasVariations ? customAmount : data.product.price.amount) *
-										(data.product.bookingSpec
-											? durationMinutes / data.product.bookingSpec.slotMinutes
-											: 1)}
+									amount={unitPrice}
 									main
-								/> <span class="font-semibold lg:contents hidden">{t('product.vatExcluded')}</span>
-
-								{#if data.discount && data.discount.mode === 'percentage'}
+								/>
+								<span class="font-semibold lg:contents hidden">{t('product.vatExcluded')}</span>
+								{#if data.discount?.mode === 'percentage'}
 									<PriceTag
 										currency={data.product.price.currency}
 										class="text-2xl lg:text-4xl truncate max-w-full"
 										short
-										amount={(data.product.hasVariations
-											? customAmount
-											: data.product.price.amount) *
-											(data.product.bookingSpec
-												? durationMinutes / data.product.bookingSpec.slotMinutes
-												: 1) *
-											(1 - data.discount.percentage / 100)}
+										amount={finalPrice}
 										main
 									/>
 								{/if}
 							</div>
 							<PriceTag
 								currency={data.product.price.currency}
-								amount={(data.product.hasVariations ? customAmount : data.product.price.amount) *
-									(data.product.bookingSpec
-										? durationMinutes / data.product.bookingSpec.slotMinutes
-										: 1) *
-									(data.discount?.mode === 'percentage' && data.discount?.percentage
-										? 1 - data.discount.percentage / 100
-										: 1)}
+								amount={finalPrice}
 								secondary
-								class={data.displayVatIncludedInProduct ? 'text-md' : 'text-xl'}
+								class="text-md"
 							/>
 						</div>
 						<span class="font-semibold contents lg:hidden">{t('product.vatExcluded')}</span>
@@ -577,36 +645,22 @@
 									? 'line-through'
 									: ''}"
 								short={!!data.discount}
-								amount={(data.product.hasVariations ? customAmount : data.product.price.amount) *
-									(data.product.bookingSpec
-										? durationMinutes / data.product.bookingSpec.slotMinutes
-										: 1)}
+								amount={unitPrice}
 								main
 							/>
-
-							{#if data.discount && data.discount.mode === 'percentage'}
+							{#if data.discount?.mode === 'percentage'}
 								<PriceTag
 									currency={data.product.price.currency}
 									class="text-2xl lg:text-4xl truncate max-w-full"
 									short
-									amount={(data.product.hasVariations ? customAmount : data.product.price.amount) *
-										(data.product.bookingSpec
-											? durationMinutes / data.product.bookingSpec.slotMinutes
-											: 1) *
-										(1 - data.discount.percentage / 100)}
+									amount={finalPrice}
 									main
 								/>
 							{/if}
 						</div>
 						<PriceTag
 							currency={data.product.price.currency}
-							amount={(data.product.hasVariations ? customAmount : data.product.price.amount) *
-								(data.product.bookingSpec
-									? durationMinutes / data.product.bookingSpec.slotMinutes
-									: 1) *
-								(data.discount?.mode === 'percentage' && data.discount?.percentage
-									? 1 - data.discount.percentage / 100
-									: 1)}
+							amount={finalPrice}
 							secondary
 							class="text-xl"
 						/>
@@ -709,8 +763,17 @@
 									return await applyAction(result);
 								}
 
+								// Capture multiplier BEFORE invalidate changes durationMinutes
+								const priceMultiplier = data.product.bookingSpec
+									? durationMinutes / data.product.bookingSpec.slotMinutes
+									: 1;
 								await invalidate(UrlDependency.Cart);
-								addToCart();
+								addToCart(priceMultiplier);
+								// Reset selection for 24h slot mode after adding to cart
+								if (is24HourSlot) {
+									selectedDate = startOfDay(new Date());
+									selectedEndDate = startOfDay(new Date());
+								}
 								document.body.scrollIntoView();
 							};
 						}}
@@ -774,65 +837,121 @@
 								</label>
 							{/if}
 							{#if data.product.bookingSpec}
-								<ScheduleWidgetCalendar
-									schedule={{
-										_id: productToScheduleId(data.product._id),
-										events: [],
-										allowSubscription: false,
-										pastEventDelay: 0
-									}}
-									bind:selectedDate
-									isDayDisabled={(date) => computeDurations(date, events).length === 0}
-								/>
-								{t('product.booking.timezone', {
-									timeZone: data.product.bookingSpec.schedule.timezone
-								})}
-								{#if durations.length}
-									<label class="form-label">
-										{t('product.booking.duration')}
-										<select class="form-input" bind:value={durationMinutes} name="durationMinutes">
-											{#each durations as duration}
-												<option value={duration.duration}
-													>{duration.duration >= 60
-														? t('product.booking.hour', {
-																count: Math.floor(duration.duration / 60)
-														  })
-														: ''}
-													{duration.duration % 60 > 0
-														? t('product.booking.minute', { count: duration.duration % 60 })
-														: ''}
-												</option>
-											{/each}
-										</select>
-									</label>
-
-									<label class="form-label">
-										{t('product.booking.time')}
-										<select
-											class="form-input"
-											bind:value={time}
-											name="time"
-											disabled={!times.length}
-										>
-											{#if !times.length}
-												<option value="" disabled selected
-													>No available time slots for this date</option
-												>
+								{#if is24HourSlot}
+									<!-- 24-hour slot mode: date range selection -->
+									<p class="text-sm text-gray-600 mb-2">
+										{t('product.booking.selectDateRange')}
+									</p>
+									<ScheduleWidgetCalendar
+										schedule={calendarSchedule}
+										bind:selectedDate
+										bind:selectedEndDate
+										rangeMode={true}
+										isDayDisabled={isDayUnavailable}
+										maxRangeDays={data.product.bookingSpec?.maxBookableDays ?? 0}
+									/>
+									{#if data.product.bookingSpec?.maxBookableDays}
+										<p class="text-sm text-gray-500">
+											{t('product.booking.maxRangeInfo', {
+												days: data.product.bookingSpec.maxBookableDays
+											})}
+										</p>
+									{/if}
+									{t('product.booking.timezone', {
+										timeZone: data.product.bookingSpec.schedule.timezone
+									})}
+									{#if selectedDate && availableDatesInRange.length > 0}
+										<p class="font-medium mt-2">
+											{#if selectedEndDate && !isSameDay(selectedDate, selectedEndDate)}
+												{t('product.booking.selectedRangeWithAvailable', {
+													totalDays: selectedRangeDays,
+													availableDays: availableDatesInRange.length,
+													dates: formatBookedDates(availableDatesInRange)
+												})}
 											{:else}
-												{#each times as time}
-													<option value={time.date}>
-														<!-- todo: handle timezone here maybe -->
-														{new Date(
-															selectedDate.toJSON().slice(0, 11) + time.time
-														).toLocaleTimeString($locale, {
-															hour: 'numeric',
-															minute: 'numeric'
-														})}
+												{t('product.booking.selectedDate', {
+													date: selectedDate.toLocaleDateString($locale)
+												})}
+											{/if}
+										</p>
+									{:else if selectedDate}
+										<p class="font-medium mt-2 text-red-500">
+											{t('product.booking.noAvailableDays')}
+										</p>
+									{/if}
+									<input type="hidden" name="time" value={time} />
+									<input type="hidden" name="durationMinutes" value={durationMinutes} />
+									<input
+										type="hidden"
+										name="endDate"
+										value={selectedEndDate?.toISOString() ?? ''}
+									/>
+									<input
+										type="hidden"
+										name="bookedDates"
+										value={availableDatesInRange.map((d) => d.toISOString()).join(',')}
+									/>
+								{:else}
+									<!-- Hourly booking mode: single date + duration + time -->
+									<ScheduleWidgetCalendar
+										schedule={calendarSchedule}
+										bind:selectedDate
+										isDayDisabled={isDayUnavailable}
+									/>
+									{t('product.booking.timezone', {
+										timeZone: data.product.bookingSpec.schedule.timezone
+									})}
+									{#if durations.length}
+										<label class="form-label">
+											{t('product.booking.duration')}
+											<select
+												class="form-input"
+												bind:value={durationMinutes}
+												name="durationMinutes"
+											>
+												{#each durations as duration}
+													<option value={duration.duration}
+														>{duration.duration >= 60
+															? t('product.booking.hour', {
+																	count: Math.floor(duration.duration / 60)
+															  })
+															: ''}
+														{duration.duration % 60 > 0
+															? t('product.booking.minute', { count: duration.duration % 60 })
+															: ''}
 													</option>
 												{/each}
-											{/if}
-										</select>
-									</label>
+											</select>
+										</label>
+
+										<label class="form-label">
+											{t('product.booking.time')}
+											<select
+												class="form-input"
+												bind:value={time}
+												name="time"
+												disabled={!times.length}
+											>
+												{#if !times.length}
+													<option value="" disabled selected
+														>No available time slots for this date</option
+													>
+												{:else}
+													{#each times as time}
+														<option value={time.date}>
+															<!-- todo: handle timezone here maybe -->
+															{new Date(
+																selectedDate.toJSON().slice(0, 11) + time.time
+															).toLocaleTimeString($locale, {
+																hour: 'numeric',
+																minute: 'numeric'
+															})}
+														</option>
+													{/each}
+												{/if}
+											</select>
+										</label>
+									{/if}
 								{/if}
 							{/if}
 							{#if data.product.deposit}
@@ -935,69 +1054,27 @@
 					</p>
 				{/if}
 				{#if data.product.cta}
+					{@const showFallbackCta =
+						!canBuy ||
+						amountAvailable <= 0 ||
+						(data.cartMaxSeparateItems && data.cart.items.length === data.cartMaxSeparateItems)}
 					{#each data.product.cta as cta}
-						{#if !cta.fallback}
-							{#if cta.downloadLink}
-								<a
-									href={cta.href.startsWith('http') || cta.href.includes('/')
-										? cta.href
-										: `/${cta.href}`}
-									class="btn body-cta body-secondaryCTA h-auto min-h-[2em] break-words hyphens-auto text-center {!cta.label.includes(
-										' '
-									)
-										? 'break-all'
-										: ''} "
-									target={cta.href.startsWith('http') ? '_blank' : '_self'}
-									download={cta.downloadLink}
-								>
-									{cta.label}
-								</a>
-							{:else}
-								<a
-									href={cta.href.startsWith('http') || cta.href.includes('/')
-										? cta.href
-										: `/${cta.href}`}
-									class="btn body-cta body-secondaryCTA h-auto min-h-[2em] break-words hyphens-auto text-center {!cta.label.includes(
-										' '
-									)
-										? 'break-all'
-										: ''} "
-									target={cta.href.startsWith('http') ? '_blank' : '_self'}
-								>
-									{cta.label}
-								</a>
-							{/if}
-						{:else if !canBuy || amountAvailable <= 0 || (data.cartMaxSeparateItems && data.cart.items.length === data.cartMaxSeparateItems)}
-							{#if cta.downloadLink}
-								<a
-									href={cta.href.startsWith('http') || cta.href.includes('/')
-										? cta.href
-										: `/${cta.href}`}
-									class="btn body-cta body-secondaryCTA h-auto min-h-[2em] break-words hyphens-auto text-center {!cta.label.includes(
-										' '
-									)
-										? 'break-all'
-										: ''} "
-									target={cta.href.startsWith('http') ? '_blank' : '_self'}
-									download={cta.downloadLink}
-								>
-									{cta.label}
-								</a>
-							{:else}
-								<a
-									href={cta.href.startsWith('http') || cta.href.includes('/')
-										? cta.href
-										: `/${cta.href}`}
-									class="btn body-cta body-secondaryCTA h-auto min-h-[2em] break-words hyphens-auto text-center {!cta.label.includes(
-										' '
-									)
-										? 'break-all'
-										: ''} "
-									target={cta.href.startsWith('http') ? '_blank' : '_self'}
-								>
-									{cta.label}
-								</a>
-							{/if}
+						{@const ctaHref =
+							cta.href.startsWith('http') || cta.href.includes('/') ? cta.href : `/${cta.href}`}
+						{@const isExternal = cta.href.startsWith('http')}
+						{#if !cta.fallback || showFallbackCta}
+							<a
+								href={ctaHref}
+								class="btn body-cta body-secondaryCTA h-auto min-h-[2em] break-words hyphens-auto text-center {!cta.label.includes(
+									' '
+								)
+									? 'break-all'
+									: ''}"
+								target={isExternal ? '_blank' : '_self'}
+								download={cta.downloadLink || null}
+							>
+								{cta.label}
+							</a>
 						{/if}
 					{/each}
 				{/if}


### PR DESCRIPTION
Products with daily pricing (24h slots) now support date range selection.
Users pick start/end dates in calendar, and only available days in that range are booked and charged. Unavailable days are skipped automatically.

Example: Select Dec 1-4, but Dec 2 is unavailable → books Dec 1, 3, 4 and charges for 3 days.

Closes #1868