### PR TITLE
🦋 Kitchen mid-ticket better format for bars and restaurants

### DIFF
--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -245,6 +245,7 @@ const baseConfig = {
 	posTabGroups: defaultPosTabGroups(),
 	posPoolEmptyIcon: '✅' as string | undefined,
 	posPoolOccupiedIcon: '⏳' as string | undefined,
+	posMidTicketTopBlankLines: 3,
 	posUseSelectForTags: false,
 	posPrefillTermOfUse: false,
 	posTapToPay: {

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -773,6 +773,11 @@
 			"motivePlaceholder": "z.B. Passeport gourmand",
 			"lockedWarning": "⚠️ Rabatt kann nach Zahlungsbeginn nicht mehr geändert werden",
 			"save": "Speichern"
+		},
+		"midTicket": {
+			"title": "Küchen-/Zwischenticket-Einstellungen",
+			"topBlankLines": "Anzahl der Leerzeilen oben auf dem Ticket (zum Einspannen)",
+			"topBlankLinesHint": "Standard: 0"
 		}
 	},
 	"product": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -773,6 +773,11 @@
 			"motivePlaceholder": "e.g., Passeport gourmand",
 			"lockedWarning": "⚠️ Cannot modify discount after payment has started",
 			"save": "Save"
+		},
+		"midTicket": {
+			"title": "Kitchen/Mid-Ticket Settings",
+			"topBlankLines": "Number of blank lines at the top of mid-ticket (for clamping)",
+			"topBlankLinesHint": "Default: 0"
 		}
 	},
 	"product": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -773,6 +773,11 @@
 			"lockedWarning": "⚠️ No se puede modificar el descuento después de iniciar el pago",
 			"save": "Guardar"
 		},
+		"midTicket": {
+			"title": "Configuración de ticket de cocina/intermedio",
+			"topBlankLines": "Número de líneas en blanco en la parte superior del ticket (para sujeción)",
+			"topBlankLinesHint": "Por defecto: 0"
+		},
 		"useSelectForTags": "Usar menú desplegable para etiquetas"
 	},
 	"product": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -773,6 +773,11 @@
 			"motivePlaceholder": "ex: Passeport gourmand",
 			"lockedWarning": "⚠️ Impossible de modifier la remise après le début du paiement",
 			"save": "Enregistrer"
+		},
+		"midTicket": {
+			"title": "Paramètres ticket cuisine/intermédiaire",
+			"topBlankLines": "Nombre de lignes vides en haut du ticket (pour le pince-ticket)",
+			"topBlankLinesHint": "Par défaut : 0"
 		}
 	},
 	"product": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -773,6 +773,11 @@
 			"lockedWarning": "⚠️ Impossibile modificare lo sconto dopo l'inizio del pagamento",
 			"save": "Salva"
 		},
+		"midTicket": {
+			"title": "Impostazioni ticket cucina/intermedio",
+			"topBlankLines": "Numero di righe vuote in cima al ticket (per il fissaggio)",
+			"topBlankLinesHint": "Predefinito: 0"
+		},
 		"useSelectForTags": "Usa menu a tendina per i tag"
 	},
 	"product": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -773,6 +773,11 @@
 			"lockedWarning": "⚠️ Korting kan niet worden gewijzigd nadat de betaling is gestart",
 			"save": "Opslaan"
 		},
+		"midTicket": {
+			"title": "Keuken-/tussenbon instellingen",
+			"topBlankLines": "Aantal lege regels bovenaan de bon (voor klemmen)",
+			"topBlankLinesHint": "Standaard: 0"
+		},
 		"useSelectForTags": "Gebruik dropdown voor tags"
 	},
 	"product": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -773,6 +773,11 @@
 			"motivePlaceholder": "ex. Passaporte gourmet",
 			"lockedWarning": "⚠️ Não é possível modificar o desconto após o início do pagamento",
 			"save": "Guardar"
