### PR TITLE
🦋 Products can now be grouped by tags in POS touch UI

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -34,6 +34,7 @@ import type { Discount } from '$lib/types/Discount';
 import type { Session } from '$lib/types/Session';
 import type { Migration } from '$lib/types/Migration';
 import type { Tag } from '$lib/types/Tag';
+import type { TagGroup } from '$lib/types/TagGroup';
 import type { Slider } from '$lib/types/slider';
 import { building } from '$app/environment';
 import type { Theme } from '$lib/types/Theme';
@@ -98,6 +99,7 @@ const genCollection = () => ({
 	sessions: db.collection<Session>('sessions'),
 	migrations: db.collection<Migration>('migrations'),
 	tags: db.collection<Tag>('tags'),
+	tagGroups: db.collection<TagGroup>('tagGroups'),
 	sliders: db.collection<Slider>('sliders'),
 	themes: db.collection<Theme>('themes'),
 	personalInfo: db.collection<PersonalInfo>('personalInfo'),

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -618,6 +618,35 @@ const migrations = [
 
 			console.log('Created default PoS payment subtype: Cash');
 		}
+	},
+	{
+		_id: new ObjectId('67558e01e92e590e858af9cd'),
+		name: 'Create default tag group for existing POS configurations',
+		run: async (session: ClientSession) => {
+			const existingGroups = await collections.tagGroups.countDocuments({}, { session });
+			if (existingGroups > 0) {
+				return;
+			}
+
+			const config = await collections.runtimeConfig.findOne({ _id: 'posTouchTag' }, { session });
+			const posTouchTag = (config?.data as string[]) ?? [];
+
+			if (posTouchTag.length === 0) {
+				return;
+			}
+
+			await collections.tagGroups.insertOne(
+				{
+					_id: new ObjectId().toHexString(),
+					name: 'All Tags',
+					tagIds: posTouchTag,
+					order: 0,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				},
+				{ session }
+			);
+		}
 	}
 ];
 

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -641,10 +641,17 @@
 		},
 		"vatFree": "Dies ist eine mehrwertsteuerfreie Bestellung (Bedingungen)",
 		"vatFreeReason": "Grund für Mehrwertsteuerbefreiung",
+		"tagGroups": {
+			"addGroup": "Gruppe hinzufügen",
+			"deleteGroup": "Gruppe löschen",
+			"groupNamePlaceholder": "Gruppenname",
+			"tooManyTagsWarning": "Die Gruppe \"{groupName}\" hat {count} Tags. Zu viele für den Button-Modus. Aktivieren Sie \"Auswahlmenü verwenden\" oder reduzieren Sie die Tags. Fortfahren?"
+		},
 		"touch": {
 			"selectTab": "Tab auswählen:",
 			"noTabs": "Diese Gruppe hat keine Tabs",
 			"cancel": "Abbrechen",
+			"back": "← Zurück",
 			"ticketNumber": "TICKET Nr.",
 			"exclVat": "oM",
 			"inclVat": "iM",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -642,10 +642,17 @@
 		},
 		"vatFree": "This is a VAT-free order (<0>conditions</0>)",
 		"vatFreeReason": "VAT-free reason",
+		"tagGroups": {
+			"addGroup": "Add Group",
+			"deleteGroup": "Delete Group",
+			"groupNamePlaceholder": "Group Name",
+			"tooManyTagsWarning": "Group \"{groupName}\" has {count} tags. Too many for button mode. Enable \"Use select menu\" option or reduce tags. Continue?"
+		},
 		"touch": {
 			"selectTab": "Select a tab:",
 			"noTabs": "This group has no tabs",
 			"cancel": "Cancel",
+			"back": "← Back",
 			"ticketNumber": "TICKET n°",
 			"exclVat": "EX",
 			"inclVat": "INC",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -641,10 +641,17 @@
 		},
 		"vatFree": "Esta compra es libre de IVA (<0>condiciones</0>)",
 		"vatFreeReason": "Razón de exención de IVA",
