### PR TITLE
🦋 Implement NIP-57 Zap receipts for Lightning tipping

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -52,6 +52,7 @@ import type { Leaderboard } from '$lib/types/Leaderboard';
 import type { OrderTab } from '$lib/types/OrderTab';
 import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
 import type { PosSession } from '$lib/types/PosSession';
+import type { PendingZap } from '$lib/types/PendingZap';
 
 // Bigger than the default 10, helpful with MongoDB errors
 Error.stackTraceLimit = 100;
@@ -114,6 +115,7 @@ const genCollection = () => ({
 	scheduleEvents: db.collection<ScheduleEventBooked>('schedule.events'),
 	posPaymentSubtypes: db.collection<PosPaymentSubtype>('posPaymentSubtypes'),
 	posSessions: db.collection<PosSession>('posSessions'),
+	pendingZaps: db.collection<PendingZap>('pendingZaps'),
 
 	errors: db.collection<unknown & { _id: ObjectId; url: string; method: string }>('errors')
 });
@@ -222,7 +224,9 @@ const indexes: Array<[Collection<any>, IndexSpecification, CreateIndexesOptions?
 	[collections.posPaymentSubtypes, { disabled: 1 }],
 	[collections.posSessions, { status: 1, openedAt: -1 }],
 	[collections.posSessions, { closedAt: -1 }],
-	[collections.orderTabs, { slug: 1 }, { unique: true }]
+	[collections.orderTabs, { slug: 1 }, { unique: true }],
+	[collections.pendingZaps, { processedAt: 1 }],
+	[collections.pendingZaps, { invoiceId: 1 }, { unique: true }]
 ];
 
 export async function createIndexes() {

--- a/src/lib/server/lnd.ts
+++ b/src/lib/server/lnd.ts
@@ -220,11 +220,16 @@ export async function lndLookupInvoice(invoiceId: string) {
 		.object({
 			amt_paid_sat: z.number({ coerce: true }).int(),
 			state: z.enum(['SETTLED', 'CANCELED', 'ACCEPTED', 'OPEN']),
-			settled_at: z.number({ coerce: true }).int().optional()
+			settled_at: z.number({ coerce: true }).int().optional(),
+			r_preimage: z.string().optional() // NIP-57: preimage for zap receipts
 		})
 		.parse(json);
 
-	return { ...ret, settled_at: ret.settled_at ? new Date(ret.settled_at * 1000) : undefined };
+	return {
+		...ret,
+		settled_at: ret.settled_at ? new Date(ret.settled_at * 1000) : undefined,
+		preimage: ret.r_preimage ? Buffer.from(ret.r_preimage, 'base64').toString('hex') : undefined
+	};
 }
 
 export async function lndListInvoices() {

--- a/src/lib/server/locks/index.ts
+++ b/src/lib/server/locks/index.ts
@@ -7,3 +7,4 @@ import './nostr-notifications';
 import './handle-messages';
 import './subscription-lock';
 import './stock-lock';
+import './zap-lock';

--- a/src/lib/server/locks/nostr-notifications.ts
+++ b/src/lib/server/locks/nostr-notifications.ts
@@ -244,28 +244,24 @@ async function handleNostrNotification(nostrNotification: NostRNotification): Pr
 			}
 
 			if (nostrNotification.kind === Kind.Zap) {
-				const npub = nostrNotification.dest;
+				const tags: string[][] = [
+					['p', nostrNotification.receiverPubkey || ''],
+					['P', nostrNotification.senderPubkey || ''],
+					['bolt11', nostrNotification.bolt11 || ''],
+					['preimage', nostrNotification.preimage || ''],
+					['description', nostrNotification.zapRequest || '']
+				];
 
-				if (!npub) {
-					return;
+				if (nostrNotification.eventId) {
+					tags.push(['e', nostrNotification.eventId]);
 				}
-
-				const receiverPublicKeyHex = nostrToHex(npub);
 
 				return {
 					id: '',
-					content: await nip04.encrypt(nostrPrivateKeyHex, receiverPublicKeyHex, content),
-					created_at: getUnixTime(
-						max([
-							nostrNotification.minCreatedAt ?? nostrNotification.createdAt,
-							nostrNotification.createdAt
-						])
-					),
+					content: nostrNotification.content, // Empty for public zaps
+					created_at: getUnixTime(new Date()),
 					pubkey: nostrPublicKeyHex,
-					tags: [
-						['p', receiverPublicKeyHex],
-						['bootikVersion', String(NOSTR_PROTOCOL_VERSION)]
-					],
+					tags,
 					kind: Kind.Zap,
 					sig: ''
 				} satisfies Event;

--- a/src/lib/server/locks/zap-lock.ts
+++ b/src/lib/server/locks/zap-lock.ts
@@ -1,0 +1,83 @@
+import { Lock } from '../lock';
+import { processClosed } from '../process';
+import { collections } from '../database';
+import { setTimeout } from 'node:timers/promises';
+import { lndLookupInvoice, isLndConfigured } from '../lnd';
+import { phoenixdLookupInvoice, isPhoenixdConfigured } from '../phoenixd';
+import { isNostrConfigured } from '../nostr';
+import { ObjectId } from 'mongodb';
+import { Kind } from 'nostr-tools';
+import { building } from '$app/environment';
+import { inspect } from 'node:util';
+
+const lock = new Lock('zaps');
+
+async function maintainZaps() {
+	while (!processClosed) {
+		if (!lock.ownsLock || !isNostrConfigured()) {
+			await setTimeout(5_000);
+			continue;
+		}
+
+		try {
+			const pendingZaps = await collections.pendingZaps
+				.find({
+					processedAt: { $exists: false }
+				})
+				.toArray();
+
+			await Promise.all(
+				pendingZaps.map(async (pendingZap) => {
+					try {
+						const paymentStatus = await (async () => {
+							if (pendingZap.processor === 'lnd' && isLndConfigured()) {
+								const invoice = await lndLookupInvoice(pendingZap.invoiceId);
+								return { isPaid: invoice.state === 'SETTLED', preimage: invoice.preimage };
+							}
+							if (pendingZap.processor === 'phoenixd' && isPhoenixdConfigured()) {
+								const invoice = await phoenixdLookupInvoice(pendingZap.invoiceId);
+								return { isPaid: invoice.isPaid, preimage: invoice.preimage };
+							}
+							return { isPaid: false, preimage: undefined };
+						})();
+
+						if (paymentStatus.isPaid && paymentStatus.preimage) {
+							// Create zap receipt notification
+							await collections.nostrNotifications.insertOne({
+								_id: new ObjectId(),
+								content: '', // NIP-57: empty for public zap
+								kind: Kind.Zap,
+								bolt11: pendingZap.bolt11,
+								preimage: paymentStatus.preimage,
+								zapRequest: pendingZap.zapRequest,
+								receiverPubkey: pendingZap.receiverPubkey,
+								senderPubkey: pendingZap.senderPubkey,
+								eventId: pendingZap.eventId,
+								createdAt: new Date(),
+								updatedAt: new Date()
+							});
+
+							// Mark as processed
+							await collections.pendingZaps.updateOne(
+								{ _id: pendingZap._id },
+								{ $set: { processedAt: new Date(), updatedAt: new Date() } }
+							);
+
+							console.log('Zap receipt created for invoice', pendingZap.invoiceId);
+						}
+					} catch (err) {
+						console.error('Error processing pending zap:', inspect(err, { depth: 10 }));
+					}
+				})
+			);
+		} catch (err) {
+			console.error('Error in maintainZaps:', inspect(err, { depth: 10 }));
+		}
+
+		await setTimeout(5_000);
+	}
+}
+
+if (!building) {
+	maintainZaps();
+}

--- a/src/lib/server/phoenixd.ts
+++ b/src/lib/server/phoenixd.ts
@@ -194,6 +194,7 @@ export async function phoenixdLookupInvoice(paymentHash: string) {
 		feesSat: json.fees,
 		receivedSat: json.receivedSat,
 		isPaid: json.isPaid,
+		preimage: json.preimage, // NIP-57: preimage for zap receipts
 		createdAt: new Date(json.createdAt),
 		completedAt: json.completedAt ? new Date(json.completedAt) : null,
 		externalId: json.externalId,

--- a/src/lib/types/NostRNotifications.ts
+++ b/src/lib/types/NostRNotifications.ts
@@ -9,7 +9,7 @@ export interface NostRNotification extends Timestamps {
 	_id: ObjectId;
 
 	content: string;
-	kind: Kind.EncryptedDirectMessage | Kind.Metadata;
+	kind: Kind.EncryptedDirectMessage | Kind.Metadata | Kind.Zap;
 
 	/**
 	 * When kind is Kind.EncryptedDirectMessage, this is the recipient's pubkey
@@ -20,4 +20,24 @@ export interface NostRNotification extends Timestamps {
 	minCreatedAt?: Date;
 
 	processedAt?: Date;
+
+	// NIP-57 Zap Receipt fields (when kind === Kind.Zap):
+
+	/** BOLT11 invoice (for zap receipt) */
+	bolt11?: string;
+
+	/** Payment preimage (for zap receipt) */
+	preimage?: string;
+
+	/** Stringified zap request event (for description tag of zap receipt) */
+	zapRequest?: string;
+
+	/** Receiver pubkey hex (for 'p' tag) */
+	receiverPubkey?: string;
+
+	/** Sender pubkey hex (for 'P' tag) */
+	senderPubkey?: string;
+
+	/** Optional event ID being zapped (for 'e' tag) */
+	eventId?: string;
 }

--- a/src/lib/types/PendingZap.ts
+++ b/src/lib/types/PendingZap.ts
@@ -1,0 +1,34 @@
+import type { ObjectId } from 'mongodb';
+import type { Timestamps } from './Timestamps';
+
+/**
+ * Pending zap waiting for payment confirmation
+ * NIP-57: https://github.com/nostr-protocol/nips/blob/master/57.md
+ */
+export interface PendingZap extends Timestamps {
+	_id: ObjectId;
+
+	/** Invoice payment hash (r_hash) */
+	invoiceId: string;
+
+	/** BOLT11 invoice string */
+	bolt11: string;
+
+	/** Stringified zap request event (kind 9734) */
+	zapRequest: string;
+
+	/** Receiver pubkey (hex) from 'p' tag of zap request */
+	receiverPubkey: string;
+
+	/** Sender pubkey (hex) from zap request event.pubkey */
+	senderPubkey: string;
+
+	/** Optional event ID being zapped (from 'e' tag) */
+	eventId?: string;
+
+	/** Lightning processor used */
+	processor: 'lnd' | 'phoenixd';
+
+	/** When zap receipt was published */
+	processedAt?: Date;
+}

--- a/src/routes/.well-known/lnurlp/[id]/+server.ts
+++ b/src/routes/.well-known/lnurlp/[id]/+server.ts
@@ -6,6 +6,7 @@ import { collections } from '$lib/server/database';
 import { SignJWT } from 'jose';
 import sharp from 'sharp';
 import { error } from '@sveltejs/kit';
+import { getNostrKeys, isNostrConfigured } from '$lib/server/nostr';
 
 export const OPTIONS = () => {
 	return new Response(null, {
@@ -76,7 +77,12 @@ export const GET = async ({ params, url }) => {
 			// values in millisatoshis
 			minSendable: 1,
 			maxSendable: SATOSHIS_PER_BTC * 1000,
-			metadata
+			metadata,
+			// NIP-57 Zaps
+			...(isNostrConfigured() && {
+				allowsNostr: true,
+				nostrPubkey: getNostrKeys().pubKeyHex
+			})
 		}),
 		{
 			headers: {

--- a/src/routes/lightning/pay/+server.ts
+++ b/src/routes/lightning/pay/+server.ts
@@ -6,6 +6,70 @@ import { error } from '@sveltejs/kit';
 import { jwtVerify } from 'jose';
 import { ObjectId } from 'mongodb';
 import { z } from 'zod';
+import { collections } from '$lib/server/database';
+import { getNostrKeys, isNostrConfigured } from '$lib/server/nostr';
+import { validateEvent, verifySignature } from 'nostr-tools';
+
+const ZAP_REQUEST_KIND = 9734;
+
+interface ZapRequestValidation {
+	valid: boolean;
+	error?: string;
+	/** Receiver pubkey (hex) from 'p' tag */
+	receiverPubkey?: string;
+	/** Sender pubkey (hex) from event.pubkey */
+	senderPubkey?: string;
+	/** Optional event ID being zapped from 'e' tag */
+	eventId?: string;
+	/** Already decoded zap request JSON string */
+	decodedRequest?: string;
+}
+
+/**
+ * Validate NIP-57 zap request event (kind 9734)
+ * Returns extracted data to avoid re-parsing in caller
+ */
+function validateZapRequest(nostrParam: string): ZapRequestValidation {
+	try {
+		const decodedRequest = decodeURIComponent(nostrParam);
+		const event = JSON.parse(decodedRequest);
+
+		// Must be kind 9734
+		if (event.kind !== ZAP_REQUEST_KIND) {
+			return { valid: false, error: `Invalid kind ${event.kind}, expected ${ZAP_REQUEST_KIND}` };
+		}
+
+		// Validate event signature
+		if (!validateEvent(event) || !verifySignature(event)) {
+			return { valid: false, error: 'Invalid event signature' };
+		}
+
+		// Must have 'p' tag (receiver)
+		const pTag = event.tags.find((t: string[]) => t[0] === 'p');
+		if (!pTag?.[1]) {
+			return { valid: false, error: 'Missing p tag' };
+		}
+
+		// Verify 'p' tag matches our pubkey
+		const { pubKeyHex } = getNostrKeys();
+		if (pTag[1] !== pubKeyHex) {
+			return { valid: false, error: 'Zap recipient does not match' };
+		}
+
+		// Extract optional 'e' tag (event being zapped)
+		const eTag = event.tags.find((t: string[]) => t[0] === 'e');
+
+		return {
+			valid: true,
+			receiverPubkey: pTag[1],
+			senderPubkey: event.pubkey,
+			eventId: eTag?.[1],
+			decodedRequest
+		};
+	} catch {
+		return { valid: false, error: 'Failed to parse zap request' };
+	}
+}
 
 export const OPTIONS = () => {
 	return new Response(null, {
@@ -25,7 +89,8 @@ export const GET = async ({ url }) => {
 	const {
 		amount,
 		metadata: metadataJwt,
-		comment
+		comment,
+		nostr
 	} = z
 		.object({
 			amount: z
@@ -34,7 +99,8 @@ export const GET = async ({ url }) => {
 				.min(1)
 				.max(SATOSHIS_PER_BTC * 1000),
 			metadata: z.string(),
-			comment: z.string().default('Zap !')
+			comment: z.string().default('Zap !'),
+			nostr: z.string().optional() // NIP-57: URL-encoded zap request event
 		})
 		.parse(Object.fromEntries(url.searchParams));
 	const result = await jwtVerify(
@@ -53,6 +119,31 @@ export const GET = async ({ url }) => {
 				milliSatoshis: true
 		  })
 		: await phoenixdCreateInvoice(amount / 1000, comment, new ObjectId().toString());
+
+	// NIP-57: Save pending zap if nostr parameter is provided
+	if (nostr && isNostrConfigured()) {
+		const validation = validateZapRequest(nostr);
+		if (validation.valid && validation.receiverPubkey && validation.senderPubkey) {
+			try {
+				await collections.pendingZaps.insertOne({
+					_id: new ObjectId(),
+					invoiceId: invoice.r_hash,
+					bolt11: invoice.payment_request,
+					zapRequest: validation.decodedRequest ?? '',
+					receiverPubkey: validation.receiverPubkey,
+					senderPubkey: validation.senderPubkey,
+					eventId: validation.eventId,
+					processor: isLndConfigured() ? 'lnd' : 'phoenixd',
+					createdAt: new Date(),
+					updatedAt: new Date()
+				});
+			} catch (err) {
+				console.error('Failed to save pending zap:', err);
+			}
+		} else if (!validation.valid) {
+			console.warn('Invalid zap request:', validation.error);
+		}
+	}
 
 	return new Response(
 		JSON.stringify({


### PR DESCRIPTION
Nostr clients (Amethyst, Primal, iris.to) now properly display zaps sent to be-BOP Lightning addresses. Previously, payments went through but showed "This address doesn't support Nostr zaps" because receipts weren't published.

Backwards compatible: non-zap Lightning tips continue working unchanged.

Closes #2255