### PR TITLE
🐛🤖 Fix OAuth provider deletion redirecting to 404 error page

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/oauth/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/oauth/[id]/+page.server.ts
@@ -1,6 +1,7 @@
 import { collections } from '$lib/server/database.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
-import { error } from 'console';
+import { error, redirect } from '@sveltejs/kit';
+import { adminPrefix } from '$lib/server/admin';
 import { z } from 'zod';
 
 export const actions = {
@@ -71,5 +72,7 @@ export const actions = {
 				}
 			}
 		);
+
+		throw redirect(303, `${adminPrefix()}/oauth`);
 	}
 };


### PR DESCRIPTION
Fixes #2044

  ## Summary
  - Deleting an OAuth provider now redirects to `/admin/oauth` with no errors
  - Fixed 404 error that appeared after deletion

  ## What changed
  In the admin OAuth settings (`/admin/oauth`), when deleting an OAuth provider, the page now properly redirects back to the OAuth providers list instead of showing "Error 404, OAuth provider not found: {label}".

  Previously, the delete action had no redirect, causing the page to reload at the now-invalid URL `/admin/oauth/{id}/?delete` where the provider no longer exists.