### PR TITLE
🐛 Fix serialization error in admin reporting with booking._id

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.server.ts
@@ -80,7 +80,13 @@ export async function load({ url }) {
 				product: {
 					...item.product,
 					vatProfileId: item.product.vatProfileId?.toString()
-				}
+				},
+				booking: item.booking
+					? {
+							...item.booking,
+							_id: item.booking._id.toString()
+					  }
+					: undefined
 			})),
 			billingAddress: order.billingAddress,
 			shippingAddress: order.shippingAddress,


### PR DESCRIPTION
Convert ObjectId to string to fix SvelteKit serialization error at /admin/reporting 