### PR TITLE
🐛 Fix POS split pool stuck when items modified during payment

### DIFF
--- a/src/lib/server/orderTab.ts
+++ b/src/lib/server/orderTab.ts
@@ -78,6 +78,15 @@ export async function getOrCreateOrderTab({ slug }: { slug: string }): Promise<O
 	}
 }
 
+export async function hasSharesPaymentStarted(orderTabId: ObjectId): Promise<boolean> {
+	const sharesOrder = await collections.orders.findOne({
+		orderTabId,
+		splitMode: 'shares',
+		payments: { $elemMatch: { status: 'paid' } }
+	});
+	return !!sharesOrder;
+}
+
 export async function orderTabNotEmptyAndFullyPaid({ slug }: { slug: string }): Promise<boolean> {
 	const returned = await collections.orderTabs.findOne({ slug });
 	if (!returned || returned.items.length === 0) {

--- a/src/routes/(app)/pos/+page.server.ts
+++ b/src/routes/(app)/pos/+page.server.ts
@@ -7,6 +7,8 @@ import { COUNTRY_ALPHA2S, type CountryAlpha2 } from '$lib/types/Country';
 import {
 	addToOrderTab,
 	checkoutOrderTab,
+	getOrCreateOrderTab,
+	hasSharesPaymentStarted,
 	removeFromOrderTab,
 	removeOrderTab
 } from '$lib/server/orderTab';
@@ -91,6 +93,12 @@ export const actions: Actions = {
 				tabSlug: formData.get('tabSlug'),
 				tabItemId: formData.get('tabItemId')
 			});
+
+		const orderTab = await getOrCreateOrderTab({ slug: tabSlug });
+		if (await hasSharesPaymentStarted(orderTab._id)) {
+			return fail(403, { error: 'sharesPaymentStarted' });
+		}
+
 		await removeFromOrderTab({ tabSlug, tabItemId });
 	},
 	removeTab: async ({ request }) => {
@@ -102,6 +110,12 @@ export const actions: Actions = {
 			.parse({
 				tabSlug: formData.get('tabSlug')
 			});
+
+		const orderTab = await getOrCreateOrderTab({ slug: tabSlug });
+		if (await hasSharesPaymentStarted(orderTab._id)) {
+			return fail(403, { error: 'sharesPaymentStarted' });
+		}
+
 		await removeOrderTab({ tabSlug });
 	},
 	checkoutTab: async ({ request, locals }) => {

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -58,6 +58,10 @@
 	let itemToEditIndex: number | undefined = undefined;
 
 	function openEditItemDialog(itemIndex: number) {
+		if (data.itemRemovalBlocked) {
+			alert(t('pos.split.completeSharesFirst'));
+			return;
+		}
 		itemToEditIndex = itemIndex;
 	}
 
@@ -888,13 +892,27 @@
 						class="col-span-1 touchScreen-action-cancel text-3xl p-4 text-center"
 						disabled={!items.length}
 						formaction="/pos?/removeFromTab"
-						on:click={() => (warningMessage = t('pos.touch.confirmDeleteLastItem'))}>❎</button
+						on:click={(e) => {
+							if (data.itemRemovalBlocked) {
+								e.preventDefault();
+								alert(t('pos.split.completeSharesFirst'));
+								return;
+							}
+							warningMessage = t('pos.touch.confirmDeleteLastItem');
+						}}>❎</button
 					>
 					<button
 						class="col-span-1 touchScreen-action-delete text-3xl p-4 text-center"
 						disabled={!items.length}
 						formaction="/pos/?/removeTab"
-						on:click={() => (warningMessage = t('pos.touch.confirmDeleteAllItems'))}>🗑️</button
+						on:click={(e) => {
+							if (data.itemRemovalBlocked) {
+								e.preventDefault();
+								alert(t('pos.split.completeSharesFirst'));
+								return;
+							}
+							warningMessage = t('pos.touch.confirmDeleteAllItems');
+						}}>🗑️</button
 					>
 				</form>
 			</div>

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
@@ -100,13 +100,10 @@
 
 	$: hasOriginalQuantities = tab.items.some((item) => item.originalQuantity !== undefined);
 
-	let isPoolFullyPaid: boolean;
-	$: {
-		const allZero = tab.items.every((item) => item.quantity === 0);
-		isPoolFullyPaid = data.sharesOrder?._id
-			? data.sharesOrder.isFullyPaid && hasOriginalQuantities
-			: hasOriginalQuantities && allZero;
-	}
+	$: isPoolFullyPaid = data.sharesOrder?._id
+		? data.sharesOrder.isFullyPaid
+		: tab.items.every((item) => item.quantity === 0) &&
+		  tab.items.some((item) => item.originalQuantity !== undefined);
 
 	// Pool fully paid calculations (based on original quantities)
 	$: itemsWithOriginalQuantities = tab.items.map((item) => ({


### PR DESCRIPTION
POS pool could become stuck without a "Close pool" button if items were modified while shares payment was in progress. User could navigate back and edit/delete items, breaking payment state.

Now when shares payment has started (paid payments exist):
- Clicking items, ❎, or 🗑️ shows alert explaining to complete payment first
- Server blocks all 3 actions with 403 as fallback protection

Closes #2287