+		"tagGroups": {
+			"addGroup": "Agregar grupo",
+			"deleteGroup": "Eliminar grupo",
+			"groupNamePlaceholder": "Nombre del grupo",
+			"tooManyTagsWarning": "El grupo \"{groupName}\" tiene {count} etiquetas. Demasiadas para el modo de botones. Active la opción \"Usar menú de selección\" o reduzca las etiquetas. ¿Continuar?"
+		},
 		"touch": {
 			"selectTab": "Seleccionar una pestaña:",
 			"noTabs": "Este grupo no tiene pestañas",
 			"cancel": "Cancelar",
+			"back": "← Atrás",
 			"ticketNumber": "TICKET n°",
 			"exclVat": "SIN",
 			"inclVat": "CON",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -641,10 +641,17 @@
 		},
 		"vatFree": "Il s'agit d'une commande sans TVA (<0>conditions</0>)",
 		"vatFreeReason": "Motif hors TVA",
+		"tagGroups": {
+			"addGroup": "Ajouter un groupe",
+			"deleteGroup": "Supprimer le groupe",
+			"groupNamePlaceholder": "Nom du groupe",
+			"tooManyTagsWarning": "Le groupe \"{groupName}\" contient {count} étiquettes. Trop pour le mode bouton. Activez l'option \"Utiliser le menu de sélection\" ou réduisez les étiquettes. Continuer ?"
+		},
 		"touch": {
 			"selectTab": "Sélectionner un onglet :",
 			"noTabs": "Ce groupe n'a pas d'onglets",
 			"cancel": "Annuler",
+			"back": "← Retour",
 			"ticketNumber": "TICKET n°",
 			"exclVat": "HT",
 			"inclVat": "TTC",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -641,10 +641,17 @@
 		},
 		"vatFree": "Questo è un ordine esente da IVA (<0>conditions</0>)",
 		"vatFreeReason": "ragione dell'esenzione da IVA",
+		"tagGroups": {
+			"addGroup": "Aggiungi gruppo",
+			"deleteGroup": "Elimina gruppo",
+			"groupNamePlaceholder": "Nome del gruppo",
+			"tooManyTagsWarning": "Il gruppo \"{groupName}\" ha {count} tag. Troppi per la modalità pulsante. Attivare l'opzione \"Usa menu di selezione\" o ridurre i tag. Continuare?"
+		},
 		"touch": {
 			"selectTab": "Seleziona una scheda:",
 			"noTabs": "Questo gruppo non ha schede",
 			"cancel": "Annulla",
+			"back": "← Indietro",
 			"ticketNumber": "BIGLIETTO n°",
 			"exclVat": "NET",
 			"inclVat": "LOR",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -641,10 +641,17 @@
 		},
 		"vatFree": "Dit is een BTW-vrije bestelling (<0>voorwaarden</0>)",
 		"vatFreeReason": "BTW-vrije reden",
+		"tagGroups": {
+			"addGroup": "Groep toevoegen",
+			"deleteGroup": "Groep verwijderen",
+			"groupNamePlaceholder": "Groepsnaam",
+			"tooManyTagsWarning": "Groep \"{groupName}\" heeft {count} tags. Te veel voor knoppenmodus. Activeer \"Gebruik selectiemenu\" optie of verminder tags. Doorgaan?"
+		},
 		"touch": {
 			"selectTab": "Selecteer een tabblad:",
 			"noTabs": "Deze groep heeft geen tabbladen",
 			"cancel": "Annuleren",
+			"back": "← Terug",
 			"ticketNumber": "TICKET nr.",
 			"exclVat": "EX",
 			"inclVat": "INC",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -641,10 +641,17 @@
 		},
 		"vatFree": "Esta é uma encomenda isenta de IVA (condições)",
 		"vatFreeReason": "Motivo de isenção de IVA",
