### PR TITLE
🦋 Add pool-level people count tracker to POS Touch

### DIFF
--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -584,6 +584,7 @@ export async function createOrder(
 		onLocation?: boolean;
 		paymentTimeOut?: number;
 		posSubtype?: string;
+		peopleCountFromPosUi?: number;
 		session?: ClientSession;
 	}
 ): Promise<Order['_id']> {
@@ -1535,6 +1536,9 @@ export async function createOrder(
 					orderTabId: params.cart.orderTabId,
 					cartId: params.cart._id,
 					splitMode: params.cart.splitMode
+				}),
+				...(params.peopleCountFromPosUi !== undefined && {
+					peopleCountFromPosUi: params.peopleCountFromPosUi
 				})
 			};
 			await collections.orders.insertOne(order, { session });

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -569,7 +569,8 @@
 			"totalInclVat": "Gesamtbetrag inkl. MwSt.",
 			"totalVat": "Gesamt-MwSt.",
 			"unitPrice": "Stückpreis",
-			"vatFreeReason": "MwSt.-befreit: {reason}"
+			"vatFreeReason": "MwSt.-befreit: {reason}",
+			"peopleCount": "Anzahl der Personen"
 		},
 		"receiptFullyPaid": "Quittung erstellen (vollständig bezahlt)",
 		"receiptPending": "Quittung erstellen (ausstehende Zahlung)",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -569,7 +569,8 @@
 			"totalInclVat": "Total Incl. VAT",
 			"totalVat": "Total VAT",
 			"unitPrice": "Unit price",
-			"vatFreeReason": "Vat exempted: {reason}"
+			"vatFreeReason": "Vat exempted: {reason}",
+			"peopleCount": "Number of people"
 		},
 		"receiptFullyPaid": "Generate receipt(fully paid)",
 		"receiptPending": "Generate receipt(pending payment)",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -569,7 +569,8 @@
 			"totalInclVat": "Total con IVA",
 			"totalVat": "Total IVA",
 			"unitPrice": "Precio unitario",
-			"vatFreeReason": "Exento de IVA: {reason}"
+			"vatFreeReason": "Exento de IVA: {reason}",
+			"peopleCount": "Número de personas"
 		},
 		"receiptFullyPaid": "Generar recibo (completamente pagado)",
 		"receiptPending": "Generar recibo (pago pendiente)",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -569,7 +569,8 @@
 			"totalInclVat": "Total TTC",
 			"totalVat": "TVA totale",
 			"unitPrice": "Prix ​​unit. HT",
-			"vatFreeReason": "Exempt de TVA: {reason}"
+			"vatFreeReason": "Exempt de TVA: {reason}",
+			"peopleCount": "Nombre de personnes"
 		},
 		"receiptFullyPaid": "Générer un reçu (entièrement payé)",
 		"receiptPending": "Générer un reçu (en attente de paiement)",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -569,7 +569,8 @@
 			"totalInclVat": "Totale IVA inclusa",
 			"totalVat": "Totale IVA",
 			"unitPrice": "Prezzo unitario",
-			"vatFreeReason": "Esente dall'IVA: {reason}"
+			"vatFreeReason": "Esente dall'IVA: {reason}",
+			"peopleCount": "Numero di persone"
 		},
 		"receiptFullyPaid": "Genera il ticket (pagato completamente)",
 		"receiptPending": "Genera il ticket (pagamento in attesa)",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -569,7 +569,8 @@
 			"totalInclVat": "Totaal Incl. VAT",
 			"totalVat": "Totale BTW",
 			"unitPrice": "Eenheid prijs",
-			"vatFreeReason": "Vrijgesteld van btw: {reason}"
+			"vatFreeReason": "Vrijgesteld van btw: {reason}",
+			"peopleCount": "Aantal personen"
 		},
 		"receiptFullyPaid": "Bon genereren (volledig betaald)",
 		"receiptPending": "Ontvangst genereren (betaling in behandeling)",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -569,7 +569,8 @@
 			"totalInclVat": "Total Incl. IVA",
 			"totalVat": "Total IVA",
 			"unitPrice": "Preço unitário",
