### PR TITLE
🦋 Adapt order page for POS touchscreen interface

### DIFF
--- a/src/lib/components/Order/BankTransferPayment.svelte
+++ b/src/lib/components/Order/BankTransferPayment.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import type { SellerIdentity } from '$lib/types/SellerIdentity';
+	import { useI18n } from '$lib/i18n';
+
+	const { t } = useI18n();
+
+	export let payment: SerializedOrderPayment;
+	export let sellerIdentity: SellerIdentity | undefined = undefined;
+
+	$: bank = sellerIdentity?.bank;
+</script>
+
+{#if payment.status === 'pending'}
+	<ul class="payment-details-list">
+		{#if bank}
+			<li>
+				<strong>{t('order.paymentAccountHolder')}</strong>
+				<p class="body-secondaryText">{bank.accountHolder}</p>
+			</li>
+
+			{#if bank.accountHolderAddress}
+				<li>
+					<strong>{t('order.paymentAccountHolderAddress')}</strong>
+					<p class="body-secondaryText whitespace-pre-line">{bank.accountHolderAddress}</p>
+				</li>
+			{/if}
+
+			<li>
+				<strong>{t('order.paymentIban')}</strong>
+				<code class="break-all">
+					{bank.iban?.replace(/(.{4})/g, '$1 ')}
+				</code>
+			</li>
+
+			<li>
+				<strong>{t('order.paymentBic')}</strong>
+				<code>{bank.bic}</code>
+			</li>
+		{/if}
+	</ul>
+
+	<!-- Email seller button -->
+	{#if sellerIdentity?.contact.email}
+		<a href="mailto:{sellerIdentity.contact.email}" class="btn btn-black self-start">
+			{t('order.informSeller')}
+		</a>
+	{/if}
+{/if}

--- a/src/lib/components/Order/BitcoinPayment.svelte
+++ b/src/lib/components/Order/BitcoinPayment.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import IconCopy from '~icons/ant-design/copy-outlined';
+	import IconCheckmark from '~icons/ant-design/check-outlined';
+
+	export let payment: SerializedOrderPayment;
+
+	let copiedPaymentAddress = '';
+
+	async function copyAddress(address: string) {
+		await navigator.clipboard.writeText(address);
+		copiedPaymentAddress = address;
+		setTimeout(() => (copiedPaymentAddress = ''), 2000);
+	}
+</script>
+
+{#if payment.status === 'pending'}
+	<ul class="payment-details-list">
+		<li class="flex items-center gap-2">
+			<code class="break-all">{payment.address}</code>
+			<button type="button" class="p-1" on:click={() => copyAddress(payment.address ?? '')}>
+				{#if copiedPaymentAddress === payment.address}
+					<IconCheckmark class="w-5 h-5 text-green-500" />
+				{:else}
+					<IconCopy class="w-5 h-5" />
+				{/if}
+			</button>
+		</li>
+	</ul>
+{/if}

--- a/src/lib/components/Order/CardPayment.svelte
+++ b/src/lib/components/Order/CardPayment.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import { useI18n } from '$lib/i18n';
+	import IconSumupWide from '$lib/components/icons/IconSumupWide.svelte';
+	import IconStripe from '$lib/components/icons/IconStripe.svelte';
+
+	const { t } = useI18n();
+
+	export let payment: SerializedOrderPayment;
+	export let orderId: string;
+</script>
+
+{#if payment.status === 'pending'}
+	<a href="/order/{orderId}/payment/{payment.id}/pay" class="body-hyperlink">
+		<span>{t('order.paymentLink')}</span>
+		{#if payment.processor === 'sumup'}
+			<IconSumupWide class="h-12" />
+		{:else if payment.processor === 'stripe'}
+			<IconStripe class="h-12" />
+		{:else if payment.processor === 'paypal'}
+			<img
+				src="https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-200px.png"
+				alt="PayPal"
+				class="h-12"
+			/>
+		{/if}
+	</a>
+{/if}

--- a/src/lib/components/Order/LightningPayment.svelte
+++ b/src/lib/components/Order/LightningPayment.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import IconCopy from '~icons/ant-design/copy-outlined';
+	import IconCheckmark from '~icons/ant-design/check-outlined';
+
+	export let payment: SerializedOrderPayment;
+	export let posMode = false;
+
+	let copiedPaymentAddress = '';
+
+	async function copyAddress(address: string) {
+		await navigator.clipboard.writeText(address);
+		copiedPaymentAddress = address;
+		setTimeout(() => (copiedPaymentAddress = ''), 2000);
+	}
+</script>
+
+{#if payment.status === 'pending' && !posMode}
+	<ul class="payment-details-list">
+		<li class="flex items-center gap-2">
+			<code class="break-all">{payment.address}</code>
+			<button type="button" class="p-1" on:click={() => copyAddress(payment.address ?? '')}>
+				{#if copiedPaymentAddress === payment.address}
+					<IconCheckmark class="w-5 h-5 text-green-500" />
+				{:else}
+					<IconCopy class="w-5 h-5" />
+				{/if}
+			</button>
+		</li>
+	</ul>
+{/if}

--- a/src/lib/components/Order/PayPalPayment.svelte
+++ b/src/lib/components/Order/PayPalPayment.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import { useI18n } from '$lib/i18n';
+
+	const { t } = useI18n();
+
+	export let payment: SerializedOrderPayment;
+	export let orderId: string;
+</script>
+
+{#if payment.status === 'pending'}
+	<a
+		href="/order/{orderId}/payment/{payment.id}/pay"
+		class="paypal-payment-link body-hyperlink flex items-center gap-2"
+	>
+		<img
+			src="https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-200px.png"
+			alt="PayPal"
+			class="h-12"
+		/>
+		<span class="paypal-text-normal">{t('order.paymentLink')}</span>
+		<span class="paypal-text-pos">{t('pos.touch.pay')}</span>
+	</a>
+{/if}
+
+<style>
+	/* Hide POS text by default, show normal */
+	.paypal-text-pos {
+		display: none;
+	}
+
+	/* In POS mode: hide normal, show POS text as black button */
+	:global(.pos-mode) .paypal-payment-link {
+		text-decoration: none;
+	}
+	:global(.pos-mode) .paypal-text-pos {
+		display: inline-block;
+		background-color: black;
+		color: white;
+		padding: 0.5rem 1rem;
+		border-radius: 0.375rem;
+	}
+
+	:global(.pos-mode) .paypal-text-normal {
+		display: none;
+	}
+</style>

--- a/src/lib/components/Order/PaymentActions.svelte
+++ b/src/lib/components/Order/PaymentActions.svelte
@@ -1,0 +1,271 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import { useI18n } from '$lib/i18n';
+	import PaymentForm from './PaymentForm.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
+
+	const { t } = useI18n();
+
+	export let payment: SerializedOrderPayment;
+	export let orderId: string;
+	export let orderStaffActionBaseUrl: string;
+	export let roleIsStaff: boolean;
+	export let paymentMethods: string[];
+	export let posSubtypes:
+		| Array<{ slug: string; name: string; paymentDetailRequired?: boolean }>
+		| undefined = undefined;
+	export let posMode = false;
+	export let tapToPayConfigured = false;
+	export let tapToPayInUseByOtherOrder = false;
+	export let printReceipt: () => void;
+	export let printTicket: () => void;
+	export let receiptReady = false;
+	export let ticketReady = false;
+
+	let openPaymentMethodChange = false;
+	let disableInfoChange = true;
+
+	$: tapToPayInProgress = payment.posTapToPay && payment.posTapToPay.expiresAt > new Date();
+	$: posSubtype =
+		payment.method === 'point-of-sale' && payment.posSubtype
+			? posSubtypes?.find((s) => s.slug === payment.posSubtype)
+			: null;
+	$: detailRequired = posSubtype?.paymentDetailRequired ?? false;
+
+	$: showProforma = payment.status !== 'paid';
+	$: showInvoice = payment.status === 'paid' && payment.invoice?.number;
+
+	function confirmCancel(event: Event) {
+		if (!confirm(t('order.confirmCancel'))) {
+			event.preventDefault();
+		}
+	}
+</script>
+
+<!-- Receipt buttons -->
+<div class="receipt-buttons flex flex-col gap-1">
+	{#if showProforma && roleIsStaff}
+		<button
+			class="body-hyperlink self-start"
+			type="button"
+			disabled={!receiptReady}
+			on:click={printReceipt}
+		>
+			Print receipt (A4)
+		</button>
+		<button
+			class="body-hyperlink self-start"
+			type="button"
+			disabled={!ticketReady}
+			on:click={printTicket}
+		>
+			Print receipt (ticket)
+		</button>
+	{/if}
+
+	{#if showProforma && !roleIsStaff}
+		<button
+			class="body-hyperlink self-start"
+			type="button"
+			disabled={!receiptReady}
+			on:click={printReceipt}
+		>
+			{t('order.receipt.createProforma')}
+		</button>
+	{/if}
+
+	{#if showInvoice && roleIsStaff}
+		<button
+			class="btn btn-black self-start"
+			type="button"
+			disabled={!receiptReady}
+			on:click={printReceipt}
+		>
+			Print receipt (A4)
+		</button>
+		<button
+			class="btn btn-black self-start"
+			type="button"
+			disabled={!ticketReady}
+			on:click={printTicket}
+		>
+			Print receipt (ticket)
+		</button>
+	{/if}
+
+	{#if showInvoice && !roleIsStaff}
+		<button
+			class="btn btn-black self-start"
+			type="button"
+			disabled={!receiptReady}
+			on:click={printReceipt}
+		>
+			{t('order.receipt.create')}
+		</button>
+	{/if}
+</div>
+
+<!-- Other actions (Cancel, Confirm, Replace, etc) -->
+<div class="other-actions flex flex-col gap-2">
+	<!-- Failed payment - customer re-attempt -->
+	{#if payment.status === 'failed' && !roleIsStaff}
+		<p class="text-red-500">{t('order.paymentCBFailed')}</p>
+		<PaymentForm
+			action="/order/{orderId}/payment/{payment.id}?/replaceMethod"
+			mode="replace"
+			{payment}
+			{paymentMethods}
+			{posSubtypes}
+			{posMode}
+		/>
+	{/if}
+
+	<!-- Pending payment - staff actions -->
+	{#if payment.status === 'pending' && roleIsStaff}
+		{#if tapToPayInProgress}
+			<!-- Tap to Pay in progress -->
+			<form
+				action="{orderStaffActionBaseUrl}/payment/{payment.id}?/cancelTapToPay"
+				method="post"
+				class="flex flex-col gap-2"
+			>
+				<button type="submit" class="btn btn-green" disabled>
+					{posMode ? t('pos.btn.tapToPay') : 'Tap to pay'}
+				</button>
+				<p>{t('pos.tapToPay.inProgress')}</p>
+				<Spinner class="w-36" />
+			</form>
+		{:else}
+			<!-- Hidden form targets -->
+			<form
+				action="{orderStaffActionBaseUrl}/payment/{payment.id}?/cancel"
+				method="post"
+				id="cancelForm-{payment.id}"
+			></form>
+			<form
+				action="{orderStaffActionBaseUrl}/payment/{payment.id}?/tapToPay"
+				method="post"
+				id="tapToPayForm-{payment.id}"
+			></form>
+
+			<!-- Main confirmation form -->
+			<form
+				action="{orderStaffActionBaseUrl}/payment/{payment.id}?/confirm"
+				method="post"
+				class="flex flex-wrap gap-2"
+				id="confirmForm-{payment.id}"
+			>
+				<!-- Bank transfer input -->
+				{#if payment.method === 'bank-transfer'}
+					<input
+						class="form-input w-auto"
+						type="text"
+						name="bankTransferNumber"
+						required
+						placeholder={posMode ? t('pos.input.txNumber') : 'Bank transfer number'}
+					/>
+				{/if}
+
+				<!-- POS detail input -->
+				{#if payment.method === 'point-of-sale'}
+					<input
+						class="form-input grow mx-2"
+						type="text"
+						name="detail"
+						required={detailRequired}
+						placeholder={posMode
+							? t('pos.input.detail')
+							: 'Detail (card transaction ID, or point-of-sale payment method)'}
+					/>
+				{/if}
+			</form>
+
+			<!-- Unified button container (POS mode = grid, normal = flex) -->
+			<div class="flex flex-wrap gap-2 unified-buttons">
+				<!-- Cancel button -->
+				<button
+					type="submit"
+					class="btn btn-red"
+					form="cancelForm-{payment.id}"
+					on:click={confirmCancel}
+				>
+					{t(posMode ? 'pos.btn.cancel' : 'pos.cta.cancelOrder')}
+				</button>
+
+				<!-- Mark paid button (POS + bank-transfer only) -->
+				{#if payment.method === 'point-of-sale' || payment.method === 'bank-transfer'}
+					<button type="submit" class="btn btn-black" form="confirmForm-{payment.id}">
+						{t(posMode ? 'pos.btn.paid' : 'pos.cta.markOrderPaid')}
+					</button>
+				{/if}
+
+				<!-- Tap to Pay button (POS only) -->
+				{#if payment.method === 'point-of-sale'}
+					{#if tapToPayInUseByOtherOrder}
+						<p class="text-red-500 w-full">{t('pos.tapToPay.inUseByOtherOrder')}</p>
+					{:else if tapToPayConfigured && payment.posSubtypeHasProcessor}
+						<button type="submit" form="tapToPayForm-{payment.id}" class="btn btn-green">
+							{posMode ? t('pos.btn.tapToPay') : 'Tap to pay'}
+						</button>
+					{/if}
+				{/if}
+
+				<!-- Change/Replace button -->
+				<button
+					type="button"
+					class="btn {openPaymentMethodChange ? 'btn-gray' : 'btn-blue'}"
+					on:click={() => (openPaymentMethodChange = !openPaymentMethodChange)}
+				>
+					{openPaymentMethodChange
+						? t('pos.cta.cancelReplacement')
+						: t(posMode ? 'pos.btn.replace' : 'pos.cta.replacePayment')}
+				</button>
+			</div>
+
+			<!-- Expanded payment form -->
+			{#if openPaymentMethodChange}
+				<PaymentForm
+					action="/order/{orderId}/payment/{payment.id}?/replaceMethod"
+					mode="replace"
+					{payment}
+					{paymentMethods}
+					{posSubtypes}
+					{posMode}
+				/>
+			{/if}
+		{/if}
+	{/if}
+
+	<!-- Paid payment detail editor (staff only, POS + bank-transfer) -->
+	{#if payment.status === 'paid' && roleIsStaff && (payment.method === 'point-of-sale' || payment.method === 'bank-transfer')}
+		<form
+			action="{orderStaffActionBaseUrl}/payment/{payment.id}?/updatePaymentDetail"
+			method="post"
+			class="flex flex-wrap gap-2 items-center"
+		>
+			<input
+				class="form-input"
+				type="text"
+				name={payment.method === 'bank-transfer' ? 'bankTransferNumber' : 'detail'}
+				value={payment.method === 'bank-transfer' ? payment.bankTransferNumber : payment.detail}
+				disabled={disableInfoChange}
+			/>
+			<button type="submit" class="btn btn-blue" disabled={disableInfoChange}>
+				{t('pos.cta.updatePaymentInfo')}
+			</button>
+			<label class="flex items-center gap-1">
+				<input type="checkbox" bind:checked={disableInfoChange} />
+				🔐
+			</label>
+		</form>
+	{/if}
+</div>
+
+<style>
+	/* Grid layout for buttons ONLY in POS mode */
+	:global(.pos-mode) .unified-buttons {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.5rem;
+	}
+</style>

--- a/src/lib/components/Order/PaymentForm.svelte
+++ b/src/lib/components/Order/PaymentForm.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import { useI18n } from '$lib/i18n';
+
+	const { t } = useI18n();
+
+	export let action: string;
+	export let mode: 'add' | 'replace';
+	export let payment: SerializedOrderPayment | undefined = undefined;
+	export let paymentMethods: string[];
+	export let posSubtypes: Array<{ slug: string; name: string }> | undefined = undefined;
+	export let maxAmount: number | undefined = undefined;
+	export let posMode = false;
+
+	let selectedMethod = paymentMethods[0] || 'card';
+	let selectedSubtype = posSubtypes?.[0]?.slug || '';
+
+	$: amount = payment?.price.amount || maxAmount || 0;
+	$: currency = payment?.price.currency || 'CHF';
+
+	// Short labels for POS
+	$: amountLabel = posMode ? t('pos.label.amount') : t('order.addPayment.amount');
+	$: methodLabel = posMode ? t('pos.label.method') : t('checkout.payment.method');
+	$: submitText =
+		mode === 'add'
+			? posMode
+				? t('pos.btn.add')
+				: t('order.addPayment.submit')
+			: posMode
+			? t('pos.btn.replaceSubmit')
+			: t('pos.cta.resendPaymentMethod');
+</script>
+
+<form {action} method="post" class="flex flex-col gap-2">
+	<!-- Amount input -->
+	<label>
+		{amountLabel}
+		<input
+			type="number"
+			name="amount"
+			class="form-input"
+			value={amount}
+			max={maxAmount}
+			disabled={mode === 'replace'}
+			required
+		/>
+	</label>
+
+	<!-- Currency select -->
+	<label>
+		{posMode ? t('pos.label.currency') : t('order.addPayment.currency')}
+		<select name="currency" class="form-input" disabled>
+			<option value={currency}>{currency}</option>
+		</select>
+	</label>
+
+	<!-- Payment method select -->
+	<label>
+		{methodLabel}
+		<select name="method" class="form-input" bind:value={selectedMethod} required>
+			{#each paymentMethods as method}
+				<option value={method}>
+					{t(`checkout.paymentMethod.${method}`)}
+				</option>
+			{/each}
+		</select>
+	</label>
+
+	<!-- POS subtype (conditional) -->
+	{#if selectedMethod === 'point-of-sale' && posSubtypes?.length}
+		<label>
+			{posMode ? t('pos.label.subtype') : t('order.addPayment.posSubtype')}
+			<select name="posSubtype" class="form-input" bind:value={selectedSubtype} required>
+				{#each posSubtypes as subtype}
+					<option value={subtype.slug}>{subtype.name}</option>
+				{/each}
+			</select>
+		</label>
+	{/if}
+
+	<!-- Submit button -->
+	<button type="submit" class="btn btn-blue">
+		{submitText}
+	</button>
+</form>

--- a/src/lib/components/Order/PaymentItem.svelte
+++ b/src/lib/components/Order/PaymentItem.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import type { SellerIdentity } from '$lib/types/SellerIdentity';
+	import CardPayment from './CardPayment.svelte';
+	import BitcoinPayment from './BitcoinPayment.svelte';
+	import LightningPayment from './LightningPayment.svelte';
+	import BankTransferPayment from './BankTransferPayment.svelte';
+	import PointOfSalePayment from './PointOfSalePayment.svelte';
+	import PayPalPayment from './PayPalPayment.svelte';
+	import PaymentQRCodes from './PaymentQRCodes.svelte';
+
+	import { useI18n } from '$lib/i18n';
+	import PriceTag from '$lib/components/PriceTag.svelte';
+
+	const { t } = useI18n();
+
+	export let payment: SerializedOrderPayment;
+	export let orderId: string;
+	export let posMode = false;
+	export let hideCreditCardQrCode: boolean | undefined = undefined;
+	export let sellerIdentity: SellerIdentity | null | undefined = undefined;
+	export let posSubtypes: Array<{ slug: string; name: string }> | undefined = undefined;
+
+	// Registry of dynamic components
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const paymentComponents: Record<string, any> = {
+		card: CardPayment,
+		bitcoin: BitcoinPayment,
+		lightning: LightningPayment,
+		'bank-transfer': BankTransferPayment,
+		'point-of-sale': PointOfSalePayment,
+		paypal: PayPalPayment
+	};
+</script>
+
+<details
+	class="payment-item border border-gray-300 rounded-xl p-4"
+	open={posMode || payment.status === 'pending'}
+>
+	<summary class="lg:text-xl cursor-pointer">
+		<span class="items-center inline-flex gap-2">
+			{t(`checkout.paymentMethod.${payment.method}`)}
+
+			{#if payment.method === 'point-of-sale' && payment.posSubtype}
+				{@const subtype = posSubtypes?.find((s) => s.slug === payment.posSubtype)}
+				<span class="text-sm text-gray-600">
+					({subtype?.name || payment.posSubtype})
+				</span>
+			{/if}
+
+			- <PriceTag
+				inline
+				class="break-words {payment.status === 'paid' ? 'text-green-500' : 'body-secondaryText'}"
+				amount={payment.price.amount}
+				currency={payment.price.currency}
+			/>
+			- {t(`order.paymentStatus.${payment.status}`)}
+		</span>
+	</summary>
+
+	<div class="payment-content flex flex-col gap-2 mt-2">
+		<!-- Dynamic component by payment method -->
+		{#if payment.method !== 'point-of-sale' && paymentComponents[payment.method]}
+			<svelte:component
+				this={paymentComponents[payment.method]}
+				{payment}
+				{orderId}
+				{sellerIdentity}
+				{posMode}
+			/>
+		{:else if payment.method === 'point-of-sale'}
+			<PointOfSalePayment />
+		{/if}
+
+		<!-- Actions (order controlled by CSS) -->
+		<slot />
+
+		<!-- QR codes -->
+		{#if payment.status === 'pending'}
+			<div class="qr-codes">
+				<PaymentQRCodes {payment} {hideCreditCardQrCode} />
+			</div>
+		{/if}
+	</div>
+</details>
+
+<style>
+	/* POS mode: Receipt buttons BEFORE QR */
+	:global(.pos-mode) .payment-content :global(.receipt-buttons) {
+		order: 1;
+	}
+	:global(.pos-mode) .payment-content .qr-codes {
+		order: 2;
+	}
+	:global(.pos-mode) .payment-content :global(.other-actions) {
+		order: 3;
+	}
+</style>

--- a/src/lib/components/Order/PaymentQRCodes.svelte
+++ b/src/lib/components/Order/PaymentQRCodes.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { SerializedOrderPayment } from '$lib/types/Order';
+	import { page } from '$app/stores';
+	import { lightningPaymentQrCodeString } from '$lib/types/Order';
+	import { useI18n } from '$lib/i18n';
+
+	const { t } = useI18n();
+
+	export let payment: SerializedOrderPayment;
+	export let hideCreditCardQrCode: boolean | undefined = undefined;
+</script>
+
+{#if payment.status === 'pending'}
+	<!-- Lightning QR -->
+	{#if payment.method === 'lightning'}
+		<a href={lightningPaymentQrCodeString(payment.address ?? '')}>
+			<img src="{$page.url.pathname}/payment/{payment.id}/qrcode" class="w-96 h-96" alt="QR code" />
+		</a>
+	{/if}
+
+	<!-- Card QR (if not hidden) -->
+	{#if payment.method === 'card' && !hideCreditCardQrCode}
+		<img src="{$page.url.pathname}/payment/{payment.id}/qrcode" class="w-96 h-96" alt="QR code" />
+	{/if}
+
+	<!-- Bitcoin QR -->
+	{#if payment.method === 'bitcoin'}
+		<a href="bitcoin:{payment.address}?amount={payment.currencySnapshot?.main?.price?.amount}">
+			<img src="{$page.url.pathname}/payment/{payment.id}/qrcode" class="w-96 h-96" alt="QR code" />
+		</a>
+		<p class="text-sm text-gray-600">
+			{t('order.clickQR')}
+		</p>
+	{/if}
+
+	<!-- Payment instruction text -->
+	{#if payment.method !== 'point-of-sale'}
+		<div class="payment-instruction">
+			<p>{t('order.payToComplete')}</p>
+			{#if payment.method === 'bitcoin'}
+				<p>{t('order.payToCompleteBitcoin', { count: payment.confirmationBlocksRequired })}</p>
+			{/if}
+		</div>
+	{/if}
+{/if}

--- a/src/lib/components/Order/PointOfSalePayment.svelte
+++ b/src/lib/components/Order/PointOfSalePayment.svelte
@@ -1,0 +1,3 @@
+<script lang="ts">
+	// Placeholder component for POS payments - no UI needed
+</script>

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -452,7 +452,10 @@
 		"addPayment": {
 			"amount": "Payment amount",
 			"cta": "Send a call for payment",
-			"currency": "Payment currency"
+			"currency": "Payment currency",
+			"posSubtype": "Type",
+			"submit": "Add",
+			"title": "Add payment"
 		},
 		"backToOrder": "<< Back to order",
 		"clickQR": "Click on the QR code to pay with your wallet",
@@ -706,6 +709,25 @@
 			"completeSharesFirst": "You have already started paying for the pool through \"Split (shares)\" payments. Please complete all payments and close the pool first. ",
 			"closePool": "Close pool",
 			"globalTicket": "Global ticket"
+		},
+		"btn": {
+			"add": "Add",
+			"cancel": "Cancel",
+			"paid": "Paid",
+			"replace": "Change ▾",
+			"replaceSubmit": "Change",
+			"tapToPay": "Card Tap",
+			"cancelTap": "Stop Tap"
+		},
+		"input": {
+			"txNumber": "TX #",
+			"detail": "Detail"
+		},
+		"label": {
+			"amount": "Amount",
+			"currency": "Currency",
+			"method": "Method",
+			"subtype": "Type"
 		},
 		"discount": {
 			"title": "Discount",

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -162,6 +162,13 @@ export interface OrderPayment {
 	detail?: string;
 }
 
+export type SerializedOrderPayment = Omit<OrderPayment, '_id'> & {
+	id: string;
+	tapToPayOnActivationUrl?: string;
+	posSubtypeHasProcessor?: boolean;
+	confirmationBlocksRequired: number;
+};
+
 export const FAKE_ORDER_INVOICE_NUMBER = -1;
 
 export interface OrderAddress {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -37,6 +37,12 @@
 
 	export let data;
 
+	// Hide header/footer in POS mode on specific routes
+	$: hideHeaderFooter =
+		data.hasPosOptions &&
+		['/pos', '/order', '/checkout'].some((path) => $page.url.pathname.startsWith(path)) &&
+		$page.url.searchParams.get('returnTo')?.startsWith('/pos/touch');
+
 	let topMenuOpen = false;
 	let navMenuOpen = false;
 
@@ -135,7 +141,7 @@
 	{#if $page.data.layoutReset || $page.url.searchParams.get('display') === 'headless'}
 		<slot />
 	{:else}
-		<header class="header items-center flex h-[100px] print:hidden">
+		<header class="header items-center flex h-[100px] print:hidden" class:hidden={hideHeaderFooter}>
 			<div class="mx-auto max-w-7xl flex items-center gap-6 px-6 grow">
 				<a class="flex items-center gap-4" href="/">
 					{#if data.logoPicture}
@@ -183,6 +189,7 @@
 			<nav
 				transition:slide
 				class="header print:hidden header-tab flex flex-col lg:hidden text-[22px] font-semibold border-x-0 border-b-0 border-opacity-25 border-t-1 border-white px-10 py-4"
+				class:hidden={hideHeaderFooter}
 			>
 				{#each data.links.topbar as link}
 					<a
@@ -196,7 +203,7 @@
 				{/each}
 			</nav>
 		{/if}
-		<header class="navbar h-[66px] items-center flex print:hidden">
+		<header class="navbar h-[66px] items-center flex print:hidden" class:hidden={hideHeaderFooter}>
 			<div class="mx-auto max-w-7xl flex items-center gap-6 px-6 grow">
 				<nav class="flex gap-6 font-light items-center">
 					<button
@@ -547,7 +554,7 @@
 			</div>
 		{/if}
 
-		<footer class="footer h-auto items-center flex print:hidden">
+		<footer class="footer h-auto items-center flex print:hidden" class:hidden={hideHeaderFooter}>
 			<div
 				class="mx-auto max-w-7xl px-6 py-6 items-start justify-between gap-y-8 w-full grid grid-cols-1 lg:flex lg:flex-wrap gap-4"
 			>

--- a/src/routes/(app)/order/[id]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/+page.server.ts
@@ -11,7 +11,7 @@ import { runtimeConfig } from '$lib/server/runtime-config.js';
 import { paymentMethods } from '$lib/server/payment-methods.js';
 import type { OrderLabel } from '$lib/types/OrderLabel.js';
 
-export async function load({ params, depends, locals }) {
+export async function load({ params, depends, locals, url }) {
 	depends(UrlDependency.Order);
 
 	const order = await fetchOrderForUser(params.id, { userRoleId: locals.user?.roleId });
@@ -93,12 +93,17 @@ export async function load({ params, depends, locals }) {
 		paymentDetailRequired: subtype.paymentDetailRequired
 	}));
 
+	const returnTo = url.searchParams.get('returnTo');
+	const posMode = locals.user?.hasPosOptions && returnTo?.startsWith('/pos/touch');
+
 	return {
 		order,
 		splitMode: order.splitMode,
 		paymentMethods: methods,
 		tapToPay,
 		posSubtypes,
+		posMode: posMode,
+		hasPosOptions: locals.user?.hasPosOptions,
 		digitalFiles: Promise.all(
 			digitalFiles.map(async (file) => ({
 				name: file.name,

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -1,44 +1,28 @@
 <script lang="ts">
 	import { invalidate } from '$app/navigation';
 	import { navigating, page } from '$app/stores';
-	import OrderSummary from '$lib/components/OrderSummary.svelte';
-	import PriceTag from '$lib/components/PriceTag.svelte';
-	import Trans from '$lib/components/Trans.svelte';
-	import IconCopy from '~icons/ant-design/copy-outlined';
-	import IconCheckmark from '~icons/ant-design/check-outlined';
-	import { useI18n } from '$lib/i18n';
-	import {
-		bitcoinPaymentQrCodeString,
-		FAKE_ORDER_INVOICE_NUMBER,
-		lightningPaymentQrCodeString,
-		orderAmountWithNoPaymentsCreated
-	} from '$lib/types/Order';
-	import { UrlDependency } from '$lib/types/UrlDependency';
-	import { CUSTOMER_ROLE_ID } from '$lib/types/User.js';
-	import { differenceInMinutes } from 'date-fns';
 	import { onMount } from 'svelte';
-	import IconSumupWide from '$lib/components/icons/IconSumupWide.svelte';
-	import CmsDesign from '$lib/components/CmsDesign.svelte';
+	import OrderSummary from '$lib/components/OrderSummary.svelte';
+	import Trans from '$lib/components/Trans.svelte';
 	import Picture from '$lib/components/Picture.svelte';
-	import IconStripe from '$lib/components/icons/IconStripe.svelte';
+	import OrderLabelComponent from '$lib/components/OrderLabelComponent.svelte';
+	import CmsDesign from '$lib/components/CmsDesign.svelte';
 	import IconDownloadWindow from '$lib/components/icons/IconDownloadWindow.svelte';
 	import IconExternalNewWindowOpen from '$lib/components/icons/IconExternalNewWindowOpen.svelte';
-	import OrderLabelComponent from '$lib/components/OrderLabelComponent.svelte';
-	import Spinner from '$lib/components/Spinner.svelte';
-	import { browser } from '$app/environment';
+	import PaymentItem from '$lib/components/Order/PaymentItem.svelte';
+	import PaymentActions from '$lib/components/Order/PaymentActions.svelte';
+	import PaymentForm from '$lib/components/Order/PaymentForm.svelte';
+	import { useI18n } from '$lib/i18n';
+	import { FAKE_ORDER_INVOICE_NUMBER, orderAmountWithNoPaymentsCreated } from '$lib/types/Order';
+	import { UrlDependency } from '$lib/types/UrlDependency';
+	import { CUSTOMER_ROLE_ID } from '$lib/types/User.js';
 
-	let currentDate = new Date();
 	export let data;
 
 	let count = 0;
-	let copiedPaymentAddress = -1;
-	let selectedPaymentMethod: string = data.paymentMethods[0] || 'card';
-	let replacePaymentMethod: string = data.paymentMethods[0] || 'card';
 
 	onMount(() => {
 		const interval = setInterval(() => {
-			currentDate = new Date();
-
 			if ($navigating) {
 				return;
 			}
@@ -64,18 +48,18 @@
 	let receiptReady: Record<string, boolean> = Object.fromEntries(
 		data.order.payments.map((payment) => [payment.id, false])
 	);
-	let ticketIframe: HTMLIFrameElement | null = null;
-	let ticketReady = false;
+	let ticketIFrame: Record<string, HTMLIFrameElement | null> = Object.fromEntries(
+		data.order.payments.map((payment) => [payment.id, null])
+	);
+	let ticketReady: Record<string, boolean> = Object.fromEntries(
+		data.order.payments.map((payment) => [payment.id, false])
+	);
+	let ticketsIframe: HTMLIFrameElement | null = null;
+	let ticketsReady = false;
 
 	$: remainingAmount = orderAmountWithNoPaymentsCreated(data.order, {
 		ignorePendingPayments: true
 	});
-	let disableInfoChange = true;
-	function confirmCancel(event: Event) {
-		if (!confirm(t('order.confirmCancel'))) {
-			event.preventDefault();
-		}
-	}
 	function confirmCancelOrder(event: Event) {
 		if (!confirm(t('pos.cancelOrderMessage'))) {
 			event.preventDefault();
@@ -84,65 +68,69 @@
 
 	let tickets = data.order.items.flatMap((item) => item.tickets ?? []);
 	let ticketNumbers = Object.fromEntries(tickets.map((ticket, i) => [ticket, i + 1]));
-	let openPaymentMethodChange = false;
-	let filteredPaymentMethods = data.paymentMethods.filter((pm) =>
-		['card', 'bitcoin', 'lightning', 'paypal'].includes(pm)
-	);
 	$: labelById = data.labels
 		? Object.fromEntries(data.labels.map((label) => [label._id, label]))
 		: undefined;
 
-	function isMobile() {
-		return browser && window.matchMedia('(max-width: 767px)').matches;
-	}
 	const roleIsStaff = !!data.roleId && data.roleId !== CUSTOMER_ROLE_ID;
-	const orderStaffActionBaseUrl = data.hasPosOptions
+	const orderStaffActionBaseUrl = data.posMode
 		? `/pos/order/${data.order._id}`
 		: `/admin/order/${data.order._id}`;
 </script>
 
-<main class="mx-auto max-w-7xl py-10 px-6 body-mainPlan">
-	{#if data.cmsOrderTop && data.cmsOrderTopData}
-		<CmsDesign
-			challenges={data.cmsOrderTopData.challenges}
-			tokens={data.cmsOrderTopData.tokens}
-			sliders={data.cmsOrderTopData.sliders}
-			products={data.cmsOrderTopData.products}
-			pictures={data.cmsOrderTopData.pictures}
-			tags={data.cmsOrderTopData.tags}
-			digitalFiles={data.cmsOrderTopData.digitalFiles}
-			hasPosOptions={data.hasPosOptions}
-			specifications={data.cmsOrderTopData.specifications}
-			contactForms={data.cmsOrderTopData.contactForms}
-			pageName={data.cmsOrderTop.title}
-			websiteLink={data.websiteLink}
-			brandName={data.brandName}
-			sessionEmail={data.email}
-			countdowns={data.cmsOrderTopData.countdowns}
-			galleries={data.cmsOrderTopData.galleries}
-			leaderboards={data.cmsOrderTopData.leaderboards}
-			schedules={data.cmsOrderTopData.schedules}
-			class={data.hideCmsZonesOnMobile ? 'prose max-w-full hidden lg:contents' : 'prose max-w-full'}
-		/>
-	{/if}
+<main class="mx-auto max-w-7xl py-10 px-6 body-mainPlan" class:pos-mode={data.posMode}>
+	<!-- ==================== CMS TOP SECTION ==================== -->
+	<div class="cms-section-top">
+		{#if data.cmsOrderTop && data.cmsOrderTopData}
+			<CmsDesign
+				challenges={data.cmsOrderTopData.challenges}
+				tokens={data.cmsOrderTopData.tokens}
+				sliders={data.cmsOrderTopData.sliders}
+				products={data.cmsOrderTopData.products}
+				pictures={data.cmsOrderTopData.pictures}
+				tags={data.cmsOrderTopData.tags}
+				digitalFiles={data.cmsOrderTopData.digitalFiles}
+				hasPosOptions={data.hasPosOptions}
+				specifications={data.cmsOrderTopData.specifications}
+				contactForms={data.cmsOrderTopData.contactForms}
+				pageName={data.cmsOrderTop.title}
+				websiteLink={data.websiteLink}
+				brandName={data.brandName}
+				sessionEmail={data.email}
+				countdowns={data.cmsOrderTopData.countdowns}
+				galleries={data.cmsOrderTopData.galleries}
+				leaderboards={data.cmsOrderTopData.leaderboards}
+				schedules={data.cmsOrderTopData.schedules}
+				class={data.hideCmsZonesOnMobile
+					? 'prose max-w-full hidden lg:contents'
+					: 'prose max-w-full'}
+			/>
+		{/if}
+	</div>
+
+	<!-- ==================== MAIN CONTAINER ==================== -->
 	<div
 		class="w-full rounded-xl body-mainPlan border-gray-300 lg:p-6 p-2 lg:grid lg:grid-cols-3 sm:flex-wrap gap-2 flex-col-reverse"
 	>
+		<!-- Back to cart link (only in headless display mode) -->
 		<div
 			class="flex justify-start {$page.url.searchParams.get('display') === 'headless'
 				? ''
 				: 'hidden'}"
 		>
-			<a href="/pos/touch" class="body-hyperlink hover:underline"
-				>&lt;&lt;{t('checkout.backToCart')}</a
-			>
+			<a href="/pos/touch" class="body-hyperlink hover:underline">
+				&lt;&lt;{t('checkout.backToCart')}
+			</a>
 		</div>
+
+		<!-- ==================== LEFT COLUMN  ==================== -->
 		<div class="col-span-2 flex flex-col gap-2">
 			<h1 class="text-3xl body-title">
 				{t('order.singleTitle', { number: data.order.number })}
 			</h1>
+
 			{#if roleIsStaff}
-				<div class="flex flex-row gap-1">
+				<div class="order-labels flex flex-row gap-1">
 					{#if data.order.orderLabelIds?.length && labelById}
 						{#each data.order.orderLabelIds as labelId}
 							<OrderLabelComponent orderLabel={labelById[labelId]} class="text-xs" />
@@ -151,533 +139,100 @@
 					<a
 						href="/admin/order/{data.order._id}/label"
 						class="bg-gray-200 px-2 rounded-full"
-						title="add label">+</a
+						title="add label"
 					>
+						+
+					</a>
 				</div>
 			{/if}
+
 			{#if data.order.notifications?.paymentStatus?.npub}
 				<p>
 					{t('order.paymentStatusNpub')}:
 					<span class="font-mono break-all break-words body-secondaryText">
-						{data.order.notifications.paymentStatus.npub}</span
-					>
+						{data.order.notifications.paymentStatus.npub}
+					</span>
 				</p>
 			{/if}
+
 			{#if data.order.status !== 'expired' && data.order.status !== 'canceled'}
-				<div>
-					<Trans key="order.linkReminder"
-						><a
+				<div class="order-link">
+					<Trans key="order.linkReminder">
+						<a
 							class="underline body-hyperlink break-all break-words body-secondaryText"
 							href={$page.url.href}
-							slot="0">{$page.url.href}</a
-						></Trans
-					>
+							slot="0"
+						>
+							{$page.url.href}
+						</a>
+					</Trans>
 				</div>
 			{/if}
 
-			{#each data.order.payments as payment, i}
-				<details class="border border-gray-300 rounded-xl p-4" open={payment.status === 'pending'}>
-					<summary class="lg:text-xl cursor-pointer">
-						<!-- Extra span to keep the "arrow" for the details -->
-						<span class="items-center inline-flex gap-2"
-							>{t(
-								`checkout.paymentMethod.${payment.method}`
-							)}{#if payment.method === 'point-of-sale' && payment.posSubtype}
-								{@const subtype = data.posSubtypes?.find((s) => s.slug === payment.posSubtype)}
-								<span class="text-sm text-gray-600">
-									({subtype?.name || payment.posSubtype})
-								</span>
-							{/if}
-							- <PriceTag
-								inline
-								class="break-words {payment.status === 'paid'
-									? 'text-green-500'
-									: 'body-secondaryText'} "
-								amount={payment.price.amount}
-								currency={payment.price.currency}
-							/> - {t(`order.paymentStatus.${payment.status}`)}</span
-						>
-					</summary>
-					<div class="flex flex-col gap-2 mt-2">
-						{#if payment.method !== 'point-of-sale'}
-							<ul>
-								{#if payment.status === 'pending'}
-									<li>
-										{#if payment.method === 'card'}
-											<a
-												href="/order/{data.order._id}/payment/{payment.id}/pay"
-												class="body-hyperlink"
-											>
-												<span>{t('order.paymentLink')}</span>
-												{#if payment.processor === 'sumup'}
-													<IconSumupWide
-														class="h-12 {data.overwriteCreditCardSvgColor
-															? 'order-creditCard-svg'
-															: ''} "
-													/>
-												{:else if payment.processor === 'stripe'}
-													<IconStripe class="h-12" />
-												{:else if payment.processor === 'paypal'}
-													<img
-														src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/PP_logo_h_200x51.png"
-														alt="PayPal"
-														class="h-12"
-													/>
-												{/if}
-											</a>
-										{:else if payment.method === 'paypal'}
-											<a
-												href="/order/{data.order._id}/payment/{payment.id}/pay"
-												class="body-hyperlink"
-											>
-												<span>{t('order.paymentLinkGeneric')}</span>
-												<img
-													src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/PP_logo_h_200x51.png"
-													alt="PayPal"
-													class="h-12"
-												/>
-											</a>
-										{:else if payment.method === 'bank-transfer'}
-											{#if data.sellerIdentity?.bank?.accountHolder}
-												<p>
-													{t('order.paymentAccountHolder')}:
-													<span class="break-words body-secondaryText break-all">
-														{data.sellerIdentity?.bank?.accountHolder}
-													</span>
-												</p>
-											{/if}
-											{#if data.sellerIdentity?.bank?.accountHolderAddress}
-												<p>
-													{t('order.paymentAccountHolderAddress')}:
-													<span class="break-words body-secondaryText break-all">
-														{data.sellerIdentity?.bank?.accountHolderAddress}
-													</span>
-												</p>
-											{/if}
-											<p>
-												{t('order.paymentIban')}:
-												<code class="break-words body-secondaryText break-all">
-													{data.sellerIdentity?.bank?.iban.replace(/.{4}(?=.)/g, '$& ')}
-												</code>
-											</p>
-											<p>
-												{t('order.paymentBic')}:
-												<code class="break-words body-secondaryText break-all">
-													{data.sellerIdentity?.bank?.bic}
-												</code>
-											</p>
-										{:else}
-											{t('order.paymentAddress')}:
-											<code class="break-words body-secondaryText break-all">{payment.address}</code
-											>
-											<button
-												class="inline-block body-secondaryText"
-												type="button"
-												title={t('order.copyAddress')}
-												on:click={() => {
-													window.navigator.clipboard.writeText(payment.address ?? '');
-													copiedPaymentAddress = i;
-												}}
-											>
-												{#if copiedPaymentAddress === i}
-													<IconCheckmark class="inline-block mb-1" />
-													{t('general.copied')}
-												{:else}
-													<IconCopy class="inline-block mb-1" />
-												{/if}
-											</button>
-										{/if}
-									</li>
-								{/if}
-								{#if payment.expiresAt && (payment.status === 'pending' || payment.status === 'failed')}
-									<li>
-										{t('order.timeRemaining', {
-											minutes: differenceInMinutes(payment.expiresAt, currentDate)
-										})}
-									</li>
-								{/if}
-								{#if payment.status === 'paid' && payment.paidAt}
-									<li>
-										{t('order.paymentPaidAt', {
-											date: payment.paidAt.toLocaleDateString($locale)
-										})}
-									</li>
-								{/if}
-								{#if payment.status === 'failed' && !roleIsStaff}
-									<br />
-									{t('order.paymentCBFailed')}
-									<form
-										action="/order/{data.order._id}/payment/{payment.id}?/replaceMethod"
-										method="post"
-										class="contents"
-									>
-										<div class="flex flex-wrap gap-2">
-											<label class="form-label">
-												{t('order.addPayment.amount')}
-												<input
-													class="form-input"
-													type="number"
-													name="amount"
-													min="0"
-													step="any"
-													max={payment.currencySnapshot.main.price.amount}
-													value={payment.currencySnapshot.main.price.amount}
-													disabled
-												/>
-											</label>
-											<label class="form-label">
-												{t('order.addPayment.currency')}
-												<select name="currency" class="form-input" disabled>
-													<option value={payment.currencySnapshot.main.price.currency}
-														>{payment.currencySnapshot.main.price.currency}}</option
-													>
-												</select>
-											</label>
-											<label class="form-label">
-												<span>{t('checkout.payment.method')}</span>
-												<select name="method" class="form-input" bind:value={replacePaymentMethod}>
-													{#each filteredPaymentMethods as paymentMethod}
-														<option value={paymentMethod}
-															>{t(`checkout.paymentMethod.${paymentMethod}`)}</option
-														>
-													{/each}
-												</select>
-											</label>
-											{#if replacePaymentMethod === 'point-of-sale' && data.posSubtypes?.length}
-												<label class="form-label">
-													<span>Payment Type</span>
-													<select name="posSubtype" class="form-input" required>
-														{#each data.posSubtypes as subtype}
-															<option value={subtype.slug}>
-																{subtype.name}
-															</option>
-														{/each}
-													</select>
-												</label>
-											{/if}
-											<br />
-											<button type="submit" class="btn btn-blue self-end"
-												>{t('order.newPaymentAttempt.cta')}</button
-											>
-										</div>
-									</form>
-								{/if}
-							</ul>
-						{/if}
+			<!-- ========== PAYMENTS SECTION ========== -->
+			{#each data.order.payments as payment}
+				<PaymentItem
+					{payment}
+					orderId={data.order._id}
+					posMode={data.posMode}
+					hideCreditCardQrCode={data.hideCreditCardQrCode}
+					sellerIdentity={data.sellerIdentity}
+					posSubtypes={data.posSubtypes}
+				>
+					<PaymentActions
+						{payment}
+						orderId={data.order._id}
+						{orderStaffActionBaseUrl}
+						{roleIsStaff}
+						paymentMethods={data.paymentMethods}
+						posSubtypes={data.posSubtypes}
+						posMode={data.posMode}
+						tapToPayConfigured={data.tapToPay.configured}
+						tapToPayInUseByOtherOrder={data.tapToPay.inUseByOtherOrder}
+						printReceipt={() => receiptIFrame[payment.id]?.contentWindow?.print()}
+						printTicket={() => ticketIFrame[payment.id]?.contentWindow?.print()}
+						receiptReady={receiptReady[payment.id]}
+						ticketReady={ticketReady[payment.id]}
+					/>
+				</PaymentItem>
 
-						{#if payment.status !== 'paid'}
-							<button
-								class="body-hyperlink self-start"
-								type="button"
-								disabled={!receiptReady[payment.id]}
-								on:click={() => receiptIFrame[payment.id]?.contentWindow?.print()}
-								>{t('order.receipt.createProforma')}</button
-							>
-							<iframe
-								src={isMobile() && data.hasPosOptions
-									? `/order/${data.order._id}/payment/${payment.id}/ticket`
-									: `/order/${data.order._id}/payment/${payment.id}/receipt`}
-								style="width: 1px; height: 1px; position: absolute; left: -1000px; top: -1000px;"
-								title=""
-								on:load={() => (receiptReady = { ...receiptReady, [payment.id]: true })}
-								bind:this={receiptIFrame[payment.id]}
-							/>
-						{/if}
-						{#if payment.status === 'paid' && payment.invoice?.number}
-							<button
-								class="btn btn-black self-start"
-								type="button"
-								disabled={!receiptReady[payment.id]}
-								on:click={() => receiptIFrame[payment.id]?.contentWindow?.print()}
-								>{t('order.receipt.create')}</button
-							>
-							{#if payment.invoice.number !== FAKE_ORDER_INVOICE_NUMBER}
-								<iframe
-									src={isMobile() && data.hasPosOptions
-										? `/order/${data.order._id}/payment/${payment.id}/ticket`
-										: `/order/${data.order._id}/payment/${payment.id}/receipt`}
-									style="width: 1px; height: 1px; position: absolute; left: -1000px; top: -1000px;"
-									title=""
-									on:load={() => (receiptReady = { ...receiptReady, [payment.id]: true })}
-									bind:this={receiptIFrame[payment.id]}
-								/>
-							{/if}
-						{/if}
-
-						{#if payment.status === 'pending'}
-							{#if payment.method === 'lightning'}
-								<a href={lightningPaymentQrCodeString(payment.address ?? '')}>
-									<img
-										src="{$page.url.pathname}/payment/{payment.id}/qrcode"
-										class="w-96 h-96"
-										alt="QR code"
-									/></a
-								>
-							{/if}
-							{#if payment.method === 'card' && !data.hideCreditCardQrCode}
-								<img
-									src="{$page.url.pathname}/payment/{payment.id}/qrcode"
-									class="w-96 h-96"
-									alt="QR code"
-								/>
-							{/if}
-							{#if payment.method === 'bitcoin' && payment.address}
-								<span class="body-hyperlink font-light italic">{t('order.clickQR')}</span>
-								<a
-									href={bitcoinPaymentQrCodeString(
-										payment.address,
-										payment.price.amount,
-										payment.price.currency
-									)}
-								>
-									<img
-										src="{$page.url.pathname}/payment/{payment.id}/qrcode"
-										class="w-96 h-96"
-										alt="QR code"
-									/>
-								</a>
-							{/if}
-							{#if payment.method !== 'point-of-sale'}
-								{t('order.payToComplete')}
-							{/if}
-							{#if payment.method === 'bitcoin'}
-								{t('order.payToCompleteBitcoin', { count: payment.confirmationBlocksRequired })}
-							{/if}
-
-							{#if payment.method === 'bank-transfer'}
-								{#if data.sellerIdentity?.contact.email}
-									<a
-										href="mailto:{data.sellerIdentity.contact.email}"
-										class="btn btn-black self-start"
-									>
-										{t('order.informSeller')}
-									</a>
-								{/if}
-							{/if}
-
-							{#if roleIsStaff}
-								{@const tapToPayInProgress =
-									payment.posTapToPay && payment.posTapToPay.expiresAt > new Date()}
-								{#if tapToPayInProgress}
-									<form
-										action="{orderStaffActionBaseUrl}/payment/{payment.id}?/cancelTapToPay"
-										method="post"
-										id="cancelTapToPayForm"
-										class="flex flex-col flex-wrap gap-2"
-									>
-										<button type="submit" class="btn btn-green whitespace-nowrap w-min" disabled>
-											{'Tap to pay'}
-										</button>
-										{t('pos.tapToPay.inProgress')}
-										<Spinner class="w-36" />
-									</form>
-								{:else}
-									{@const posSubtype =
-										payment.method === 'point-of-sale' && payment.posSubtype
-											? data.posSubtypes?.find((s) => s.slug === payment.posSubtype)
-											: null}
-									{@const detailRequired = posSubtype?.paymentDetailRequired ?? false}
-									<form
-										action="{orderStaffActionBaseUrl}/payment/{payment.id}?/cancel"
-										method="post"
-										id="cancelForm"
-									></form>
-									<form
-										action="{orderStaffActionBaseUrl}/payment/{payment.id}?/tapToPay"
-										method="post"
-										id="tapToPayForm"
-									></form>
-									<form
-										action="{orderStaffActionBaseUrl}/payment/{payment.id}?/confirm"
-										method="post"
-										class="flex flex-wrap gap-2"
-									>
-										{#if payment.method === 'bank-transfer'}
-											<input
-												class="form-input w-auto"
-												type="text"
-												name="bankTransferNumber"
-												required
-												placeholder="bank transfer number"
-											/>
-										{/if}
-										{#if payment.method === 'point-of-sale'}
-											<input
-												class="form-input grow mx-2"
-												type="text"
-												name="detail"
-												required={detailRequired}
-												placeholder="Detail (card transaction ID, or point-of-sale payment method)"
-											/>
-										{/if}
-
-										<button
-											type="submit"
-											class="btn btn-red"
-											on:click={confirmCancel}
-											form="cancelForm"
-										>
-											{t('pos.cta.cancelOrder')}
-										</button>
-										{#if payment.method === 'point-of-sale' || payment.method === 'bank-transfer'}
-											<button type="submit" class="btn btn-black">
-												{t('pos.cta.markOrderPaid')}
-											</button>
-										{/if}
-										{#if payment.method === 'point-of-sale'}
-											{#if data.tapToPay.inUseByOtherOrder}
-												<p class="text-red-500 w-full">
-													{t('pos.tapToPay.inUseByOtherOrder')}
-												</p>
-											{:else if data.tapToPay.configured && payment.posSubtypeHasProcessor}
-												<button
-													type="submit"
-													form="tapToPayForm"
-													class="btn btn-green"
-													on:click={() =>
-														payment.tapToPayOnActivationUrl &&
-														window.open(
-															payment.tapToPayOnActivationUrl,
-															'_blank',
-															'noopener,noreferrer'
-														)}
-												>
-													{'Tap to pay'}
-												</button>
-											{/if}
-										{/if}
-									</form>
-								{/if}
-								<div class="flex flex-wrap gap-2">
-									{#if tapToPayInProgress}
-										<button
-											type="submit"
-											class="btn btn-red whitespace-nowrap"
-											form="cancelTapToPayForm"
-										>
-											{t('pos.cta.cancelTapToPay')}
-										</button>
-									{/if}
-									<button
-										type="button"
-										class="btn btn-red"
-										form="replacePaymentForm"
-										on:click={() => {
-											openPaymentMethodChange = !openPaymentMethodChange;
-										}}
-									>
-										{openPaymentMethodChange
-											? t('pos.cta.cancelReplacement')
-											: t('pos.cta.replacePayment')}
-									</button>
-									{#if openPaymentMethodChange}
-										<form
-											action="/order/{data.order._id}/payment/{payment.id}?/replaceMethod"
-											method="post"
-											class="contents"
-										>
-											<div class="flex flex-wrap gap-2">
-												<label class="form-label">
-													{t('order.addPayment.amount')}
-													<input
-														class="form-input"
-														type="number"
-														name="amount"
-														min="0"
-														step="any"
-														max={payment.currencySnapshot.main.price.amount}
-														value={payment.currencySnapshot.main.price.amount}
-														disabled
-													/>
-												</label>
-												<label class="form-label">
-													{t('order.addPayment.currency')}
-													<select name="currency" class="form-input" disabled>
-														<option value={payment.currencySnapshot.main.price.currency}
-															>{payment.currencySnapshot.main.price.currency}</option
-														>
-													</select>
-												</label>
-												<label class="form-label">
-													<span>{t('checkout.payment.method')}</span>
-													<select
-														name="method"
-														class="form-input"
-														bind:value={replacePaymentMethod}
-													>
-														{#each data.paymentMethods as paymentMethod}
-															<option value={paymentMethod}
-																>{t(`checkout.paymentMethod.${paymentMethod}`)}</option
-															>
-														{/each}
-													</select>
-												</label>
-
-												{#if replacePaymentMethod === 'point-of-sale' && data.posSubtypes?.length}
-													<label class="form-label">
-														<span>Payment Type</span>
-														<select name="posSubtype" class="form-input" required>
-															{#each data.posSubtypes as subtype}
-																<option value={subtype.slug}>
-																	{subtype.name}
-																</option>
-															{/each}
-														</select>
-													</label>
-												{/if}
-												<br />
-												<button type="submit" class="btn btn-blue self-end"
-													>{t('pos.cta.resendPaymentMethod')}</button
-												>
-											</div>
-										</form>
-									{/if}
-								</div>
-							{/if}
-						{/if}
-
-						{#if (payment.method === 'point-of-sale' || payment.method === 'bank-transfer') && roleIsStaff && payment.status === 'paid'}
-							<form
-								action="{orderStaffActionBaseUrl}/payment/{payment.id}?/updatePaymentDetail"
-								method="post"
-								class="contents"
-							>
-								<input
-									class="form-input w-auto"
-									type="text"
-									name="paymentDetail"
-									disabled={disableInfoChange}
-									placeholder="bank transfer number / Detail (card transaction ID, or point-of-sale payment method)"
-									value={payment.bankTransferNumber ?? payment.detail}
-									required
-								/>
-								<div class="flex gap-2">
-									<button type="submit" class="btn btn-blue" disabled={disableInfoChange}
-										>{t('pos.cta.updatePaymentInfo')}</button
-									>
-									<label class="checkbox-label">
-										<input class="form-checkbox" type="checkbox" bind:checked={disableInfoChange} />
-										🔐
-									</label>
-								</div>
-							</form>
-						{/if}
-					</div>
-				</details>
+				<!-- Hidden iframes for receipt/invoice printing -->
+				{#if payment.status !== 'paid' || (payment.invoice?.number && payment.invoice.number !== FAKE_ORDER_INVOICE_NUMBER)}
+					<iframe
+						src="/order/{data.order._id}/payment/{payment.id}/receipt"
+						style="width: 1px; height: 1px; position: absolute; left: -1000px; top: -1000px;"
+						title=""
+						on:load={() => (receiptReady = { ...receiptReady, [payment.id]: true })}
+						bind:this={receiptIFrame[payment.id]}
+					/>
+					{#if roleIsStaff}
+						<iframe
+							src="/order/{data.order._id}/payment/{payment.id}/ticket"
+							style="width: 1px; height: 1px; position: absolute; left: -1000px; top: -1000px;"
+							title=""
+							on:load={() => (ticketReady = { ...ticketReady, [payment.id]: true })}
+							bind:this={ticketIFrame[payment.id]}
+						/>
+					{/if}
+				{/if}
 			{/each}
 
-			{#if data.order.status === 'paid'}
-				<p>
-					<Trans key="order.paymentStatus.paidTemplate"
-						><span class="text-green-500" let:translation slot="0">{translation}</span></Trans
-					>
-				</p>
-			{:else if data.order.status === 'expired'}
-				<p>{t('order.paymentStatus.expiredTemplate')}</p>
-			{:else if data.order.status === 'canceled'}
-				<p class="font-bold">{t('order.paymentStatus.canceledTemplate')}</p>
-			{/if}
+			<!-- ========== ORDER STATUS MESSAGE ========== -->
+			<div class="order-status-message">
+				{#if data.order.status === 'paid'}
+					<p>
+						<Trans key="order.paymentStatus.paidTemplate">
+							<span class="text-green-500" let:translation slot="0">{translation}</span>
+						</Trans>
+					</p>
+				{:else if data.order.status === 'expired'}
+					<p>{t('order.paymentStatus.expiredTemplate')}</p>
+				{:else if data.order.status === 'canceled'}
+					<p class="font-bold">{t('order.paymentStatus.canceledTemplate')}</p>
+				{/if}
+			</div>
 
+			<!-- ========== TICKETS SECTION ========== -->
 			{#if data.order.items.some((item) => item.tickets?.length)}
 				<h2 class="text-2xl">{t('order.tickets.title')}</h2>
 
@@ -685,15 +240,15 @@
 					src="/order/{data.order._id}/tickets"
 					style="width: 1px; height: 1px; position: absolute; left: -1000px; top: -1000px;"
 					title=""
-					on:load={() => (ticketReady = true)}
-					bind:this={ticketIframe}
+					on:load={() => (ticketsReady = true)}
+					bind:this={ticketsIframe}
 				/>
 
 				<p>
 					<button
 						class="body-hyperlink self-start"
-						disabled={!ticketReady}
-						on:click={() => ticketIframe?.contentWindow?.print()}
+						disabled={!ticketsReady}
+						on:click={() => ticketsIframe?.contentWindow?.print()}
 					>
 						{t('order.tickets.printAll')}
 					</button>
@@ -722,6 +277,8 @@
 					{/if}
 				{/each}
 			{/if}
+
+			<!-- ========== DIGITAL FILES SECTION ========== -->
 			{#if data.digitalFiles.length}
 				<h2 class="text-2xl">{t('product.digitalFiles.title')}</h2>
 				<ul>
@@ -729,9 +286,9 @@
 						<li class="flex flex-row gap-2">
 							<IconDownloadWindow class="mt-1 body-hyperlink" />
 							{#if digitalFile.link}
-								<a href={digitalFile.link} class="body-hyperlink hover:underline" target="_blank"
-									>{digitalFile.name}</a
-								>
+								<a href={digitalFile.link} class="body-hyperlink hover:underline" target="_blank">
+									{digitalFile.name}
+								</a>
 							{:else}
 								{digitalFile.name}
 							{/if}
@@ -739,6 +296,8 @@
 					{/each}
 				</ul>
 			{/if}
+
+			<!-- ========== EXTERNAL RESOURCES SECTION ========== -->
 			{#if data.order.items.flatMap((item) => item.product.externalResources || []).length}
 				<h2 class="text-2xl">{t('order.externalResources.title')}</h2>
 				<ul>
@@ -749,8 +308,10 @@
 								<a
 									href={externalResource?.href}
 									class="body-hyperlink hover:underline"
-									target="_blank">{externalResource?.label}</a
+									target="_blank"
 								>
+									{externalResource?.label}
+								</a>
 							{:else}
 								{externalResource?.label}
 							{/if}
@@ -758,17 +319,23 @@
 					{/each}
 				</ul>
 			{/if}
+
+			<!-- ========== ADDITIONAL INFO ========== -->
+
 			{#if data.order.vatFree}
 				<p>{t('order.vatFree', { reason: data.order.vatFree.reason })}</p>
 			{/if}
-			<p class="text-base">
-				<Trans key="order.createdAt"
-					><time
+
+			<p class="order-created-date text-base">
+				<Trans key="order.createdAt">
+					<time
 						datetime={data.order.createdAt.toJSON()}
 						title={data.order.createdAt.toLocaleString($locale)}
-						slot="0">{data.order.createdAt.toLocaleString($locale)}</time
-					></Trans
-				>
+						slot="0"
+					>
+						{data.order.createdAt.toLocaleString($locale)}
+					</time>
+				</Trans>
 			</p>
 
 			{#if data.order.shippingAddress}
@@ -779,8 +346,9 @@
 					</p>
 				</div>
 			{/if}
+
 			{#if data.order.user}
-				<div>
+				<div class="contact-address">
 					{t('order.contactAddress.title')}:
 					{#if data.order.user.email}
 						<p class="body-secondaryText whitespace-pre-line">
@@ -802,80 +370,45 @@
 				</div>
 			{/if}
 
+			<!-- ========== ADD PAYMENT SECTION (Staff Only) ========== -->
 			{#if data.order.status === 'pending' && remainingAmount && roleIsStaff}
-				<form action="{orderStaffActionBaseUrl}?/cancel" method="post" id="cancelOrderForm"></form>
-				<form action="{orderStaffActionBaseUrl}?/addPayment" method="post" class="contents">
-					<div class="flex flex-wrap gap-2">
-						<label class="form-label">
-							{t('order.addPayment.amount')}
-							<input
-								class="form-input"
-								type="number"
-								name="amount"
-								min="0"
-								step="any"
-								max={remainingAmount}
-								value={remainingAmount}
-								required
-							/>
-						</label>
-						<label class="form-label">
-							{t('order.addPayment.currency')}
-							<select name="currency" class="form-input" disabled>
-								<option value={data.order.currencySnapshot.main.totalPrice.currency}
-									>{data.order.currencySnapshot.main.totalPrice.currency}</option
-								>
-							</select>
-						</label>
-						<label class="form-label">
-							<span>{t('checkout.payment.method')}</span>
-							<select name="method" class="form-input" bind:value={selectedPaymentMethod}>
-								{#each data.paymentMethods as paymentMethod}
-									<option value={paymentMethod}
-										>{t(`checkout.paymentMethod.${paymentMethod}`)}</option
-									>
-								{/each}
-							</select>
-						</label>
+				<div class="border border-gray-300 rounded-xl p-4 add-payment-section">
+					<h3 class="text-xl mb-2">{t('order.addPayment.title')}</h3>
 
-						{#if selectedPaymentMethod === 'point-of-sale' && data.posSubtypes?.length}
-							<label class="form-label">
-								<span>Payment Type</span>
-								<select name="posSubtype" class="form-input" required>
-									{#each data.posSubtypes as subtype}
-										<option value={subtype.slug}>
-											{subtype.name}
-										</option>
-									{/each}
-								</select>
-							</label>
-						{/if}
-					</div>
-					<div class="flex gap-2 mt-4">
-						<button type="submit" class="btn btn-blue">{t('order.addPayment.cta')}</button>
-						<button
-							type="submit"
-							class="btn btn-red"
-							on:click={confirmCancelOrder}
-							form="cancelOrderForm"
-						>
+					<PaymentForm
+						action="{orderStaffActionBaseUrl}?/addPayment"
+						mode="add"
+						paymentMethods={data.paymentMethods}
+						posSubtypes={data.posSubtypes}
+						maxAmount={remainingAmount}
+						posMode={data.posMode}
+					/>
+
+					<form action="{orderStaffActionBaseUrl}?/cancel" method="post" id="cancelOrderForm">
+						<button type="submit" class="btn btn-red mt-2" on:click={confirmCancelOrder}>
 							{t('pos.cta.cancelMultiPayOrder')}
 						</button>
-					</div>
-				</form>
+					</form>
+				</div>
 			{/if}
 
+			<!-- ========== STAFF ONLY SECTION ========== -->
 			{#if roleIsStaff}
 				{#if data.order.payments.length > 1 && data.order.status !== 'expired' && data.order.status !== 'canceled'}
-					{#if data.order.status === 'paid'}
-						<a class="btn bg-green-600 text-white self-start" href="/order/{data.order._id}/summary"
-							>{t('order.receiptFullyPaid')}</a
-						>
-					{:else}
-						<a class="btn btn-blue self-start" href="/order/{data.order._id}/summary"
-							>{t('order.receiptPending')}</a
-						>
-					{/if}
+					<div class="multi-payment-receipt">
+						{#if data.order.status === 'paid'}
+							<a
+								class="btn bg-green-600 text-white self-start"
+								href="/order/{data.order._id}/summary"
+							>
+								{t('order.receiptFullyPaid')}
+							</a>
+						{:else}
+							<a class="btn btn-blue self-start" href="/order/{data.order._id}/summary">
+								{t('order.receiptPending')}
+							</a>
+						{/if}
+					</div>
 				{/if}
 
 				<form action="{orderStaffActionBaseUrl}?/saveNote" method="post" class="contents">
@@ -884,18 +417,21 @@
 							<div class="p-4 flex flex-col gap-3">
 								<label class="form-label text-2xl">
 									{t('order.note.label')}
-
 									<textarea name="noteContent" cols="30" rows="2" class="form-input" />
 								</label>
 							</div>
 						</article>
+
 						<div class="flex flex-wrap gap-3 justify-between">
-							<button type="submit" class="btn lg:w-auto w-full btn-blue self-start"
-								>{t('order.note.saveText')}</button
+							<button type="submit" class="btn lg:w-auto w-full btn-blue self-start">
+								{t('order.note.saveText')}
+							</button>
+							<a
+								href="/order/{data.order._id}/notes"
+								class="btn lg:w-auto w-full btn-gray self-end"
 							>
-							<a href="/order/{data.order._id}/notes" class="btn lg:w-auto w-full btn-gray self-end"
-								>{t('order.note.seeText')}</a
-							>
+								{t('order.note.seeText')}
+							</a>
 							{#if data.order.orderTabSlug}
 								{#if data.splitMode}
 									<a
@@ -917,32 +453,78 @@
 				</form>
 			{/if}
 		</div>
+		<!-- END: LEFT COLUMN -->
 
+		<!-- ==================== RIGHT COLUMN (1/3 width) ==================== -->
 		<div class="mt-6">
 			<OrderSummary class="sticky top-4 -mr-2 -mt-2" order={data.order} />
 		</div>
 	</div>
-	{#if data.cmsOrderBottom && data.cmsOrderBottomData}
-		<CmsDesign
-			challenges={data.cmsOrderBottomData.challenges}
-			tokens={data.cmsOrderBottomData.tokens}
-			sliders={data.cmsOrderBottomData.sliders}
-			products={data.cmsOrderBottomData.products}
-			pictures={data.cmsOrderBottomData.pictures}
-			tags={data.cmsOrderBottomData.tags}
-			digitalFiles={data.cmsOrderBottomData.digitalFiles}
-			hasPosOptions={data.hasPosOptions}
-			specifications={data.cmsOrderBottomData.specifications}
-			contactForms={data.cmsOrderBottomData.contactForms}
-			pageName={data.cmsOrderBottom.title}
-			websiteLink={data.websiteLink}
-			brandName={data.brandName}
-			sessionEmail={data.email}
-			countdowns={data.cmsOrderBottomData.countdowns}
-			galleries={data.cmsOrderBottomData.galleries}
-			leaderboards={data.cmsOrderBottomData.leaderboards}
-			schedules={data.cmsOrderBottomData.schedules}
-			class={data.hideCmsZonesOnMobile ? 'prose max-w-full hidden lg:contents' : 'prose max-w-full'}
-		/>
-	{/if}
+	<!-- END: MAIN CONTAINER -->
+
+	<!-- ==================== CMS BOTTOM SECTION ==================== -->
+	<div class="cms-section-bottom">
+		{#if data.cmsOrderBottom && data.cmsOrderBottomData}
+			<CmsDesign
+				challenges={data.cmsOrderBottomData.challenges}
+				tokens={data.cmsOrderBottomData.tokens}
+				sliders={data.cmsOrderBottomData.sliders}
+				products={data.cmsOrderBottomData.products}
+				pictures={data.cmsOrderBottomData.pictures}
+				tags={data.cmsOrderBottomData.tags}
+				digitalFiles={data.cmsOrderBottomData.digitalFiles}
+				hasPosOptions={data.hasPosOptions}
+				specifications={data.cmsOrderBottomData.specifications}
+				contactForms={data.cmsOrderBottomData.contactForms}
+				pageName={data.cmsOrderBottom.title}
+				websiteLink={data.websiteLink}
+				brandName={data.brandName}
+				sessionEmail={data.email}
+				countdowns={data.cmsOrderBottomData.countdowns}
+				galleries={data.cmsOrderBottomData.galleries}
+				leaderboards={data.cmsOrderBottomData.leaderboards}
+				schedules={data.cmsOrderBottomData.schedules}
+				class={data.hideCmsZonesOnMobile
+					? 'prose max-w-full hidden lg:contents'
+					: 'prose max-w-full'}
+			/>
+		{/if}
+	</div>
 </main>
+
+<style>
+	/* ==================== POS MODE STYLES ==================== */
+	/* Applied when data.posMode = true (adds .pos-mode class to main) */
+
+	/* Hide non-essential elements in POS mode */
+	:global(.pos-mode .cms-section-top),
+	:global(.pos-mode .cms-section-bottom),
+	:global(.pos-mode .order-labels),
+	:global(.pos-mode .order-link),
+	:global(.pos-mode .order-status-message),
+	:global(.pos-mode .payment-details-list),
+	:global(.pos-mode .payment-instruction),
+	:global(.pos-mode .order-created-date),
+	:global(.pos-mode .contact-address),
+	:global(.pos-mode .mt-6),
+	:global(.pos-mode .multi-payment-receipt),
+	:global(.pos-mode .add-payment-section) {
+		display: none !important;
+	}
+
+	/* Show only last payment in split payments (POS) */
+	:global(.pos-mode .payment-item:not(:last-of-type)) {
+		display: none !important;
+	}
+
+	:global(.pos-mode) {
+		padding-top: 1rem;
+		padding-bottom: 1.5rem;
+	}
+
+	:global(.pos-grid) {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.5rem;
+	}
+</style>


### PR DESCRIPTION
Order page now displays a clean, touch-optimized interface for POS users: hides unnecessary details (order labels, creation date, status messages), shows only the active payment, and uses compact button labels in a 2-column grid.

Regular staff and admin users see the unchanged detailed interface with all information visible.

Closes #2051