+		},
+		"midTicket": {
+			"title": "Configurações de ticket de cozinha/intermediário",
+			"topBlankLines": "Número de linhas em branco no topo do ticket (para fixação)",
+			"topBlankLinesHint": "Padrão: 0"
 		}
 	},
 	"product": {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
@@ -58,6 +58,7 @@ export const load = async ({}) => {
 		posTabGroups: runtimeConfig.posTabGroups,
 		posPoolEmptyIcon: runtimeConfig.posPoolEmptyIcon,
 		posPoolOccupiedIcon: runtimeConfig.posPoolOccupiedIcon,
+		posMidTicketTopBlankLines: runtimeConfig.posMidTicketTopBlankLines,
 		defaultEmptyPoolIcon: defaultConfig.posPoolEmptyIcon,
 		defaultFullPoolIcon: defaultConfig.posPoolOccupiedIcon,
 		posUseSelectForTags: runtimeConfig.posUseSelectForTags,
@@ -119,6 +120,7 @@ export const actions: Actions = {
 				posTouchTag: z.string().array(),
 				posPoolEmptyIcon: z.string().optional(),
 				posPoolOccupiedIcon: z.string().optional(),
+				posMidTicketTopBlankLines: z.number({ coerce: true }).min(0).max(20).default(3),
 				tapToPayOnActivationUrl: z.string().trim().optional(),
 				tapToPayProvider: z.string().optional(),
 				posSession: z
@@ -175,6 +177,8 @@ export const actions: Actions = {
 		runtimeConfig.posPoolEmptyIcon = posPoolEmptyIcon;
 		await persistConfigElement('posPoolOccupiedIcon', posPoolOccupiedIcon);
 		runtimeConfig.posPoolOccupiedIcon = posPoolOccupiedIcon;
+		await persistConfigElement('posMidTicketTopBlankLines', result.posMidTicketTopBlankLines);
+		runtimeConfig.posMidTicketTopBlankLines = result.posMidTicketTopBlankLines;
 		await persistConfigElement('posUseSelectForTags', result.posUseSelectForTags);
 		runtimeConfig.posUseSelectForTags = result.posUseSelectForTags;
 		await persistConfigElement('posQrCodeAfterPayment', posQrCodeAfterPayment);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
@@ -303,6 +303,19 @@
 		<input type="text" name="posPoolEmptyIcon" class="form-input" bind:value={posPoolEmptyIcon} />
 	</label>
 
+	<label class="form-label">
+		{t('pos.midTicket.topBlankLines')}
+		<small class="text-gray-600">{t('pos.midTicket.topBlankLinesHint')}</small>
+		<input
+			type="number"
+			name="posMidTicketTopBlankLines"
+			class="form-input max-w-[10rem]"
+			min="0"
+			max="20"
+			value={data.posMidTicketTopBlankLines}
+		/>
+	</label>
+
 	<!-- svelte-ignore a11y-label-has-associated-control -->
 	<label class="form-label">
 		Tabs management

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.server.ts
@@ -1,5 +1,6 @@
 import { collections } from '$lib/server/database';
 import { buildTagGroupsForPrint, getOrCreateOrderTab } from '$lib/server/orderTab';
+import { runtimeConfig } from '$lib/server/runtime-config';
 
 export async function load({ locals, params, url }) {
 	const tab = await getOrCreateOrderTab({ slug: params.orderTabSlug });
@@ -22,7 +23,8 @@ export async function load({ locals, params, url }) {
 			poolLabel: historyEntry?.poolLabel ?? poolLabel,
 			generatedAt: new Date(),
 			tagGroups: historyEntry?.tagGroups ?? [],
-			showBebopLogo: false
+			showBebopLogo: false,
+			topBlankLines: runtimeConfig.posMidTicketTopBlankLines
 		};
 	}
 
@@ -67,6 +69,7 @@ export async function load({ locals, params, url }) {
 		poolLabel,
 		generatedAt: new Date(),
 		tagGroups,
-		showBebopLogo: false
+		showBebopLogo: false,
+		topBlankLines: runtimeConfig.posMidTicketTopBlankLines
 	};
 }

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.svelte
@@ -11,4 +11,5 @@
 	showBebopLogo={data.showBebopLogo}
 	showOnScreen={true}
 	showGroupHeaders={true}
+	topBlankLines={data.topBlankLines}
 />


### PR DESCRIPTION
Kitchen tickets in POS Touch now print each product category (drinks, food, etc.) as a separate section. Each section includes the table number and time, so tickets can be cut apart and each piece remains identifiable.

New features:
- Configurable blank lines at the top of tickets for clamping on ticket holders
- Each tag group prints independently with full header
- Fixed spacing at bottom for clean thermal printer cutting
- Settings available in Admin → POS with translations for all 7 languages

Also fixed: "All Items" print button now works reliably on repeated clicks.

Closes #2343