### PR TITLE
Fix Nostr relay list reset after reboot (#2012)

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/nostr/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/nostr/+page.server.ts
@@ -153,18 +153,9 @@ export const actions = {
 		const formData = await request.formData();
 
 		const relays = z.string().array().parse(formData.getAll('relays'));
-		await collections.runtimeConfig.updateOne(
-			{
-				_id: 'nostrRelays'
-			},
-			{
-				$set: {
-					data: relays.filter((rel) => rel.startsWith('wss://')),
-					updatedAt: new Date()
-				}
-			}
-		);
-		runtimeConfig.nostrRelays = relays.filter((rel) => rel.startsWith('wss://'));
+		const filteredRelays = relays.filter((rel) => rel.startsWith('wss://'));
+		await persistConfigElement('nostrRelays', filteredRelays);
+		runtimeConfig.nostrRelays = filteredRelays;
 		return {
 			success: 'Relay list updated sucessfully !'
 		};


### PR DESCRIPTION
Fixes https://github.com/be-BOP-io-SA/be-BOP/issues/2012
  Previously, custom Nostr relay configurations set in Settings > Node Management > Nostr would reset to default values after restarting be-BOP.

  Now relay list changes are properly saved and persist across restarts.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)