### PR TITLE
🐛🤖 Fix wide logo setting not saving when clicking Update button

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/picture/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/picture/[id]/+page.server.ts
@@ -19,7 +19,27 @@ export const load = async ({ params }) => {
 
 export const actions: Actions = {
 	update: async function (input) {
-		const name = String((await input.request.formData()).get('name'));
+		const formData = await input.request.formData();
+		const name = String(formData.get('name'));
+		const logoIsWide = Boolean(formData.get('isWide'));
+
+		// If this picture is currently set as logo (light or dark mode), update the isWide setting
+		if (
+			runtimeConfig.logo.pictureId === input.params.id ||
+			runtimeConfig.logo.darkModePictureId === input.params.id
+		) {
+			await collections.runtimeConfig.updateOne(
+				{ _id: 'logo' },
+				{
+					$set: {
+						'data.isWide': logoIsWide,
+						updatedAt: new Date()
+					}
+				}
+			);
+			runtimeConfig.logo.isWide = logoIsWide;
+		}
+
 		await collections.pictures.updateOne(
 			{ _id: input.params.id },
 			{


### PR DESCRIPTION
Fixes https://github.com/be-BOP-io-SA/be-BOP/issues/2269

  ## Summary
  - The "Image will be a wide logo" checkbox now saves correctly when clicking the "Update" button
  - No more workaround needed (remove from logo → set as wide logo → set as logo)      

  ## What changed
  In the admin picture detail page (`/admin/picture/[id]`), when a picture is set as logo (or dark logo), the "Image will be a wide logo" checkbox setting now saves when clicking the "Update" button.

  Previously, this setting only saved when clicking "Set as logo" or "Remove from logo" buttons, requiring a workaround to change the wide logo setting after the picture was 
already assigned.