### PR TITLE
🦋 POS Touch UI for mobile phones

### DIFF
--- a/src/lib/components/CategorySelect.svelte
+++ b/src/lib/components/CategorySelect.svelte
@@ -88,12 +88,12 @@
 	<!-- bg-[#310d40] and text-white are added directly to avoid race condition with touch.css loading -->
 	<button
 		type="button"
-		class="touchScreen-category-cta bg-[#310d40] text-white w-full flex items-center justify-between text-3xl px-6 min-h-[4.25rem]"
+		class="touchScreen-category-cta bg-[#310d40] text-white w-full flex items-center justify-between text-xl lg:text-3xl px-3 lg:px-6 min-h-[2.25rem] lg:min-h-[4.25rem]"
 		on:click={toggleDropdown}
 	>
 		<span class="uppercase">{currentLabel}</span>
 		<svg
-			class="w-8 h-8 transition-transform {isOpen ? 'rotate-180' : ''}"
+			class="w-5 h-5 lg:w-8 lg:h-8 transition-transform {isOpen ? 'rotate-180' : ''}"
 			xmlns="http://www.w3.org/2000/svg"
 			fill="none"
 			viewBox="0 0 24 24"
@@ -128,7 +128,7 @@
 			{#if showBackButton}
 				<button
 					type="button"
-					class="w-full text-left px-6 py-4 text-2xl font-medium uppercase border-b border-gray-300 bg-gray-50 hover:bg-gray-100"
+					class="w-full text-left px-3 lg:px-6 py-2 lg:py-4 text-lg lg:text-2xl font-medium uppercase border-b border-gray-300 bg-gray-50 hover:bg-gray-100"
 					on:click={clearSelection}
 					role="menuitem"
 				>
@@ -139,7 +139,7 @@
 			{#each options as option, idx}
 				<button
 					type="button"
-					class="w-full text-left px-6 py-4 text-2xl font-medium uppercase border-b border-gray-200 transition-colors hover:bg-gray-100 hover:text-purple-600 {option.id ===
+					class="w-full text-left px-3 lg:px-6 py-2 lg:py-4 text-lg lg:text-2xl font-medium uppercase border-b border-gray-200 transition-colors hover:bg-gray-100 hover:text-purple-600 {option.id ===
 					currentFilter
 						? 'bg-purple-100 text-purple-600 font-bold'
 						: 'text-gray-900'}"

--- a/src/lib/components/PrintTicketModal.svelte
+++ b/src/lib/components/PrintTicketModal.svelte
@@ -63,7 +63,7 @@
 	>
 		<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 		<div
-			class="bg-white p-4 rounded-lg min-w-[800px] max-w-[90%] max-h-[90vh] shadow-lg flex flex-col"
+			class="bg-white p-4 rounded-lg w-[95vw] md:w-auto md:min-w-[800px] max-w-[90%] max-h-[90vh] shadow-lg flex flex-col"
 			on:click|stopPropagation
 			on:keydown|stopPropagation
 			role="dialog"
@@ -148,7 +148,7 @@
 						</div>
 					</div>
 				{:else if activeTab === 'history'}
-					<div class="max-h-[500px] overflow-y-auto">
+					<div class="max-h-[500px] overflow-y-auto overflow-x-auto">
 						{#if printHistory.length === 0}
 							<p class="text-center text-gray-500 py-8 text-xl">No print history available</p>
 						{:else}

--- a/src/lib/components/ProductWidget/ProductWidgetPOS.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetPOS.svelte
@@ -10,6 +10,10 @@
 	export let pictures: Picture[] | [];
 	export let product: Pick<Product, 'name' | '_id' | 'price' | 'stock'>;
 	export let tabSlug: string;
+	export let priceWithVat = 0;
+	export let currency = product.price.currency;
+	export let quantityInCart = 0;
+	export let isMobile = false;
 	let loading = false;
 	let className = '';
 	export { className as class };
@@ -45,16 +49,24 @@
 	<input type="hidden" name="tabSlug" value={tabSlug} />
 	<input type="hidden" name="productId" value={product._id} />
 	<button type="submit" disabled={!hasStock || loading}>
-		<div class="touchScreen-product-cta flex flex-row {className} max-h-[4em]">
-			<div>
-				<PictureComponent
-					picture={pictures[0]}
-					class="object-contain h-24 w-24"
-					style="object-fit: cover;"
-				/>
+		<div class="touchScreen-product-cta flex flex-col {className}">
+			<div class="relative {isMobile ? '' : 'flex flex-row'}">
+				<div class={isMobile ? 'w-full h-24 overflow-hidden' : 'shrink-0 w-24 h-24'}>
+					<PictureComponent picture={pictures[0]} class="w-full h-full object-cover" />
+				</div>
+				<div
+					class={isMobile
+						? 'absolute inset-0 bg-gradient-to-t from-black/80 to-transparent flex items-end p-2'
+						: 'static bg-none bg-transparent h-auto p-3 pt-0 pl-1 items-start text-left flex-1 min-w-0'}
+				>
+					<h2 class="line-clamp-2 break-words {isMobile ? 'font-bold text-white' : 'font-normal'}">
+						{product.name}
+					</h2>
+				</div>
 			</div>
-			<div class="p-3 flex items-start text-left">
-				<h2 class="text-3xl break-all break-words">{product.name}</h2>
+			<div class="flex justify-between items-center px-2 py-0.5 bg-black/40 text-base">
+				<span class="font-semibold text-white">{priceWithVat.toFixed(2)} {currency}</span>
+				<span class="font-bold text-white">x {quantityInCart}</span>
 			</div>
 		</div>
 	</button>

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -246,6 +246,8 @@ const baseConfig = {
 	posPoolEmptyIcon: '✅' as string | undefined,
 	posPoolOccupiedIcon: '⏳' as string | undefined,
 	posMidTicketTopBlankLines: 3,
+	posProductsPerPage: 0,
+	posMobileBreakpoint: 1024,
 	posUseSelectForTags: false,
 	posPrefillTermOfUse: false,
 	posTapToPay: {

--- a/src/lib/utils/swipe.ts
+++ b/src/lib/utils/swipe.ts
@@ -1,0 +1,45 @@
+const SWIPE_THRESHOLD = 50;
+
+type SwipeParams = {
+	onSwipeLeft?: () => void;
+	onSwipeRight?: () => void;
+	enabled?: boolean;
+};
+
+export function swipe(node: HTMLElement, params: SwipeParams) {
+	let touchStartX = 0;
+
+	function handleTouchStart(e: TouchEvent) {
+		touchStartX = e.touches[0].clientX;
+	}
+
+	function handleTouchEnd(e: TouchEvent) {
+		if (params.enabled === false) {
+			return;
+		}
+
+		const touchEndX = e.changedTouches[0].clientX;
+		const diff = touchEndX - touchStartX;
+
+		if (Math.abs(diff) > SWIPE_THRESHOLD) {
+			if (diff > 0) {
+				params.onSwipeRight?.();
+			} else {
+				params.onSwipeLeft?.();
+			}
+		}
+	}
+
+	node.addEventListener('touchstart', handleTouchStart);
+	node.addEventListener('touchend', handleTouchEnd);
+
+	return {
+		update(newParams: SwipeParams) {
+			params = newParams;
+		},
+		destroy() {
+			node.removeEventListener('touchstart', handleTouchStart);
+			node.removeEventListener('touchend', handleTouchEnd);
+		}
+	};
+}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
@@ -61,6 +61,8 @@ export const load = async ({}) => {
 		posMidTicketTopBlankLines: runtimeConfig.posMidTicketTopBlankLines,
 		defaultEmptyPoolIcon: defaultConfig.posPoolEmptyIcon,
 		defaultFullPoolIcon: defaultConfig.posPoolOccupiedIcon,
+		posProductsPerPage: runtimeConfig.posProductsPerPage,
+		posMobileBreakpoint: runtimeConfig.posMobileBreakpoint,
 		posUseSelectForTags: runtimeConfig.posUseSelectForTags,
 		posPrefillTermOfUse: runtimeConfig.posPrefillTermOfUse,
 		posDisplayOrderQrAfterPayment: runtimeConfig.posDisplayOrderQrAfterPayment,
@@ -105,6 +107,8 @@ export const actions: Actions = {
 			.object({
 				posDisplayOrderQrAfterPayment: z.boolean({ coerce: true }),
 				posPrefillTermOfUse: z.boolean({ coerce: true }),
+				posProductsPerPage: z.number({ coerce: true }).min(0).default(0),
+				posMobileBreakpoint: z.number({ coerce: true }).min(500).max(1500).default(1024),
 				posUseSelectForTags: z.boolean({ coerce: true }),
 				posTabGroups: z
 					.object({
@@ -181,6 +185,10 @@ export const actions: Actions = {
 		runtimeConfig.posPoolOccupiedIcon = posPoolOccupiedIcon;
 		await persistConfigElement('posMidTicketTopBlankLines', result.posMidTicketTopBlankLines);
 		runtimeConfig.posMidTicketTopBlankLines = result.posMidTicketTopBlankLines;
+		await persistConfigElement('posProductsPerPage', result.posProductsPerPage);
+		runtimeConfig.posProductsPerPage = result.posProductsPerPage;
+		await persistConfigElement('posMobileBreakpoint', result.posMobileBreakpoint);
+		runtimeConfig.posMobileBreakpoint = result.posMobileBreakpoint;
 		await persistConfigElement('posUseSelectForTags', result.posUseSelectForTags);
 		runtimeConfig.posUseSelectForTags = result.posUseSelectForTags;
 		await persistConfigElement('posQrCodeAfterPayment', posQrCodeAfterPayment);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
@@ -326,6 +326,33 @@
 		/>
 	</label>
 
+	<label class="form-label">
+		Products per page in POS Touch
+		<small class="text-gray-600">Set to 0 for automatic calculation based on screen size</small>
+		<input
+			type="number"
+			name="posProductsPerPage"
+			class="form-input"
+			min="0"
+			value={data.posProductsPerPage ?? 0}
+		/>
+	</label>
+
+	<label class="form-label">
+		Mobile breakpoint (px)
+		<small class="text-gray-600"
+			>Screen width below which mobile layout is used (500-1500, default: 1024)</small
+		>
+		<input
+			type="number"
+			name="posMobileBreakpoint"
+			class="form-input max-w-[10rem]"
+			min="500"
+			max="1500"
+			value={data.posMobileBreakpoint ?? 1024}
+		/>
+	</label>
+
 	<!-- svelte-ignore a11y-label-has-associated-control -->
 	<label class="form-label">
 		Tabs management

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+layout.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+layout.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-	<meta name="viewport" content="width=1024" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 </svelte:head>
 <main class="top-0 bottom-0 right-0 left-0 bg-white">
 	<slot />

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
@@ -170,6 +170,8 @@ export const load = async ({ locals, depends, params }) => {
 		posPoolOccupiedIcon: runtimeConfig.posPoolOccupiedIcon ?? defaultConfig.posPoolOccupiedIcon,
 		allOrderTabs: pojo(allOrderTabs),
 		tabSlug,
+		posProductsPerPage: runtimeConfig.posProductsPerPage ?? 0,
+		posMobileBreakpoint: runtimeConfig.posMobileBreakpoint ?? 1024,
 		posUseSelectForTags: runtimeConfig.posUseSelectForTags,
 		printTags: pojo(printTags),
 		tagGroups: tagGroupsData.groups,

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+layout.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+layout.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-	<meta name="viewport" content="width=1024" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 </svelte:head>
 <main class="top-0 bottom-0 right-0 left-0 bg-white">
 	<slot />

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
@@ -162,6 +162,7 @@ export const load = async ({ depends, locals, params }) => {
 	return {
 		orderTab,
 		tabSlug,
+		posMobileBreakpoint: runtimeConfig.posMobileBreakpoint ?? 1024,
 		sharesOrder: sharesOrderData,
 		availablePaymentMethods: methods,
 		paymentSubtypes: posSubtypes.map((s) => ({

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/touch.css
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/touch.css
@@ -58,3 +58,48 @@
 .touchScreen-action-delete {
 	background-color: var(--touchScreen-action-delete-backgroundColor);
 }
+.touchScreen-product-cta h2 {
+	font-size: 24px !important;
+}
+
+.pos-mobile .touchScreen-product-cta h2 {
+	font-size: 14px !important;
+}
+
+/* Mobile panel toggle buttons: hidden by default, visible when .pos-mobile */
+.mobile-panel-toggle {
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background-color: #4a5568;
+	color: white;
+	padding: 1rem 0.5rem;
+	font-size: 1.5rem;
+	z-index: 10;
+	border: none;
+	cursor: pointer;
+}
+
+.pos-mobile .mobile-panel-toggle {
+	display: block;
+}
+
+.mobile-panel-toggle-left {
+	left: 0;
+	border-radius: 0 0.5rem 0.5rem 0;
+}
+
+.mobile-panel-toggle-right {
+	right: 0;
+	border-radius: 0.5rem 0 0 0.5rem;
+}
+
+/* Line clamp for product names */
+.line-clamp-2 {
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}


### PR DESCRIPTION
POS Touch now works natively on mobile phones. Previously it was hardcoded to a 1024px viewport, rendering as a desktop page on phones. Now both the catalog and split payment screens adapt to any screen size.

- Single-column layout on mobile with swipe gestures to switch between cart and catalog
- Redesigned product cards: vertical with image overlay on mobile, price and quantity always visible
- Auto-calculated pagination fills the screen optimally (or set a fixed number in admin)
- Split screen: sticky footer and SUBTOTAL section, portrait-optimized split mode buttons
- All UI elements (category selector, pool modal, ticket modal, buttons) scaled for touch on small screens
- Category filter preserved when switching pools
- Admin setting added: "Products per page in POS Touch" (set to 0 for automatic screen-based calculation).

Closes #2292