### PR TITLE
🐛🤖 Fix documentation encoding issues (#2307)

### DIFF
--- a/src/routes/(app)/docs/[lang]/[filename]/+server.ts
+++ b/src/routes/(app)/docs/[lang]/[filename]/+server.ts
@@ -34,6 +34,6 @@ export async function GET({ params }) {
 
 	return new Response(content, {
 		status: 200,
-		headers: { 'Content-Type': 'text/plain' }
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' }
 	});
 }


### PR DESCRIPTION
Documentation markdown files served from the back-office (`/docs/[lang]/[filename]`) were displaying encoding issues with special characters (é, è, ç, etc.) because the `Content-Type`  header was missing the charset declaration.

Added `charset=utf-8` to the response header so browsers correctly interpret the UTF-8 encoded content.

Partially fixes #2307