### PR TITLE
🦋 Allow products to reference another product's stock

### DIFF
--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -48,6 +48,7 @@
 	export let vatProfiles: LayoutServerData['vatProfiles'];
 	export let defaultActionSettings: ProductActionSettings;
 	export let availablePaymentMethods: PaymentMethod[];
+	export let productsWithStock: { _id: string; name: string }[] = [];
 	export let product: WithId<PojoObject<Product>> = {
 		_id: '',
 		payWhatYouWant: false,
@@ -1069,6 +1070,28 @@
 						value={product.stock?.total ?? 0}
 					/>
 				</label>
+
+				<label class="form-label">
+					{t('admin.product.stockReference.label')}
+					<select
+						class="form-input"
+						name="stockReferenceProductId"
+						value={product.stockReference?.productId ?? ''}
+					>
+						<option value="">{t('admin.product.stockReference.noReference')}</option>
+						{#each productsWithStock as p}
+							{#if p._id !== product._id}
+								<option value={p._id}>{p.name}</option>
+							{/if}
+						{/each}
+					</select>
+				</label>
+
+				{#if product.stockReference?.productId}
+					<p class="text-sm text-gray-600">
+						{t('admin.product.stockReference.warning')}
+					</p>
+				{/if}
 			{/if}
 
 			{#if !isNew}

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -2524,9 +2524,11 @@ export async function updateAfterOrderPaid(order: Order, session: ClientSession)
 
 	// Update product stock in DB
 	for (const item of order.items.filter((item) => item.product.stock)) {
+		const productIdToDecrement = item.product.stockReference?.productId || item.product._id;
+
 		await collections.products.updateOne(
 			{
-				_id: item.product._id
+				_id: productIdToDecrement
 			},
 			{
 				$inc: { 'stock.total': -item.quantity, 'stock.available': -item.quantity },

--- a/src/lib/server/product.ts
+++ b/src/lib/server/product.ts
@@ -1,12 +1,24 @@
 import type { ClientSession } from 'mongodb';
 import { collections } from './database';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
+import type { Product } from '$lib/types/Product';
 import { getCartFromDb } from './cart';
 
 /**
- * Amount of product reserved in carts and pending orders
+ * Amount of stock reserved in carts and pending orders.
+ *
+ * Finds ALL products that use the specified stock (either directly or via stockReference)
+ * and returns the total reserved quantity across all of them.
+ *
+ * @param productId - ID of the product whose stock to check (can be either the product with stock or a product referencing it)
+ * @returns Total quantity reserved in carts and pending orders for this stock
+ *
+ * @example
+ * // Product A has stock, Product B references A's stock
+ * amountOfStockReserved('A') // returns reserves for BOTH A and B
+ * amountOfStockReserved('B') // returns reserves for BOTH A and B (same result!)
  */
-export async function amountOfProductReserved(
+export async function amountOfStockReserved(
 	productId: string,
 	opts?: {
 		/** Include stock for outdated carts with this id */
@@ -19,6 +31,16 @@ export async function amountOfProductReserved(
 	const userIdentifier = opts?.include ?? opts?.exclude;
 	const cart = userIdentifier ? await getCartFromDb({ user: userIdentifier }) : undefined;
 
+	// Find all products that use this stock (either directly or via stockReference)
+	const productIds = (
+		await collections.products
+			.find({
+				$or: [{ _id: productId }, { 'stockReference.productId': productId }]
+			})
+			.project({ _id: 1 })
+			.toArray()
+	).map((p) => p._id);
+
 	return (
 		((
 			await collections.carts
@@ -26,7 +48,7 @@ export async function amountOfProductReserved(
 					[
 						{
 							$match: {
-								'items.productId': productId
+								'items.productId': { $in: productIds }
 							}
 						},
 						{
@@ -34,7 +56,7 @@ export async function amountOfProductReserved(
 						},
 						{
 							$match: {
-								'items.productId': productId,
+								'items.productId': { $in: productIds },
 								$or: [
 									{
 										'items.reservedUntil': { $gt: new Date() }
@@ -71,7 +93,7 @@ export async function amountOfProductReserved(
 					[
 						{
 							$match: {
-								'items.product._id': productId,
+								'items.product._id': { $in: productIds },
 								status: 'pending'
 							}
 						},
@@ -80,7 +102,7 @@ export async function amountOfProductReserved(
 						},
 						{
 							$match: {
-								'items.product._id': productId
+								'items.product._id': { $in: productIds }
 							}
 						},
 						{
@@ -102,11 +124,21 @@ export async function amountOfProductReserved(
 }
 
 export async function refreshAvailableStockInDb(productId: string, session?: ClientSession) {
-	const amountReserved = await amountOfProductReserved(productId, { session });
+	const stockProduct = await resolveStockProduct(productId, session);
+
+	if (!stockProduct) {
+		console.warn(
+			`Cannot refresh stock for product ${productId}: ` +
+				`product not found or has no stock configuration`
+		);
+		return;
+	}
+
+	const amountReserved = await amountOfStockReserved(stockProduct._id, { session });
 
 	await collections.products.updateOne(
 		{
-			_id: productId,
+			_id: stockProduct._id,
 			stock: { $exists: true }
 		},
 		[
@@ -154,4 +186,166 @@ export async function amountOfProductSold(productId: string): Promise<number> {
 				.next()
 		)?.total ?? 0
 	);
+}
+
+/**
+ * Resolve the product whose stock should be used.
+ * If product has stockReference, return referenced product.
+ * Otherwise return the product itself.
+ */
+export async function resolveStockProduct(
+	productId: string,
+	session?: ClientSession
+): Promise<Product | null> {
+	const product = await collections.products.findOne({ _id: productId }, { session });
+
+	if (!product) {
+		return null;
+	}
+
+	// If has reference, return referenced product
+	if (product.stockReference?.productId) {
+		return await collections.products.findOne(
+			{ _id: product.stockReference.productId },
+			{ session }
+		);
+	}
+
+	// Otherwise return product itself
+	return product;
+}
+
+/**
+ * Validate stock reference.
+ * - Referenced product must exist
+ * - Referenced product must have stock
+ * - Referenced product must NOT have stockReference (prevent cascade)
+ * - No cyclic reference
+ */
+export async function validateStockReference(
+	productId: string,
+	stockReferenceProductId: string
+): Promise<{ valid: boolean; error?: string }> {
+	// Cannot reference self
+	if (productId === stockReferenceProductId) {
+		return {
+			valid: false,
+			error: 'Product cannot reference its own stock'
+		};
+	}
+
+	// Check referenced product exists
+	const referencedProduct = await collections.products.findOne({
+		_id: stockReferenceProductId
+	});
+
+	if (!referencedProduct) {
+		return {
+			valid: false,
+			error: `Referenced product ${stockReferenceProductId} does not exist`
+		};
+	}
+
+	// Referenced product must have stock
+	if (!referencedProduct.stock) {
+		return {
+			valid: false,
+			error: 'Referenced product must have stock enabled'
+		};
+	}
+
+	// Referenced product must NOT have stockReference (prevent cascade)
+	if (referencedProduct.stockReference) {
+		return {
+			valid: false,
+			error: 'Cascade references are forbidden. Referenced product cannot have stockReference.'
+		};
+	}
+
+	return { valid: true };
+}
+
+export async function getProductsWithStock() {
+	return collections.products
+		.find({
+			stock: { $exists: true },
+			stockReference: { $exists: false }
+		})
+		.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
+		.toArray();
+}
+
+/**
+ * Apply resolved stock to already loaded product.
+ * Does NOT load from DB - works with existing product object.
+ *
+ * If product has stockReference, replaces its stock with the referenced product's stock.
+ * Otherwise returns product unchanged.
+ *
+ * @example
+ * const product = await collections.products.findOne({ _id: 'ricard' });
+ * const withStock = await applyResolvedStock(product);
+ * // withStock._id = 'ricard', withStock.stock = Whiskey's stock
+ */
+export async function applyResolvedStock<
+	T extends {
+		_id: string;
+		stockReference?: { productId: string };
+		stock?: { available: number; total: number; reserved: number };
+	}
+>(product: T, session?: ClientSession): Promise<T> {
+	if (!product.stockReference?.productId) {
+		return product;
+	}
+
+	const resolved = await resolveStockProduct(product._id, session);
+
+	if (resolved?.stock) {
+		return { ...product, stock: resolved.stock };
+	}
+
+	return product;
+}
+
+/**
+ * Load product from DB and apply resolved stock.
+ * Convenience wrapper around applyResolvedStock.
+ */
+export async function loadProductWithResolvedStock(
+	productId: string,
+	session?: ClientSession
+): Promise<Product | null> {
+	const product = await collections.products.findOne({ _id: productId }, { session });
+	if (!product) {
+		return null;
+	}
+
+	return await applyResolvedStock(product, session);
+}
+
+/**
+ * Clean variation labels by removing empty strings from names and values.
+ * Returns object with non-empty names and values only.
+ */
+export function cleanVariationLabels(variationLabels?: {
+	names: Record<string, string>;
+	values: Record<string, Record<string, string>>;
+}): {
+	names: Record<string, string>;
+	values: Record<string, Record<string, string>>;
+} {
+	const names = Object.fromEntries(
+		Object.entries(variationLabels?.names ?? {}).filter(([, v]) => v.trim() !== '')
+	);
+
+	const values = Object.fromEntries(
+		Object.entries(variationLabels?.values ?? {})
+			.map(([key, entries]) => [
+				key,
+				Object.fromEntries(Object.entries(entries).filter(([, v]) => v.trim() !== ''))
+			])
+			.filter(([, entries]) => Object.keys(entries).length > 0)
+	);
+
+	return { names, values };
 }

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -13,6 +13,15 @@
 		"vatNumber": "Umsatzsteuer-Identifikationsnummer",
 		"zipCode": "Postleitzahl"
 	},
+	"admin": {
+		"product": {
+			"stockReference": {
+				"label": "Auf Lagerbestand eines anderen Produkts verweisen (optional)",
+				"noReference": "-- Keine Referenz (eigenen Lagerbestand verwenden) --",
+				"warning": "⚠️ Dieses Produkt verweist auf den Lagerbestand eines anderen Produkts. Lagerbestandsänderungen wirken sich auf das referenzierte Produkt aus."
+			}
+		}
+	},
 	"ageWarning": {
 		"agreement": "Ich habe die Zugangsbedingungen gelesen, erfülle sie und respektiere sie",
 		"navigate": "Weiter stöbern"

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -13,6 +13,15 @@
 		"vatNumber": "VAT number",
 		"zipCode": "Zip code"
 	},
+	"admin": {
+		"product": {
+			"stockReference": {
+				"label": "Reference another product's stock (optional)",
+				"noReference": "-- No reference (use own stock) --",
+				"warning": "⚠️ This product references another product's stock. Stock changes will affect the referenced product."
+			}
+		}
+	},
 	"ageWarning": {
 		"agreement": "I have read the access conditions, fulfill them and respect them",
 		"navigate": "Continue browsing"

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -13,6 +13,15 @@
 		"vatNumber": "Número de IVA",
 		"zipCode": "Código postal"
 	},
+	"admin": {
+		"product": {
+			"stockReference": {
+				"label": "Referenciar el stock de otro producto (opcional)",
+				"noReference": "-- Sin referencia (usar stock propio) --",
+				"warning": "⚠️ Este producto referencia el stock de otro producto. Los cambios de stock afectarán al producto referenciado."
+			}
+		}
+	},
 	"ageWarning": {
 		"agreement": "He leído las condiciones de acceso, las cumplo y las respeto",
 		"navigate": "Continuar navegando"

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -13,6 +13,15 @@
 		"vatNumber": "Numéro TVA",
 		"zipCode": "Code postal"
 	},
+	"admin": {
+		"product": {
+			"stockReference": {
+				"label": "Référencer le stock d'un autre produit (optionnel)",
+				"noReference": "-- Pas de référence (utiliser le stock propre) --",
+				"warning": "⚠️ Ce produit référence le stock d'un autre produit. Les modifications de stock affecteront le produit référencé."
+			}
+		}
+	},
 	"ageWarning": {
 		"agreement": "J'ai pris connaissance des conditions d'accès, les remplis et les respecte.",
 		"navigate": "Continuer la navigation"

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -13,6 +13,15 @@
 		"vatNumber": "Numero IVA",
 		"zipCode": "Codice d'avviamento postale"
 	},
+	"admin": {
+		"product": {
+			"stockReference": {
+				"label": "Riferimento allo stock di un altro prodotto (opzionale)",
+				"noReference": "-- Nessun riferimento (usa stock proprio) --",
+				"warning": "⚠️ Questo prodotto fa riferimento allo stock di un altro prodotto. Le modifiche allo stock influenzeranno il prodotto di riferimento."
+			}
+		}
+	},
 	"ageWarning": {
 		"agreement": "Ho letto le condizioni di accesso, le adempio e le rispetto",
 		"navigate": "Continua la navigazione"

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -13,6 +13,15 @@
 		"vatNumber": "btw-nummer",
 		"zipCode": "Postcode"
 	},
+	"admin": {
+		"product": {
+			"stockReference": {
+				"label": "Verwijzing naar voorraad van ander product (optioneel)",
+				"noReference": "-- Geen verwijzing (gebruik eigen voorraad) --",
+				"warning": "⚠️ Dit product verwijst naar de voorraad van een ander product. Voorraadwijzigingen zullen het gerefereerde product beïnvloeden."
+			}
+		}
+	},
 	"ageWarning": {
 		"agreement": "Ik heb de toegangsvoorwaarden gelezen, voldoe eraan en respecteer ze",
 		"navigate": "Vervolg de navigatie"

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -13,6 +13,15 @@
 		"vatNumber": "Número de IVA",
 		"zipCode": "Código postal"
 	},
+	"admin": {
+		"product": {
+			"stockReference": {
+				"label": "Referenciar o stock de outro produto (opcional)",
+				"noReference": "-- Sem referência (usar stock próprio) --",
+				"warning": "⚠️ Este produto referencia o stock de outro produto. As alterações de stock afetarão o produto referenciado."
+			}
+		}
+	},
 	"ageWarning": {
 		"agreement": "Li e cumpro as condições de acesso e respeito-as",
 		"navigate": "Continuar a navegar"

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -49,6 +49,9 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 		total: number;
 		reserved: number;
 	};
+	stockReference?: {
+		productId: string;
+	};
 	vatProfileId?: ObjectId;
 	maxQuantityPerOrder?: number;
 	type: 'subscription' | 'resource' | 'donation';

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -109,6 +109,7 @@ export async function load(params) {
 							| 'standalone'
 							| 'maxQuantityPerOrder'
 							| 'stock'
+							| 'stockReference'
 							| 'isTicket'
 							| 'vatProfileId'
 							| 'paymentMethods'
@@ -134,6 +135,7 @@ export async function load(params) {
 						standalone: 1,
 						maxQuantityPerOrder: 1,
 						stock: 1,
+						stockReference: 1,
 						vatProfileId: 1,
 						paymentMethods: 1,
 						'bookingSpec.slotMinutes': 1,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
@@ -32,6 +32,7 @@
 	globalDeliveryFees={data.deliveryFees}
 	product={data.product}
 	tags={data.tags}
+	productsWithStock={data.productsWithStock}
 	adminPrefix={data.adminPrefix}
 	reserved={data.reserved}
 	defaultActionSettings={data.productActionSettings}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
@@ -13,6 +13,7 @@
 	isNew
 	duplicateFromId={data.product?._id}
 	tags={data.tags}
+	productsWithStock={data.productsWithStock}
 	product={data.product ?? undefined}
 	defaultActionSettings={data.productActionSettings}
 	vatProfiles={data.vatProfiles}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -144,6 +144,11 @@ export const productBaseSchema = () => ({
 	standalone: z.boolean({ coerce: true }).default(false),
 	free: z.boolean({ coerce: true }).default(false),
 	stock: z.number({ coerce: true }).int().min(0).optional(),
+	stockReferenceProductId: z
+		.string()
+		.trim()
+		.transform((val) => val || undefined)
+		.optional(),
 	maxQuantityPerOrder: z.number({ coerce: true }).int().min(1).optional(),
 	eshopVisible: z.boolean({ coerce: true }).default(false),
 	retailVisible: z.boolean({ coerce: true }).default(false),

--- a/src/routes/(app)/cart/+page.svelte
+++ b/src/routes/(app)/cart/+page.svelte
@@ -24,19 +24,19 @@
 	let errorMessage = data.errorMessage;
 	let errorProductId = '';
 
-	$: items = data.cart.items;
+	$: items = data.cart?.items ?? [];
 	$: deliveryFees =
 		data.countryCode && isAlpha2CountryCode(data.countryCode)
 			? computeDeliveryFees(UNDERLYING_CURRENCY, data.countryCode, items, data.deliveryFees)
 			: NaN;
-	$: priceInfo = data.cart.priceInfo;
+	$: priceInfo = data.cart?.priceInfo;
 	let alias = '';
 	let formAlias: HTMLInputElement;
 	let loading = false;
 	const { t, locale, countryName } = useI18n();
 	$: isDigital = items.every((item) => !item.product.shipping);
 	$: physicalCartCanBeOrdered =
-		!!data.physicalCartMinAmount && !isDigital
+		!!data.physicalCartMinAmount && !isDigital && priceInfo
 			? priceInfo.partialPriceWithVat >=
 			  toCurrency(priceInfo.currency, data.physicalCartMinAmount, data.currencies.main)
 			: true;
@@ -114,7 +114,7 @@
 			<p class="text-red-500">{errorMessage}</p>
 		{/if}
 
-		{#if items.length}
+		{#if items.length && priceInfo}
 			<div
 				class="lg:grid gap-x-4 gap-y-6 overflow-hidden"
 				style="grid-template-columns: auto 1fr auto auto"

--- a/src/routes/(app)/cart/[id]/+page.server.ts
+++ b/src/routes/(app)/cart/[id]/+page.server.ts
@@ -1,6 +1,6 @@
 import { addToCartInDb, findItemInCart, getCartFromDb, removeFromCartInDb } from '$lib/server/cart';
 import { collections, withTransaction } from '$lib/server/database';
-import { refreshAvailableStockInDb } from '$lib/server/product.js';
+import { loadProductWithResolvedStock, refreshAvailableStockInDb } from '$lib/server/product.js';
 import { userIdentifier, userQuery } from '$lib/server/user.js';
 import { DEFAULT_MAX_QUANTITY_PER_ORDER } from '$lib/types/Product.js';
 import { error, redirect } from '@sveltejs/kit';
@@ -43,7 +43,7 @@ export const actions = {
 		throw redirect(303, request.headers.get('referer') || '/cart');
 	},
 	increase: async ({ locals, params, request }) => {
-		const product = await collections.products.findOne({ _id: params.id });
+		const product = await loadProductWithResolvedStock(params.id);
 
 		if (!product) {
 			await collections.carts.updateOne(userQuery(userIdentifier(locals)), {
@@ -80,7 +80,7 @@ export const actions = {
 		throw redirect(303, request.headers.get('referer') || '/cart');
 	},
 	decrease: async ({ request, locals, params }) => {
-		const product = await collections.products.findOne({ _id: params.id });
+		const product = await loadProductWithResolvedStock(params.id);
 
 		if (!product) {
 			await collections.carts.updateMany(
@@ -108,7 +108,7 @@ export const actions = {
 		throw redirect(303, request.headers.get('referer') || '/cart');
 	},
 	setQuantity: async ({ locals, params, request }) => {
-		const product = await collections.products.findOne({ _id: params.id });
+		const product = await loadProductWithResolvedStock(params.id);
 
 		if (!product) {
 			await collections.carts.updateOne(userQuery(userIdentifier(locals)), {


### PR DESCRIPTION
Products can now share inventory by referencing another product's stock. This enables selling the same item on multiple pages with different prices (e.g., regular and discounted versions) while maintaining a single shared inventory.

Features:
- Admin UI dropdown to select which product's stock to use
- Validation prevents self-references, cascades, and circular dependencies
- Protection prevents deleting products that others reference
- Automatic stock resolution in cart, checkout, and order processing

When a product references another's stock, all operations (add to cart, checkout, payment) correctly update the referenced product's inventory. The UI clearly indicates when a stock reference is active.

  Closes #2015