### PR TITLE
🦋 Add pool-level discount to POS Touch

### DIFF
--- a/src/lib/components/OrderSummary.svelte
+++ b/src/lib/components/OrderSummary.svelte
@@ -29,6 +29,7 @@
 				| 'depositPercentage'
 				| 'discountPercentage'
 				| 'freeQuantity'
+				| 'vatRate'
 			> & {
 				digitalFiles: Array<{ _id: string }>;
 				picture?: Picture;
@@ -63,6 +64,23 @@
 			p.currencySnapshot.main.price.amount < order.currencySnapshot.main.totalPrice.amount &&
 			(p.status === 'expired' || p.status === 'canceled')
 	);
+
+	// Calculate total discount from all items with discountPercentage
+	const calculateTotalDiscount = (currency: 'main' | 'secondary') =>
+		order.items.reduce((sum, item) => {
+			if (!item.discountPercentage || !item.currencySnapshot[currency]) {
+				return sum;
+			}
+			const priceWithoutVat = orderItemPriceUndiscounted(item, currency);
+			const priceWithVat = priceWithoutVat * (1 + item.vatRate / 100);
+			const discount = priceWithVat * (item.discountPercentage / 100);
+			return sum + discount;
+		}, 0);
+
+	$: totalDiscountAmount = calculateTotalDiscount('main');
+	$: totalDiscountAmountSecondary = order.currencySnapshot.secondary
+		? calculateTotalDiscount('secondary')
+		: 0;
 </script>
 
 <article
@@ -206,24 +224,40 @@
 		<div class="border-b border-gray-300 col-span-4" />
 	{/each}
 
