### PR TITLE
🐛🤖 Fix Schedule widget options not working on mobile (#1930)

### DIFF
--- a/src/lib/components/ScheduleWidget.svelte
+++ b/src/lib/components/ScheduleWidget.svelte
@@ -80,7 +80,12 @@
 		/>
 	</div>
 	<div class="lg:hidden contents">
-		<svelte:component this={ScheduleWidgetMobile} {schedule} {pictures} class={className} />
+		<svelte:component
+			this={ScheduleWidgetMobile}
+			schedule={updatedSchedule}
+			{pictures}
+			class={className}
+		/>
 	</div>
 {:else}
 	<svelte:component


### PR DESCRIPTION
Schedule widget options "show past events" and "sort by date" were not applied on mobile devices, showing all events in their original order.

Now mobile displays events with the same filtering and sorting as desktop.

Closes #1930 