### PR TITLE
🦋🤖 Stack admin login buttons vertically with full width

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/login/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/login/+page.svelte
@@ -118,7 +118,9 @@
 				disabled={!!form?.disabledUser}
 			/>
 			{#if data.isAdminCreated}
-				<a href="{data.adminPrefix}/login/recovery" class="btn body-mainCTA w-full text-center">Recovery</a>
+				<a href="{data.adminPrefix}/login/recovery" class="btn body-mainCTA w-full text-center"
+					>Recovery</a
+				>
 			{/if}
 		</div>
 	</form>


### PR DESCRIPTION
Login and Recovery buttons on the admin login page were displayed side by side, which was inconsistent with the form layout.

Changed buttons to stack vertically with full width, matching the login/password input fields for a cleaner, more consistent appearance.

Closes https://github.com/be-BOP-io-SA/be-BOP/issues/2308