-	{#if order?.discount}
+	{#if totalDiscountAmount > 0 || order?.discount}
 		<div class="flex justify-between items-center">
 			<h3 class="text-base flex items-center gap-2">
 				{t('order.discount.title')}
 			</h3>
 
 			<div class="flex flex-col ml-auto items-end justify-center">
-				{#if order.currencySnapshot.main.discount}
+				{#if order?.discount && order.currencySnapshot.main.discount}
+					<!-- Old discount mechanism (from /checkout) -->
 					<PriceTag
 						class="text-2xl truncate"
 						amount={order.currencySnapshot.main.discount.amount}
 						currency={order.currencySnapshot.main.discount.currency}
 					/>
+				{:else}
+					<!-- New discount mechanism (from POS pool via item.discountPercentage) -->
+					<PriceTag
+						class="text-2xl truncate"
+						amount={totalDiscountAmount}
+						currency={order.currencySnapshot.main.totalPrice.currency}
+					/>
 				{/if}
-				{#if order.currencySnapshot.secondary?.discount}
+				{#if order?.discount && order.currencySnapshot.secondary?.discount}
+					<!-- Old discount mechanism secondary currency -->
 					<PriceTag
 						amount={order.currencySnapshot.secondary.discount.amount}
 						currency={order.currencySnapshot.secondary.discount.currency}
+						class="text-base truncate"
+					/>
+				{:else if order.currencySnapshot.secondary && totalDiscountAmountSecondary > 0}
+					<!-- New discount mechanism secondary currency -->
+					<PriceTag
+						amount={totalDiscountAmountSecondary}
+						currency={order.currencySnapshot.secondary.totalPrice.currency}
 						class="text-base truncate"
 					/>
 				{/if}

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -706,6 +706,20 @@
 			"completeSharesFirst": "You have already started paying for the pool through \"Split (shares)\" payments. Please complete all payments and close the pool first. ",
 			"closePool": "Close pool",
 			"globalTicket": "Global ticket"
+		},
+		"discount": {
+			"title": "Discount",
+			"noDiscount": "No discount",
+			"manualPercent": "Manual %",
+			"manualPercentPlaceholder": "Enter percentage (0-100)",
+			"applyToTag": "Apply to tag :",
+			"allProducts": "All products",
+			"currentDiscount": "Current discount:",
+			"none": "None",
+			"motiveLabelOptional": "Discount motive (optional):",
+			"motivePlaceholder": "e.g., Passeport gourmand",
+			"lockedWarning": "⚠️ Cannot modify discount after payment has started",
+			"save": "Save"
 		}
 	},
 	"product": {

--- a/src/lib/types/Cart.ts
+++ b/src/lib/types/Cart.ts
@@ -26,6 +26,7 @@ export interface Cart extends Timestamps {
 		customPrice?: { amount: number; currency: Currency };
 		reservedUntil?: Date;
 		depositPercentage?: number;
+		discountPercentage?: number;
 		internalNote?: { value: string; updatedAt: Date; updatedById?: User['_id'] };
 		chosenVariations?: Record<string, string>;
 	}>;

--- a/src/lib/types/OrderTab.ts
+++ b/src/lib/types/OrderTab.ts
@@ -23,6 +23,11 @@ export interface OrderTab extends Timestamps {
 	items: Array<OrderTabItem>;
 	processedPayments?: string[];
 	printHistory?: PrintHistoryEntry[];
+	discount?: {
+		percentage: number;
+		tagId?: string;
+		motive?: string;
+	};
 }
 
 export interface OrderTabPoolStatus {

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -36,9 +36,9 @@
 	$: {
 		if (offerOrder) {
 			discountType = 'percentage';
-			discountAmount = 100;
+			discountAmount = 99;
 		} else {
-			if (discountType !== 'percentage' || discountAmount !== 100) {
+			if (discountType !== 'percentage' || discountAmount !== 99) {
 				offerOrder = false;
 			}
 		}
@@ -209,7 +209,7 @@
 	$: isDiscountValid =
 		(discountType === 'fiat' &&
 			priceInfo.totalPriceWithVat >= toSatoshis(discountAmount || 0, data.currencies.main)) ||
-		(discountType === 'percentage' && discountAmount <= 100);
+		(discountType === 'percentage' && discountAmount <= 99);
 	let showBillingInfo = false;
 	let isProfessionalOrder = false;
 	let changePaymentTimeOut = false;

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
@@ -76,7 +76,11 @@ async function hydratedOrderItems(
 }
 
 async function getHydratedOrderTab(locale: Locale, tab: OrderTab) {
-	return { slug: tab.slug, items: await hydratedOrderItems(locale, tab.items) };
+	return {
+		slug: tab.slug,
+		items: await hydratedOrderItems(locale, tab.items),
+		discount: tab.discount
+	};
 }
 
 export const load = async ({ depends, locals, params }) => {
@@ -255,7 +259,8 @@ export const actions = {
 						quantity: cartItem.quantity,
 						product,
 						internalNote: cartItem.internalNote,
-						chosenVariations: cartItem.chosenVariations
+						chosenVariations: cartItem.chosenVariations,
+						discountPercentage: cartItem.discountPercentage
 					};
 				});
 

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
@@ -518,12 +518,20 @@
 						{#if data.sharesOrder}
 							<div class="bg-gray-100 p-6 rounded-lg space-y-3">
 								<div class="text-3xl font-semibold">{t('pos.split.totalAlreadyPaid')}</div>
+								{#if tab.discount && tab.discount.percentage > 0}
+									<!-- Show strikethrough undiscounted price -->
+									<div class="text-3xl font-bold line-through text-gray-500">
+										<PriceTag
+											amount={originalTabTotalWithVat}
+											currency={UNDERLYING_CURRENCY}
+											main
+										/>
+									</div>
+								{/if}
 								<div class="text-4xl font-bold">
 									<PriceTag
-										amount={isPoolFullyPaid
-											? originalTabTotalWithVat
-											: data.sharesOrder.totalAlreadyPaid}
-										currency={isPoolFullyPaid ? UNDERLYING_CURRENCY : data.sharesOrder.currency}
+										amount={data.sharesOrder.totalAlreadyPaid}
+										currency={data.sharesOrder.currency}
 										main
 									/>
 								</div>


### PR DESCRIPTION
 - POS touch pools now support percentage-based discounts (e.g., Passeport Gourmand).
 - Staff can apply discounts via new DISCOUNT button, optionally filtering by tag (Food/Drinks).
 - Discount is locked after first payment and automatically applied at checkout.
 
 Closes #2247