### PR TITLE
🐛🤖 Fix discount validation to allow up to 100% discounts

### DIFF
--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -981,7 +981,10 @@ export async function createOrder(
 		throw error(400, 'Missing billing address for deliveryless order');
 	}
 
-	if (paymentMethod === 'free' && totalSatoshis !== 0) {
+	if (
+		paymentMethod === 'free' &&
+		toCurrency(runtimeConfig.mainCurrency, totalSatoshis, 'SAT') > 0
+	) {
 		throw error(400, "You can't use free payment method on this order");
 	}
 


### PR DESCRIPTION
Fixes https://github.com/be-BOP-io-SA/be-BOP/issues/2270

  ## Summary
  - Employees with PoS options can now apply 100% percentage discounts (was limited to 
99%)
  - "Offrir la commande" checkbox correctly sets 100% discount
  - Fiat discounts equal to the full order amount now work correctly (e.g., 215€ discount on a 215€ order)

  ## What changed
  When logged as an employee with PoS options on `/checkout`, the discount validation now accepts:
  - Percentage discounts up to 100% (previously limited to 99%)
  - Fiat discounts equal to the exact order total (previously rejected with "La réduction n'est pas valable !")