+		"tagGroups": {
+			"addGroup": "Adicionar grupo",
+			"deleteGroup": "Eliminar grupo",
+			"groupNamePlaceholder": "Nome do grupo",
+			"tooManyTagsWarning": "O grupo \"{groupName}\" tem {count} etiquetas. Demasiadas para o modo de botões. Ative a opção \"Usar menu de seleção\" ou reduza as etiquetas. Continuar?"
+		},
 		"touch": {
 			"selectTab": "Selecionar um separador:",
 			"noTabs": "Este grupo não tem separadores",
 			"cancel": "Cancelar",
+			"back": "← Voltar",
 			"ticketNumber": "BILHETE n°",
 			"exclVat": "SEM",
 			"inclVat": "COM",

--- a/src/lib/types/Tag.ts
+++ b/src/lib/types/Tag.ts
@@ -27,6 +27,7 @@ export interface Tag extends Timestamps, TagTranslatableFields {
 	reportingFilter: boolean;
 	printReceiptFilter: boolean;
 	cssOveride: string;
+	tagGroupId?: string;
 
 	translations?: Partial<Record<LanguageKey, Partial<TagTranslatableFields>>>;
 }

--- a/src/lib/types/TagGroup.ts
+++ b/src/lib/types/TagGroup.ts
@@ -1,0 +1,8 @@
+import type { Timestamps } from './Timestamps';
+
+export interface TagGroup extends Timestamps {
+	_id: string;
+	name: string;
+	tagIds: string[];
+	order: number;
+}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -155,6 +155,8 @@
 
 	$: hasNewItems = items.some((item) => item.quantity - (item.printedQuantity ?? 0) > 0);
 
+	let expandedGroupId: string | null = null;
+
 	let poolLabel = 'n° tmp';
 	$: {
 		const tabs = data.posTabGroups.flatMap((group, g) =>
@@ -514,33 +516,86 @@
 				{#if rightPanel === 'products'}
 					<div class="grid grid-cols-2 gap-4 text-3xl text-center">
 						{#if data.posUseSelectForTags}
-							<!-- Select menu mode -->
+							<!-- Dropdown mode -->
 							<div class="col-span-2">
 								<CategorySelect
 									tags={data.posTouchScreenTags}
+									tagGroups={data.tagGroups}
 									currentFilter={filter}
 									onSelect={handleCategorySelect}
 								/>
 							</div>
 						{:else}
-							<!-- Button mode (current) -->
+							<!-- Button mode -->
+							{@const shouldShowGroups = data.tagGroups.length >= 2}
+
 							<a
 								class="col-span-2 touchScreen-category-cta"
 								href={selfPageLink({ filter: 'pos-favorite', skip: 0 })}
-								>{t('pos.touch.favorites')}</a
 							>
-							{#each data.posTouchScreenTags as favoriteTag}
-								<a
-									class="touchScreen-category-cta"
-									href={selfPageLink({ filter: favoriteTag._id, skip: 0 })}>{favoriteTag.name}</a
-								>
-							{/each}
+								{t('pos.touch.favorites')}
+							</a>
+
+							{#if shouldShowGroups}
+								<!-- Group mode: collapse/expand -->
+								{#each data.tagGroups as group}
+									<button
+										type="button"
+										class="col-span-2 touchScreen-category-cta flex items-center justify-between px-6"
+										on:click={() => {
+											expandedGroupId = expandedGroupId === group._id ? null : group._id;
+										}}
+									>
+										<span>{group.name}</span>
+										<svg
+											class="w-8 h-8 transition-transform {expandedGroupId === group._id
+												? 'rotate-180'
+												: ''}"
+											xmlns="http://www.w3.org/2000/svg"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width="2"
+												d="M19 9l-7 7-7-7"
+											/>
+										</svg>
+									</button>
+
+									{#if expandedGroupId === group._id}
+										<div class="col-span-2 grid grid-cols-2 gap-4 mb-2">
+											{#each data.posTouchScreenTags.filter( (t) => group.tagIds.includes(t._id) ) as tag}
+												<a
+													class="touchScreen-category-cta"
+													href={selfPageLink({ filter: tag._id, skip: 0 })}
+												>
+													{tag.name}
+												</a>
+											{/each}
+										</div>
+									{/if}
+								{/each}
+							{:else}
+								<!-- Flat mode (0-1 groups) -->
+								{#each data.posTouchScreenTags as tag}
+									<a
+										class="touchScreen-category-cta"
+										href={selfPageLink({ filter: tag._id, skip: 0 })}
+									>
+										{tag.name}
+									</a>
+								{/each}
+							{/if}
+
 							<a
 								class="col-span-2 touchScreen-category-cta"
 								href={selfPageLink({ filter: 'all', skip: 0 })}
 							>
-								{t('pos.touch.allProducts')}</a
-							>
+								{t('pos.touch.allProducts')}
+							</a>
 						{/if}
 
 						<div class="col-span-2 grid grid-cols-2 gap-4">


### PR DESCRIPTION
POS touch interface now supports tag grouping for better product navigation.
Admins can organize tags into named groups (e.g., "Drinks", "Food", "Snacks").

Two display modes:
- Button mode: collapsible groups with expand/collapse
- Dropdown mode: two-level navigation (groups → tags)

Requires migration that converts existing flat tag config into default group.

Closes #2241