### PR TITLE
Fix AgeWall redirect to original target URL (#2235)

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -517,6 +517,7 @@
 			<div class="grow body-mainPlan">
 				{#if data.ageRestriction.enabled && !data.sessionAcceptAgeLimitation && !$page.url.pathname.startsWith('/admin')}
 					<form class="mx-auto max-w-7xl" method="POST" action="{data.websiteLink}?/navigate">
+						<input type="hidden" name="redirectTo" value={$page.url.pathname + $page.url.search} />
 						{#if data.cmsAgewall && data.cmsAgewallData}
 							<CmsDesign
 								{...data.cmsAgewallData}

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -65,7 +65,19 @@ export const load = async ({ locals, url }) => {
 };
 
 export const actions = {
-	navigate: async ({ locals }) => {
+	navigate: async ({ locals, request }) => {
+		const formData = await request.formData();
+		let redirectTo = formData.get('redirectTo')?.toString() || '/';
+
+		// Only allow redirect to public pages (not employee-only areas)
+		if (
+			!redirectTo.startsWith('/') ||
+			redirectTo.startsWith('/admin') ||
+			redirectTo.startsWith('/pos')
+		) {
+			redirectTo = '/';
+		}
+
 		await collections.sessions.updateOne(
 			{
 				sessionId: locals.sessionId
@@ -82,6 +94,6 @@ export const actions = {
 			},
 			{ upsert: true }
 		);
-		throw redirect(303, `/`);
+		throw redirect(303, redirectTo);
 	}
 };


### PR DESCRIPTION
Fixes https://github.com/be-BOP-io-SA/be-BOP/issues/2235

  Previously, when visitors accepted the age restriction wall, they were always redirected to the homepage, regardless of which page they were trying to access.

  Now visitors are correctly redirected to their intended destination after accepting the age wall, including any URL parameters (e.g., language preferences).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)