### PR TITLE
🦋 Add POS cashback calculator with Z-ticket integration

### DIFF
--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -147,6 +147,7 @@ export async function onOrderPayment(
 		fees?: Price;
 		tapToPay?: { expiresAt: Date };
 		providedSession?: ClientSession;
+		cashbackAmount?: Price;
 	}
 ): Promise<Order> {
 	const invoiceNumber = ((await lastInvoiceNumber()) ?? 0) + 1;
@@ -177,6 +178,9 @@ export async function onOrderPayment(
 					}),
 					...(params?.detail && {
 						'payments.$.detail': params.detail
+					}),
+					...(params?.cashbackAmount && {
+						'payments.$.cashbackAmount': params.cashbackAmount
 					}),
 					'payments.$.paidAt': paidAt,
 					...(isOrderFullyPaid(order) && {

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -628,6 +628,14 @@
 			"replaceSubmit": "Ändern",
 			"tapToPay": "Kartenzahlung"
 		},
+		"cashback": {
+			"title": "Bargeldauszahlung ▾",
+			"toPay": "Zu zahlen",
+			"paid": "Bezahlt",
+			"change": "Rückgeld",
+			"cancel": "Bargeldauszahlung abbrechen",
+			"validate": "Bestätigen"
+		},
 		"input": {
 			"detail": "Detail",
 			"txNumber": "TX-Nr."

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -736,6 +736,14 @@
 			"tapToPay": "Card Tap",
 			"cancelTap": "Stop Tap"
 		},
+		"cashback": {
+			"title": "Cashback ▾",
+			"toPay": "To pay",
+			"paid": "Paid",
+			"change": "Change",
+			"cancel": "Cancel cashback",
+			"validate": "Validate"
+		},
 		"input": {
 			"txNumber": "TX #",
 			"detail": "Detail"

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -628,6 +628,14 @@
 			"replaceSubmit": "Cambiar",
 			"tapToPay": "Pago con tarjeta"
 		},
+		"cashback": {
+			"title": "Cambio de efectivo ▾",
+			"toPay": "A pagar",
+			"paid": "Pagado",
+			"change": "Vuelto",
+			"cancel": "Cancelar cambio",
+			"validate": "Validar"
+		},
 		"input": {
 			"detail": "Detalle",
 			"txNumber": "TX n°"

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -628,6 +628,14 @@
 			"replaceSubmit": "Modifier",
 			"tapToPay": "Paiement carte"
 		},
+		"cashback": {
+			"title": "Cashback ▾",
+			"toPay": "A payer",
+			"paid": "Payé",
+			"change": "A rendre",
+			"cancel": "Annuler cashback",
+			"validate": "Valider"
+		},
 		"input": {
 			"detail": "Détail",
 			"txNumber": "TX n°"

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -628,6 +628,14 @@
 			"replaceSubmit": "Modifica",
 			"tapToPay": "Pagamento carta"
 		},
+		"cashback": {
+			"title": "Resto ▾",
+			"toPay": "Da pagare",
+			"paid": "Pagato",
+			"change": "Resto",
+			"cancel": "Annulla resto",
+			"validate": "Conferma"
+		},
 		"input": {
 			"detail": "Dettaglio",
 			"txNumber": "TX n°"

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -639,6 +639,14 @@
 			"replaceSubmit": "Wijzigen",
 			"tapToPay": "Kaartbetaling"
 		},
+		"cashback": {
+			"title": "Wisselgeld ▾",
+			"toPay": "Te betalen",
+			"paid": "Betaald",
+			"change": "Wisselgeld",
+			"cancel": "Wisselgeld annuleren",
+			"validate": "Bevestigen"
+		},
 		"input": {
 			"detail": "Detail",
 			"txNumber": "TX nr."

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -628,6 +628,14 @@
 			"replaceSubmit": "Alterar",
 			"tapToPay": "Pagamento com cartão"
 		},
+		"cashback": {
+			"title": "Troco ▾",
+			"toPay": "A pagar",
+			"paid": "Pago",
+			"change": "Troco",
+			"cancel": "Cancelar troco",
+			"validate": "Validar"
+		},
 		"input": {
 			"detail": "Detalhe",
 			"txNumber": "TX n°"

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -160,6 +160,7 @@ export interface OrderPayment {
 	lastStatusNotified?: OrderPaymentStatus;
 	bankTransferNumber?: string;
 	detail?: string;
+	cashbackAmount?: Price;
 }
 
 export type SerializedOrderPayment = Omit<OrderPayment, '_id'> & {

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -149,7 +149,8 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 			confirmationBlocksRequired:
 				payment.method === 'bitcoin' ? getConfirmationBlocks(payment.price) : 0,
 			...(payment.bankTransferNumber && { bankTransferNumber: payment.bankTransferNumber }),
-			...(payment.detail && { detail: payment.detail })
+			...(payment.detail && { detail: payment.detail }),
+			...(payment.cashbackAmount && { cashbackAmount: payment.cashbackAmount })
 		})),
 		items: order.items.map((item) => ({
 			quantity: item.quantity,

--- a/src/routes/(app)/pos/closing/+page.server.ts
+++ b/src/routes/(app)/pos/closing/+page.server.ts
@@ -1,7 +1,8 @@
 import {
 	closePosSession,
 	getCurrentPosSession,
-	calculateDailyIncomes
+	calculateDailyIncomes,
+	calculateTotalCashback
 } from '$lib/server/pos-sessions';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { error, redirect } from '@sveltejs/kit';
@@ -18,6 +19,7 @@ export const load = async ({ locals }: { locals: App.Locals }) => {
 	}
 
 	const dailyIncomes = await calculateDailyIncomes(posSession);
+	const cashbackTotal = await calculateTotalCashback(posSession);
 
 	return {
 		session: {
@@ -31,6 +33,7 @@ export const load = async ({ locals }: { locals: App.Locals }) => {
 			amount: inc.amount,
 			currency: inc.currency
 		})),
+		cashbackTotal: cashbackTotal.amount,
 		cashDeltaJustificationMandatory: runtimeConfig.posSession.cashDeltaJustificationMandatory,
 		user: locals.user
 			? {

--- a/src/routes/(app)/pos/closing/+page.svelte
+++ b/src/routes/(app)/pos/closing/+page.svelte
@@ -10,7 +10,8 @@
 	$: cashIncome = data.incomes
 		.filter((i) => i.paymentSubtype === 'cash')
 		.reduce((sum, i) => sum + i.amount, 0);
-	$: theoreticalClosing = data.session.cashOpening.amount + cashIncome - (bankDepositAmount ?? 0);
+	$: totalOutcomes = (bankDepositAmount ?? 0) + data.cashbackTotal;
+	$: theoreticalClosing = data.session.cashOpening.amount + cashIncome - totalOutcomes;
 	$: cashDelta = (cashClosingAmount ?? 0) - theoreticalClosing;
 	$: hasCashDelta = Math.abs(cashDelta) > 0.01;
 	$: shouldShowJustification = hasCashDelta;
@@ -49,17 +50,25 @@
 			<!-- Daily Outcomes -->
 			<div>
 				<p class="font-semibold text-blue-700 mb-2">Daily outcomes:</p>
-				{#if (bankDepositAmount ?? 0) > 0}
-					<p class="ml-4">
-						• Bank deposit: {(bankDepositAmount ?? 0).toFixed(2)}
-						{data.session.cashOpening.currency}
-					</p>
+				{#if (bankDepositAmount ?? 0) > 0 || data.cashbackTotal > 0}
+					{#if (bankDepositAmount ?? 0) > 0}
+						<p class="ml-4">
+							• Bank deposit: {(bankDepositAmount ?? 0).toFixed(2)}
+							{data.session.cashOpening.currency}
+						</p>
+					{/if}
+					{#if data.cashbackTotal > 0}
+						<p class="ml-4">
+							• Cashback to customer: {data.cashbackTotal.toFixed(2)}
+							{data.session.cashOpening.currency}
+						</p>
+					{/if}
 				{:else}
 					<p class="ml-4 text-gray-500">No outcomes recorded</p>
 				{/if}
 				<p class="font-bold mt-3">Daily outcomes total:</p>
 				<p class="ml-0">
-					{(bankDepositAmount ?? 0).toFixed(2)}
+					{totalOutcomes.toFixed(2)}
 					{data.session.cashOpening.currency}
 				</p>
 			</div>
@@ -76,7 +85,7 @@
 					{data.session.cashOpening.currency}
 				</p>
 				<p class="ml-4">
-					• Daily cash outcomes: {(bankDepositAmount ?? 0).toFixed(2)}
+					• Daily cash outcomes: {totalOutcomes.toFixed(2)}
 					{data.session.cashOpening.currency}
 				</p>
 				<p class="ml-4">
@@ -156,6 +165,24 @@
 				<span class="text-gray-600">{data.session.cashOpening.currency}</span>
 			</div>
 		</div>
+
+		{#if data.cashbackTotal > 0}
+			<div>
+				<label for="cashbackTotal" class="form-label">
+					Cashback to customer (automatic count)
+				</label>
+				<div class="flex items-center gap-2">
+					<input
+						type="text"
+						id="cashbackTotal"
+						value={data.cashbackTotal.toFixed(2)}
+						class="form-input flex-1 bg-gray-100"
+						readonly
+					/>
+					<span class="text-gray-600">{data.session.cashOpening.currency}</span>
+				</div>
+			</div>
+		{/if}
 
 		{#if shouldShowJustification}
 			<div class="bg-yellow-50 border border-yellow-300 rounded-lg p-4">


### PR DESCRIPTION
🦋 POS cashback calculator with Z-ticket integration

POS cashiers can now calculate change directly on the payment screen. A new "Cashback" button appears next to "Change", opening a calculator section with:
- Amount to pay (from order)
- Amount paid by customer (editable)
- Change to return (auto-calculated, red if insufficient)

For non-cash payments (card, Twint, crypto), the cashback amount is automatically tracked and appears in the Z-ticket as "Cashback to customer" under Daily outcomes. This helps reconcile the cash drawer when customers pay by card but receive cash back.

Daily incomes now shows the actual amount received (order total + cashback), not just the order amount, giving accurate revenue reporting.

Closes #2286