### PR TITLE
🦋 Masking nsec like API keys and passwords with dots placeholders and unmask zpub

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/bitcoin-nodeless/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/bitcoin-nodeless/+page.svelte
@@ -25,7 +25,7 @@
 	<label class="form-label">
 		Public key (ZPub)
 		<input
-			type="password"
+			type="text"
 			name="publicKey"
 			class="form-input"
 			required

--- a/src/routes/(app)/admin[[hash=admin_hash]]/nostr/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/nostr/+page.svelte
@@ -80,6 +80,7 @@
 		Private Key (nsec format)
 		<input
 			bind:this={nsecInputEl}
+			type="password"
 			class="form-input"
 			name="privateKey"
 			bind:value={data.nostr.privateKey}


### PR DESCRIPTION
Fix #2263

  - Unmask ZPub public key field on /admin/bitcoin-nodeless (change from password to text input)
  - Mask nsec private key field on /admin/nostr (add password input type)
  - Improves security by hiding sensitive private keys
  - Improves usability by showing public keys that are not sensitive

For reminder, any page can be restricted to employees through Settings > ARM (/admin/arm)