### PR TITLE
🦋 Move items between pools in POS Touch

### DIFF
--- a/src/lib/components/MoveItemsModal.svelte
+++ b/src/lib/components/MoveItemsModal.svelte
@@ -1,0 +1,362 @@
+<script lang="ts">
+	import { computePriceInfo } from '$lib/cart';
+	import PosSplitTotalSection from '$lib/components/PosSplitTotalSection.svelte';
+	import PosSplitItemRow from '$lib/components/PosSplitItemRow.svelte';
+	import PoolDropdown from '$lib/components/PoolDropdown.svelte';
+	import { useI18n } from '$lib/i18n';
+	import { UNDERLYING_CURRENCY } from '$lib/types/Currency.js';
+	import { invalidate } from '$app/navigation';
+	import { UrlDependency } from '$lib/types/UrlDependency';
+	import { enhance } from '$app/forms';
+	import type { Price } from '$lib/types/Order';
+
+	const { t } = useI18n();
+
+	type HydratedItem = {
+		_id: string;
+		product: { _id: string; name: string; price: Price; vatProfileId?: string; shipping: boolean };
+		quantity: number;
+		internalNote?: { value: string; updatedAt: Date };
+	};
+
+	async function fetchTabItems(slug: string): Promise<HydratedItem[]> {
+		const res = await fetch(`/pos/touch/tab/${slug}/items`);
+		if (!res.ok) {
+			return [];
+		}
+		return res.json();
+	}
+
+	export let isOpen = false;
+	export let currentTabSlug: string;
+	export let availableTabs: Array<{ slug: string; name: string }>;
+	export let allOrderTabs: Array<{ slug: string; itemsCount?: number }>;
+	export let priceConfig: Parameters<typeof computePriceInfo>[1];
+	export let emptyIcon: string | undefined = '✅';
+	export let occupiedIcon: string | undefined = '⏳';
+	export let onClose: () => void;
+
+	// State for tab selection
+	let leftTabSlug: string;
+	let rightTabSlug: string;
+
+	// Sync with currentTabSlug reactively
+	$: leftTabSlug = currentTabSlug;
+	$: rightTabSlug = availableTabs.find((tab) => tab.slug !== currentTabSlug)?.slug ?? '';
+
+	// Pending changes (itemId → delta quantity)
+	let pendingMoves = new Map<string, { from: string; to: string; quantity: number }>();
+
+	// Hydrated items state
+	let leftTabItems: HydratedItem[] = [];
+	let rightTabItems: HydratedItem[] = [];
+
+	// Grouped items by productId with display quantities
+	let displayLeftItemsGrouped: Array<HydratedItem & { displayQty: number; itemIds: string[] }> = [];
+	let displayRightItemsGrouped: Array<HydratedItem & { displayQty: number; itemIds: string[] }> =
+		[];
+
+	// Group items by productId with display quantities
+	$: (displayLeftItemsGrouped = groupItemsByProduct(
+		[...leftTabItems, ...rightTabItems.filter((i) => pendingMoves.get(i._id)?.to === leftTabSlug)],
+		leftTabSlug
+	)),
+		pendingMoves.size;
+	$: (displayRightItemsGrouped = groupItemsByProduct(
+		[...rightTabItems, ...leftTabItems.filter((i) => pendingMoves.get(i._id)?.to === rightTabSlug)],
+		rightTabSlug
+	)),
+		pendingMoves.size;
+
+	function groupItemsByProduct(items: HydratedItem[], currentSlug: string) {
+		const grouped = new Map<string, HydratedItem & { displayQty: number; itemIds: string[] }>();
+
+		items.forEach((item) => {
+			const displayQty = getDisplayQuantity(item._id, item.quantity, currentSlug);
+			if (displayQty <= 0) {
+				return;
+			}
+
+			const productId = item.product._id;
+			const existing = grouped.get(productId);
+			if (existing) {
+				existing.displayQty += displayQty;
+				existing.itemIds.push(item._id);
+			} else {
+				grouped.set(productId, { ...item, displayQty, itemIds: [item._id] });
+			}
+		});
+
+		return Array.from(grouped.values());
+	}
+
+	// Fetch items when modal opens OR tabs change
+	$: if (isOpen) {
+		if (leftTabSlug) {
+			fetchTabItems(leftTabSlug).then((items) => {
+				leftTabItems = items;
+			});
+		}
+		if (rightTabSlug) {
+			fetchTabItems(rightTabSlug).then((items) => {
+				rightTabItems = items;
+			});
+		}
+	}
+
+	// Handle tab selection change - clear pending moves ONLY when user changes dropdown
+	function handleTabChange(side: 'left' | 'right', slug: string) {
+		if (side === 'left') {
+			leftTabSlug = slug;
+		} else {
+			rightTabSlug = slug;
+		}
+
+		pendingMoves.clear();
+		pendingMoves = pendingMoves;
+	}
+
+	// Universal move functions
+	function moveOne(itemId: string, from: string, to: string) {
+		const existing = pendingMoves.get(itemId);
+
+		if (existing) {
+			if (existing.from === from && existing.to === to) {
+				existing.quantity += 1;
+			} else if (existing.from === to && existing.to === from) {
+				existing.quantity -= 1;
+				if (existing.quantity <= 0) {
+					pendingMoves.delete(itemId);
+					pendingMoves = pendingMoves;
+					return;
+				}
+			}
+		} else {
+			pendingMoves.set(itemId, { from, to, quantity: 1 });
+		}
+
+		pendingMoves = pendingMoves;
+	}
+
+	function moveAll(itemId: string, from: string, to: string) {
+		const originalQty =
+			leftTabItems.find((i) => i._id === itemId)?.quantity ??
+			rightTabItems.find((i) => i._id === itemId)?.quantity ??
+			0;
+
+		const existing = pendingMoves.get(itemId);
+		if (existing && existing.from === to && existing.to === from) {
+			pendingMoves.delete(itemId);
+		} else {
+			pendingMoves.set(itemId, { from, to, quantity: originalQty });
+		}
+
+		pendingMoves = pendingMoves;
+	}
+
+	// Compute display quantities with pending changes
+	function getDisplayQuantity(itemId: string, originalQty: number, currentSlug: string): number {
+		const pending = pendingMoves.get(itemId);
+		if (!pending) {
+			return originalQty;
+		}
+
+		// If this is the FROM pool, subtract quantity
+		if (pending.from === currentSlug) {
+			return originalQty - pending.quantity;
+		}
+
+		// If this is the TO pool, add quantity
+		if (pending.to === currentSlug) {
+			// Check if item was originally in THIS pool
+			const wasInThisPool =
+				(currentSlug === leftTabSlug && leftTabItems.find((i) => i._id === itemId)) ||
+				(currentSlug === rightTabSlug && rightTabItems.find((i) => i._id === itemId));
+			const baseQty = wasInThisPool ? originalQty : 0;
+			return baseQty + pending.quantity;
+		}
+
+		return originalQty;
+	}
+
+	// Price calculations using grouped items (already computed display quantities)
+	$: leftTabPriceInfo = computePriceInfo(
+		displayLeftItemsGrouped.map((item) => ({ ...item, quantity: item.displayQty })),
+		priceConfig
+	);
+	$: rightTabPriceInfo = computePriceInfo(
+		displayRightItemsGrouped.map((item) => ({ ...item, quantity: item.displayQty })),
+		priceConfig
+	);
+
+	// Prepare data for submission
+	$: movesJson = JSON.stringify(
+		Array.from(pendingMoves.entries())
+			.filter(([, move]) => move.quantity !== 0)
+			.map(([itemId, move]) => ({
+				itemId,
+				from: move.from,
+				to: move.to,
+				quantity: move.quantity
+			}))
+	);
+
+	let saveError = '';
+</script>
+
+{#if isOpen}
+	<div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
+		<div class="bg-white w-full h-full flex flex-col">
+			<!-- Header with dropdowns -->
+			<header class="bg-gray-800">
+				<div class="grid grid-cols-2 gap-4">
+					<PoolDropdown
+						pools={availableTabs}
+						selectedSlug={leftTabSlug}
+						{allOrderTabs}
+						{emptyIcon}
+						{occupiedIcon}
+						disabledSlugs={[rightTabSlug]}
+						onSelect={(slug) => handleTabChange('left', slug)}
+					/>
+					<PoolDropdown
+						pools={availableTabs}
+						selectedSlug={rightTabSlug}
+						{allOrderTabs}
+						{emptyIcon}
+						{occupiedIcon}
+						disabledSlugs={[leftTabSlug]}
+						onSelect={(slug) => handleTabChange('right', slug)}
+					/>
+				</div>
+			</header>
+
+			<!-- Main content: 2-panel layout -->
+			<main class="flex-grow overflow-y-auto">
+				<div class="grid grid-cols-2 gap-4 h-full">
+					<!-- Left panel -->
+					<div class="flex flex-col justify-between p-3 h-full overflow-y-auto bg-gray-50">
+						<div>
+							<h3 class="font-semibold text-3xl mb-4">
+								{availableTabs.find((tab) => tab.slug === leftTabSlug)?.name ?? leftTabSlug}
+							</h3>
+							{#each displayLeftItemsGrouped as item}
+								{@const itemId = item.itemIds[0]}
+								{@const displayQty = item.displayQty}
+								{@const priceInfo = {
+									amount: (item.product?.price?.amount ?? 0) * displayQty,
+									currency: item.product?.price?.currency ?? UNDERLYING_CURRENCY
+								}}
+
+								<PosSplitItemRow
+									{item}
+									quantity={displayQty}
+									{priceInfo}
+									vatRate={8.1}
+									controls="move-to-cart"
+									isComplete={displayQty === 0}
+									onMoveOne={() => moveOne(itemId, leftTabSlug, rightTabSlug)}
+									onMoveAll={() => {
+										item.itemIds.forEach((id) => moveAll(id, leftTabSlug, rightTabSlug));
+									}}
+								/>
+							{/each}
+						</div>
+						<PosSplitTotalSection
+							totalExcl={leftTabPriceInfo.partialPrice}
+							totalIncl={leftTabPriceInfo.partialPriceWithVat}
+							currency={leftTabPriceInfo.currency}
+							vatRates={leftTabPriceInfo.vat.map((vat) => vat.rate)}
+						/>
+					</div>
+
+					<!-- Right panel -->
+					<div class="flex flex-col justify-between p-3 h-full overflow-y-auto bg-blue-50">
+						<div>
+							<h3 class="font-semibold text-3xl mb-4">
+								{availableTabs.find((tab) => tab.slug === rightTabSlug)?.name ?? rightTabSlug}
+							</h3>
+							{#each displayRightItemsGrouped as item}
+								{@const itemId = item.itemIds[0]}
+								{@const displayQty = item.displayQty}
+								{@const priceInfo = {
+									amount: (item.product?.price?.amount ?? 0) * displayQty,
+									currency: item.product?.price?.currency ?? UNDERLYING_CURRENCY
+								}}
+
+								<PosSplitItemRow
+									{item}
+									quantity={displayQty}
+									{priceInfo}
+									vatRate={8.1}
+									controls="return-to-pool"
+									onReturnOne={() => moveOne(itemId, rightTabSlug, leftTabSlug)}
+									onReturnAll={() => {
+										item.itemIds.forEach((id) => moveAll(id, rightTabSlug, leftTabSlug));
+									}}
+								/>
+							{/each}
+						</div>
+						<PosSplitTotalSection
+							totalExcl={rightTabPriceInfo.partialPrice}
+							totalIncl={rightTabPriceInfo.partialPriceWithVat}
+							currency={rightTabPriceInfo.currency}
+							vatRates={rightTabPriceInfo.vat.map((vat) => vat.rate)}
+						/>
+					</div>
+				</div>
+			</main>
+
+			<!-- Footer: Cancel + Save -->
+			<footer class="bg-gray-100 p-4">
+				{#if saveError}
+					<div class="bg-red-100 border-2 border-red-400 p-3 rounded mb-4 text-center">
+						<p class="text-red-600 text-xl">{saveError}</p>
+					</div>
+				{/if}
+
+				<div class="grid grid-cols-2 gap-4">
+					<button
+						type="button"
+						class="bg-gray-600 hover:bg-gray-700 text-white text-3xl p-4 rounded uppercase"
+						on:click={onClose}
+					>
+						{t('pos.touch.cancel')}
+					</button>
+
+					<form
+						method="POST"
+						action="?/moveItems"
+						use:enhance={() => {
+							saveError = '';
+							return async ({ result }) => {
+								if (result.type === 'error') {
+									saveError = result.error?.message || 'Failed to move items';
+									return;
+								}
+								if (result.type === 'failure') {
+									saveError =
+										(result.data && typeof result.data === 'object' && 'message' in result.data
+											? String(result.data.message)
+											: null) || 'Failed to move items';
+									return;
+								}
+								await invalidate(UrlDependency.orderTab(currentTabSlug));
+								onClose();
+							};
+						}}
+					>
+						<input type="hidden" name="moves" value={movesJson} />
+						<button
+							type="submit"
+							class="bg-green-600 hover:bg-green-700 text-white text-3xl p-4 rounded uppercase w-full"
+							disabled={pendingMoves.size === 0}
+						>
+							{t('pos.touch.save')}
+						</button>
+					</form>
+				</div>
+			</footer>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/PoolDropdown.svelte
+++ b/src/lib/components/PoolDropdown.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	export let pools: Array<{ slug: string; name: string }>;
+	export let selectedSlug: string;
+	export let onSelect: (slug: string) => void;
+	export let allOrderTabs: Array<{ slug: string; itemsCount?: number }> = [];
+	export let emptyIcon = '';
+	export let occupiedIcon = '';
+	export let disabledSlugs: string[] = [];
+
+	let isOpen = false;
+
+	$: selectedName = pools.find((p) => p.slug === selectedSlug)?.name ?? selectedSlug;
+
+	function getPoolIcon(poolSlug: string): string {
+		const orderTab = allOrderTabs.find((t) => t.slug === poolSlug);
+		const isEmpty = !orderTab || (orderTab.itemsCount ?? 0) === 0;
+		return isEmpty ? emptyIcon : occupiedIcon;
+	}
+</script>
+
+<div class="relative w-full">
+	<button
+		type="button"
+		class="touchScreen-category-cta bg-[#310d40] text-white w-full flex items-center justify-between text-3xl px-6 min-h-[4.25rem]"
+		on:click={() => (isOpen = !isOpen)}
+	>
+		<span class="uppercase">{selectedName} {getPoolIcon(selectedSlug)}</span>
+		<svg
+			class="w-8 h-8 transition-transform {isOpen ? 'rotate-180' : ''}"
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+		</svg>
+	</button>
+
+	{#if isOpen}
+		<div
+			class="fixed inset-0 z-40"
+			on:click={() => (isOpen = false)}
+			on:keydown={(e) => e.key === 'Escape' && (isOpen = false)}
+			role="button"
+			tabindex="-1"
+		></div>
+		<div
+			class="absolute top-full left-0 right-0 mt-2 bg-white shadow-[0_0_0_4px_rgba(0,0,0,0.8)] max-h-[60vh] overflow-y-auto z-50"
+		>
+			{#each pools as pool}
+				{@const isDisabled = disabledSlugs.includes(pool.slug)}
+				<button
+					type="button"
+					disabled={isDisabled}
+					class="w-full text-left px-6 py-4 text-2xl font-medium uppercase border-b border-gray-200 transition-colors {isDisabled
+						? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+						: pool.slug === selectedSlug
+						? 'bg-purple-100 text-purple-600 font-bold'
+						: 'text-gray-900 hover:bg-gray-100 hover:text-purple-600'}"
+					on:click={() => {
+						onSelect(pool.slug);
+						isOpen = false;
+					}}
+				>
+					{pool.name}
+					{getPoolIcon(pool.slug)}
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -703,6 +703,7 @@
 			"pagination": "SEITE {currentPage}/{totalPages}",
 			"tickets": "TICKETS",
 			"save": "SPEICHERN",
+			"moveItems": "Artikel verschieben",
 			"pool": "POOL",
 			"openDrawer": "KASSE ÖFFNEN",
 			"pay": "BEZAHLEN",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -676,6 +676,7 @@
 			"pagination": "PAGE {currentPage}/{totalPages}",
 			"tickets": "TICKETS",
 			"save": "SAVE",
+			"moveItems": "Move Items",
 			"pool": "POOL",
 			"openDrawer": "OPEN DRAWER",
 			"pay": "PAY",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -702,6 +702,7 @@
 			"pagination": "PÁGINA {currentPage}/{totalPages}",
 			"tickets": "TICKETS",
 			"save": "GUARDAR",
+			"moveItems": "Mover artículos",
 			"pool": "POOL",
 			"openDrawer": "ABRIR CAJÓN",
 			"pay": "PAGAR",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -703,6 +703,7 @@
 			"pagination": "PAGE {currentPage}/{totalPages}",
 			"tickets": "TICKETS",
 			"save": "SAUVER",
+			"moveItems": "Déplacer les articles",
 			"pool": "POOL",
 			"openDrawer": "OUVRIR TIROIR",
 			"pay": "PAYER",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -702,6 +702,7 @@
 			"pagination": "PAGINA {currentPage}/{totalPages}",
 			"tickets": "BIGLIETTI",
 			"save": "SALVA",
+			"moveItems": "Sposta articoli",
 			"pool": "POOL",
 			"openDrawer": "APRI CASSETTO",
 			"pay": "PAGA",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -702,6 +702,7 @@
 			"pagination": "PAGINA {currentPage}/{totalPages}",
 			"tickets": "TICKETS",
 			"save": "OPSLAAN",
+			"moveItems": "Items verplaatsen",
 			"pool": "POOL",
 			"openDrawer": "LADE OPENEN",
 			"pay": "BETALEN",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -703,6 +703,7 @@
 			"pagination": "PÁGINA {currentPage}/{totalPages}",
 			"tickets": "BILHETES",
 			"save": "GUARDAR",
+			"moveItems": "Mover itens",
 			"pool": "POOL",
 			"openDrawer": "ABRIR GAVETA",
 			"pay": "PAGAR",

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { collections } from '$lib/server/database';
+import { collections, withTransaction } from '$lib/server/database';
 import {
 	concludeOrderTab,
 	getOrCreateOrderTab,
@@ -69,6 +69,15 @@ const discountSchema = z
 		motive: z.string().max(500).optional()
 	})
 	.nullable();
+
+const movesSchema = z.array(
+	z.object({
+		itemId: z.string(),
+		from: z.string(),
+		to: z.string(),
+		quantity: z.number()
+	})
+);
 
 async function hydratedOrderItems(
 	locale: Locale,
@@ -348,5 +357,114 @@ export const actions = {
 				? { $set: { peopleCountFromPosUi, updatedAt: new Date() } }
 				: { $unset: { peopleCountFromPosUi: 1 }, $set: { updatedAt: new Date() } }
 		);
+	},
+
+	moveItems: async ({ request }) => {
+		const movesJson = (await request.formData()).get('moves');
+
+		if (typeof movesJson !== 'string') {
+			throw error(400, 'Invalid moves data');
+		}
+
+		const moves = movesSchema.parse(JSON.parse(movesJson));
+
+		if (!moves.length) {
+			return;
+		}
+
+		await withTransaction(async (session) => {
+			for (const { itemId, from, to, quantity } of moves) {
+				if (quantity === 0) {
+					continue;
+				}
+
+				const id = new ObjectId(itemId);
+
+				// Get source item
+				const sourceTab = await collections.orderTabs.findOne(
+					{ slug: from, 'items._id': id },
+					{ projection: { 'items.$': 1 }, session }
+				);
+
+				if (!sourceTab?.items?.[0]) {
+					continue;
+				}
+
+				const itemToMove = sourceTab.items[0];
+
+				// Validate sufficient quantity
+				if (itemToMove.quantity < quantity) {
+					throw error(
+						400,
+						`Insufficient quantity: requested ${quantity}, available ${itemToMove.quantity}`
+					);
+				}
+
+				// Decrement source
+				await collections.orderTabs.updateOne(
+					{ slug: from, 'items._id': id },
+					{ $inc: { 'items.$.quantity': -quantity }, $set: { updatedAt: new Date() } },
+					{ session }
+				);
+
+				// Find matching in target
+				const targetTab = await collections.orderTabs.findOne(
+					{ slug: to },
+					{ projection: { items: 1 }, session }
+				);
+
+				const matchingItem = targetTab?.items?.find(
+					(item) =>
+						item.productId === itemToMove.productId &&
+						JSON.stringify(item.chosenVariations ?? {}) ===
+							JSON.stringify(itemToMove.chosenVariations ?? {})
+				);
+
+				// Increment or push
+				await collections.orderTabs.updateOne(
+					{ slug: to, ...(matchingItem && { 'items._id': matchingItem._id }) },
+					matchingItem
+						? { $inc: { 'items.$.quantity': quantity }, $set: { updatedAt: new Date() } }
+						: {
+								$push: { items: { ...itemToMove, _id: new ObjectId(), quantity } },
+								$set: { updatedAt: new Date() }
+						  },
+					{ session }
+				);
+			}
+
+			// Merge duplicates and cleanup in affected pools
+			const affectedSlugs = [...new Set(moves.flatMap((m) => [m.from, m.to]))];
+
+			await Promise.all(
+				affectedSlugs.map(async (slug) => {
+					const tab = await collections.orderTabs.findOne(
+						{ slug },
+						{ projection: { items: 1 }, session }
+					);
+					if (!tab?.items?.length) {
+						return;
+					}
+
+					const merged = tab.items.reduce((m, i) => {
+						const k = `${i.productId}:${JSON.stringify(i.chosenVariations ?? {})}`;
+						const p = m.get(k);
+						return m.set(k, p ? { ...p, quantity: p.quantity + i.quantity } : i);
+					}, new Map());
+
+					// Merge + cleanup in one update
+					await collections.orderTabs.updateOne(
+						{ slug },
+						{
+							$set: {
+								items: [...merged.values()].filter((i) => i.quantity > 0),
+								updatedAt: new Date()
+							}
+						},
+						{ session }
+					);
+				})
+			);
+		});
 	}
 };

--- a/src/routes/(app)/pos/touch/tab/[slug]/items/+server.ts
+++ b/src/routes/(app)/pos/touch/tab/[slug]/items/+server.ts
@@ -1,0 +1,71 @@
+import { collections } from '$lib/server/database';
+import { getOrCreateOrderTab } from '$lib/server/orderTab';
+import { pojo } from '$lib/server/pojo';
+import type { OrderTab } from '$lib/types/OrderTab';
+import type { Price } from '$lib/types/Order';
+import { json } from '@sveltejs/kit';
+
+type Locale = App.Locals['language'];
+
+type ProductProjection = {
+	_id: string;
+	name: string;
+	price: Price;
+	vatProfileId?: string;
+	shipping: boolean;
+};
+
+type HydratedItem = {
+	_id: string;
+	product: ProductProjection;
+	quantity: number;
+	internalNote?: {
+		value: string;
+		updatedAt: Date;
+	};
+};
+
+async function hydratedOrderItems(
+	locale: Locale,
+	tabItems: OrderTab['items']
+): Promise<HydratedItem[]> {
+	const products = await collections.products
+		.find({
+			_id: { $in: tabItems.map((it) => it.productId) }
+		})
+		.project<ProductProjection>({
+			_id: 1,
+			name: { $ifNull: [`$translations.${locale}.name`, '$name'] },
+			price: 1,
+			vatProfileId: 1,
+			shipping: 1
+		})
+		.toArray();
+
+	const productById = new Map(products.map((p) => [p._id, p]));
+
+	return tabItems
+		.map((item) => {
+			const product = productById.get(item.productId);
+			if (!product) {
+				return undefined;
+			}
+
+			return {
+				_id: item._id.toString(),
+				product: { ...product, vatProfileId: product.vatProfileId?.toString() },
+				quantity: item.quantity,
+				internalNote: item.internalNote && {
+					value: item.internalNote.value,
+					updatedAt: item.internalNote.updatedAt
+				}
+			};
+		})
+		.filter((item): item is NonNullable<typeof item> => item !== undefined);
+}
+
+export const GET = async ({ params, locals }) => {
+	const tab = await getOrCreateOrderTab({ slug: params.slug });
+	const items = await hydratedOrderItems(locals.language, tab.items);
+	return json(pojo(items));
+};


### PR DESCRIPTION
Restaurant staff can now transfer items between pools (tabs) in POS Touch interface. Features include moving items one-by-one or all at once, visual preview of pending changes before saving, and smart merging of duplicate items.

- “Move Items” button on the modal pool selection window
- Two drop-down lists - from where and to where to move
- Move 1 item (button +) or all at once (button >>)
- Visual preview of changes before saving
- You can cancel the move before clicking Save

Closes #2153