-			"vatFreeReason": "Isento de IVA: {reason}"
+			"vatFreeReason": "Isento de IVA: {reason}",
+			"peopleCount": "Número de pessoas"
 		},
 		"receiptFullyPaid": "Gerar recibo (totalmente pago)",
 		"receiptPending": "Gerar recibo (pagamento pendente)",

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -246,6 +246,7 @@ export interface Order extends Timestamps {
 	orderTabId?: ObjectId;
 	cartId?: ObjectId;
 	splitMode?: 'items' | 'shares';
+	peopleCountFromPosUi?: number;
 
 	shippingAddress?: OrderAddress;
 	billingAddress?: OrderAddress;

--- a/src/lib/types/OrderTab.ts
+++ b/src/lib/types/OrderTab.ts
@@ -28,6 +28,7 @@ export interface OrderTab extends Timestamps {
 		tagId?: string;
 		motive?: string;
 	};
+	peopleCountFromPosUi?: number;
 }
 
 export interface OrderTabPoolStatus {

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -197,6 +197,7 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 		orderTabSlug: order.orderTabSlug,
 		cartId: order.cartId?.toString(),
 		splitMode: order.splitMode,
+		peopleCountFromPosUi: order.peopleCountFromPosUi,
 		shippingPrice: order.shippingPrice && {
 			amount: order.shippingPrice.amount,
 			currency: order.shippingPrice.currency

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/ticket/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/ticket/+page.svelte
@@ -279,6 +279,11 @@
 				.iban}<br />BIC &nbsp; &nbsp;{identity.bank.bic}
 		</p>
 	{/if}
+	{#if data.order.peopleCountFromPosUi}
+		<p>
+			<br />{t('order.receipt.peopleCount')}: {data.order.peopleCountFromPosUi}
+		</p>
+	{/if}
 	{#if data.order.receiptNote}
 		<div class="mt-4 text-center">
 			<p>

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
@@ -335,5 +335,18 @@ export const actions = {
 				? { $set: { discount, updatedAt: new Date() } }
 				: { $unset: { discount: 1 }, $set: { updatedAt: new Date() } }
 		);
+	},
+	updatePeopleCount: async ({ request, params }) => {
+		const formData = await request.formData();
+		const peopleCountValue = formData.get('peopleCount');
+
+		const peopleCountFromPosUi = z.coerce.number().int().min(0).max(100).parse(peopleCountValue);
+
+		await collections.orderTabs.updateOne(
+			{ slug: params.orderTabSlug },
+			peopleCountFromPosUi > 0
+				? { $set: { peopleCountFromPosUi, updatedAt: new Date() } }
+				: { $unset: { peopleCountFromPosUi: 1 }, $set: { updatedAt: new Date() } }
+		);
 	}
 };

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -351,6 +351,9 @@
 	let manualPercentage = '';
 	let discountError = '';
 
+	let peopleDropdownOpen = false;
+	const peopleCountOptions = Array.from({ length: 21 }, (_, i) => i);
+
 	$: isDiscountLocked = !!data.orderTab.processedPayments?.length;
 	$: discountData =
 		selectedPercentage > 0
@@ -807,16 +810,68 @@
 					class="touchScreen-ticket-menu text-3xl p-4 text-center"
 					on:click={() => (tabSelectModalOpen = true)}>POOL</button
 				>
-				<button
-					class="touchScreen-action-secondaryCTA text-3xl p-4"
-					disabled={!items.length}
-					on:click={() => (printModalOpen = true)}>PRINT TICKETS</button
-				>
-				<button
-					class="touchScreen-action-secondaryCTA text-3xl p-4 uppercase"
-					disabled={!items.length}
-					on:click={openDiscountPanel}>{t('pos.discount.title')}</button
-				>
+				<div class="col-span-2 grid gap-4" style="grid-template-columns: 1fr 1fr 200px;">
+					<button
+						class="touchScreen-action-secondaryCTA text-3xl p-4"
+						disabled={!items.length}
+						on:click={() => (printModalOpen = true)}>PRINT TICKETS</button
+					>
+					<button
+						class="touchScreen-action-secondaryCTA text-3xl p-4 uppercase"
+						disabled={!items.length}
+						on:click={openDiscountPanel}>{t('pos.discount.title')}</button
+					>
+					<div class="flex items-center gap-2 bg-gray-200 rounded p-2 h-full relative">
+						<span class="text-3xl pl-1">👨‍👩‍👧‍👦</span>
+						<button
+							type="button"
+							class="flex-1 text-2xl text-center p-2 border-0 rounded bg-white hover:bg-gray-50 flex items-center justify-center gap-2"
+							on:click={() => (peopleDropdownOpen = !peopleDropdownOpen)}
+						>
+							<span>{data.orderTab.peopleCountFromPosUi ?? 0}</span>
+							<span class="text-sm opacity-70">{peopleDropdownOpen ? '▲' : '▼'}</span>
+						</button>
+						{#if peopleDropdownOpen}
+							<div
+								class="absolute bottom-full left-0 right-0 mb-2 bg-white border-2 border-gray-400 rounded shadow-xl overflow-hidden z-50"
+								style="max-height: min(80vh, 500px);"
+							>
+								<div class="overflow-y-auto" style="max-height: min(80vh, 500px);">
+									<form
+										method="POST"
+										action="?/updatePeopleCount"
+										use:enhance={() => {
+											return async ({ result }) => {
+												if (result.type === 'error') {
+													return await applyAction(result);
+												}
+												await invalidate(UrlDependency.orderTab(tabSlug));
+												peopleDropdownOpen = false;
+											};
+										}}
+									>
+										<input type="hidden" name="peopleCount" value="" />
+										{#each peopleCountOptions as count}
+											<button
+												type="submit"
+												class="w-full text-2xl py-3 px-4 hover:bg-blue-100 text-center border-b border-gray-200 last:border-b-0"
+												on:click={(e) => {
+													const form = e.currentTarget.closest('form');
+													const input = form?.querySelector('input[name="peopleCount"]');
+													if (input instanceof HTMLInputElement) {
+														input.value = count.toString();
+													}
+												}}
+											>
+												{count}
+											</button>
+										{/each}
+									</form>
+								</div>
+							</div>
+						{/if}
+					</div>
+				</div>
 			{:else if rightPanel === 'discount'}
 				<button
 					class="touchScreen-action-cancel uppercase text-3xl text-white p-4 text-center"

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
@@ -270,7 +270,8 @@ export const actions = {
 					user,
 					userVatCountry: runtimeConfig.vatCountry,
 					shippingAddress: null,
-					cart
+					cart,
+					peopleCountFromPosUi: orderTab.peopleCountFromPosUi
 				});
 
 				order = await collections.orders.findOne({ _id: orderId });


### PR DESCRIPTION
POS staff can now track the number of people at each table/pool directly in the Touch interface. A new dropdown (0-20 people) appears in the bottom-right footer next to the PRINT TICKETS and DISCOUNT buttons, marked with a 👨‍👩‍👧‍👦 icon.

The selected people count:
- Persists when switching between pools
- Automatically saves to the final Order for historical tracking
- Works with both split-by-items and split-by-shares payment modes

This helps staff track table occupancy and provides valuable analytics data in order history (stored as `peopleCountFromPosUi` field).

Fixes issue #2236 