### PR TITLE
🦋 Restrict pool changes after mid-ticket print

### DIFF
--- a/src/lib/components/ItemEditDialog.svelte
+++ b/src/lib/components/ItemEditDialog.svelte
@@ -8,6 +8,7 @@
 		product: { name: string; maxQuantityPerOrder?: number };
 	};
 	export let onClose: (_: { note?: string; quantity?: number }) => Promise<void>;
+	export let errorMessage = '';
 
 	let note = item.internalNote?.value || '';
 	let quantity = item.quantity;
@@ -173,6 +174,12 @@
 				></textarea>
 			</div>
 		</div>
+
+		{#if errorMessage}
+			<div class="bg-red-100 border-2 border-red-400 p-3 mx-6 rounded">
+				<p class="text-red-600 text-xl text-center font-bold">{errorMessage}</p>
+			</div>
+		{/if}
 
 		<!-- Footer -->
 		<div class="px-6 py-4 border-t border-gray-200 grid grid-cols-2 gap-4">

--- a/src/lib/server/orderTab.ts
+++ b/src/lib/server/orderTab.ts
@@ -321,9 +321,16 @@ export async function handleOrderTabAfterPayment({
 			.map((item) => {
 				const tabItem = orderTab?.items.find((i) => item._id && i._id.equals(item._id));
 				const currentQuantity = tabItem?.quantity || 0;
+				const currentPrintedQuantity = tabItem?.printedQuantity ?? 0;
+				const printedQuantityDecrement = Math.min(item.quantity, currentPrintedQuantity);
 
 				const updateFields: Record<string, unknown> = {
-					$inc: { 'items.$.quantity': -item.quantity }
+					$inc: {
+						'items.$.quantity': -item.quantity,
+						...(printedQuantityDecrement > 0 && {
+							'items.$.printedQuantity': -printedQuantityDecrement
+						})
+					}
 				};
 
 				if (currentQuantity === item.quantity) {

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -279,7 +279,8 @@ const baseConfig = {
 	posSession: {
 		enabled: false,
 		allowXTicketEditing: false,
-		cashDeltaJustificationMandatory: false
+		cashDeltaJustificationMandatory: false,
+		lockItemsAfterMidTicket: true
 	},
 	displayNewsletterCommercialProspection: false,
 	cartMaxSeparateItems: null as null | number,

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -712,7 +712,10 @@
 			"notDeveloped": "Noch nicht entwickelt",
 			"confirmDeleteLastItem": "Möchten Sie die letzte Warenkorb-Zeile löschen?",
 			"confirmDeleteAllItems": "Möchten Sie alle Warenkorb-Zeilen löschen?",
-			"maxQuantityReached": "Maximale Menge pro Bestellung erreicht ({max})"
+			"maxQuantityReached": "Maximale Menge pro Bestellung erreicht ({max})",
+			"itemPrintedCannotDelete": "Dieser Artikel wurde auf einem Küchenbon gedruckt und kann nicht gelöscht werden",
+			"itemPrintedCannotReduce": "Die Menge kann nicht unter die gedruckte Menge reduziert werden: {min}",
+			"poolHasPrintedItems": "Dieser Pool enthält gedruckte Artikel und kann nicht gelöscht werden"
 		},
 		"itemEdit": {
 			"quantity": "Menge",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -685,7 +685,10 @@
 			"notDeveloped": "Not developed yet",
 			"confirmDeleteLastItem": "Do you want to delete the last cart line?",
 			"confirmDeleteAllItems": "Do you want to delete all cart lines?",
-			"maxQuantityReached": "Maximum quantity per order reached ({max})"
+			"maxQuantityReached": "Maximum quantity per order reached ({max})",
+			"itemPrintedCannotDelete": "This item has been printed on a kitchen ticket and cannot be deleted",
+			"itemPrintedCannotReduce": "Cannot reduce quantity below printed amount: {min}",
+			"poolHasPrintedItems": "This pool contains printed items and cannot be deleted"
 		},
 		"itemEdit": {
 			"quantity": "Quantity",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -711,7 +711,10 @@
 			"notDeveloped": "Aún no desarrollado",
 			"confirmDeleteLastItem": "¿Quieres eliminar la última línea del carrito?",
 			"confirmDeleteAllItems": "¿Quieres eliminar todas las líneas del carrito?",
-			"maxQuantityReached": "Cantidad máxima por pedido alcanzada ({max})"
+			"maxQuantityReached": "Cantidad máxima por pedido alcanzada ({max})",
+			"itemPrintedCannotDelete": "Este artículo fue impreso en un ticket de cocina y no puede ser eliminado",
+			"itemPrintedCannotReduce": "No se puede reducir la cantidad por debajo de la cantidad impresa: {min}",
+			"poolHasPrintedItems": "Este pool contiene artículos impresos y no puede ser eliminado"
 		},
 		"itemEdit": {
 			"quantity": "Cantidad",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -712,7 +712,10 @@
 			"notDeveloped": "Pas encore développé",
 			"confirmDeleteLastItem": "Voulez-vous supprimer la dernière ligne du panier ?",
 			"confirmDeleteAllItems": "Voulez-vous supprimer toutes les lignes du panier ?",
-			"maxQuantityReached": "Quantité maximale par commande atteinte ({max})"
+			"maxQuantityReached": "Quantité maximale par commande atteinte ({max})",
+			"itemPrintedCannotDelete": "Cet article a été imprimé sur un ticket cuisine et ne peut pas être supprimé",
+			"itemPrintedCannotReduce": "Impossible de réduire la quantité en dessous de la quantité imprimée : {min}",
+			"poolHasPrintedItems": "Ce pool contient des articles imprimés et ne peut pas être supprimé"
 		},
 		"itemEdit": {
 			"quantity": "Quantité",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -711,7 +711,10 @@
 			"notDeveloped": "Non ancora sviluppato",
 			"confirmDeleteLastItem": "Vuoi eliminare l'ultima riga del carrello?",
 			"confirmDeleteAllItems": "Vuoi eliminare tutte le righe del carrello?",
-			"maxQuantityReached": "Quantità massima per ordine raggiunta ({max})"
+			"maxQuantityReached": "Quantità massima per ordine raggiunta ({max})",
+			"itemPrintedCannotDelete": "Questo articolo è stato stampato su un ticket cucina e non può essere eliminato",
+			"itemPrintedCannotReduce": "Non è possibile ridurre la quantità al di sotto della quantità stampata: {min}",
+			"poolHasPrintedItems": "Questo pool contiene articoli stampati e non può essere eliminato"
 		},
 		"itemEdit": {
 			"quantity": "Quantità",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -711,7 +711,10 @@
 			"notDeveloped": "Nog niet ontwikkeld",
 			"confirmDeleteLastItem": "Wil je de laatste winkelwagen regel verwijderen?",
 			"confirmDeleteAllItems": "Wil je alle winkelwagen regels verwijderen?",
-			"maxQuantityReached": "Maximale hoeveelheid per bestelling bereikt ({max})"
+			"maxQuantityReached": "Maximale hoeveelheid per bestelling bereikt ({max})",
+			"itemPrintedCannotDelete": "Dit artikel is afgedrukt op een keukenbon en kan niet worden verwijderd",
+			"itemPrintedCannotReduce": "De hoeveelheid kan niet worden verminderd onder de afgedrukte hoeveelheid: {min}",
+			"poolHasPrintedItems": "Deze pool bevat afgedrukte artikelen en kan niet worden verwijderd"
 		},
 		"itemEdit": {
 			"quantity": "Hoeveelheid",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -712,7 +712,10 @@
 			"notDeveloped": "Ainda não desenvolvido",
 			"confirmDeleteLastItem": "Quer eliminar a última linha do carrinho?",
 			"confirmDeleteAllItems": "Quer eliminar todas as linhas do carrinho?",
-			"maxQuantityReached": "Quantidade máxima por encomenda atingida ({max})"
+			"maxQuantityReached": "Quantidade máxima por encomenda atingida ({max})",
+			"itemPrintedCannotDelete": "Este artigo foi impresso num ticket de cozinha e não pode ser eliminado",
+			"itemPrintedCannotReduce": "Não é possível reduzir a quantidade abaixo da quantidade impressa: {min}",
+			"poolHasPrintedItems": "Este pool contém artigos impressos e não pode ser eliminado"
 		},
 		"itemEdit": {
 			"quantity": "Quantidade",

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
@@ -127,12 +127,14 @@ export const actions: Actions = {
 					.object({
 						enabled: z.boolean({ coerce: true }).default(false),
 						allowXTicketEditing: z.boolean({ coerce: true }).default(false),
-						cashDeltaJustificationMandatory: z.boolean({ coerce: true }).default(false)
+						cashDeltaJustificationMandatory: z.boolean({ coerce: true }).default(false),
+						lockItemsAfterMidTicket: z.boolean({ coerce: true }).default(true)
 					})
 					.default({
 						enabled: false,
 						allowXTicketEditing: false,
-						cashDeltaJustificationMandatory: false
+						cashDeltaJustificationMandatory: false,
+						lockItemsAfterMidTicket: true
 					})
 			})
 			.parse({

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
@@ -208,6 +208,16 @@
 	<label class="checkbox-label">
 		<input
 			type="checkbox"
+			name="posSession.lockItemsAfterMidTicket"
+			class="form-checkbox"
+			checked={data.posSession.lockItemsAfterMidTicket}
+		/>
+		Forbid item deletion / qty reduction, after mid-ticket print
+	</label>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
 			name="posUseSelectForTags"
 			class="form-checkbox"
 			bind:checked={posUseSelectForTags}

--- a/src/routes/(app)/pos/+page.server.ts
+++ b/src/routes/(app)/pos/+page.server.ts
@@ -99,6 +99,13 @@ export const actions: Actions = {
 			return fail(403, { error: 'sharesPaymentStarted' });
 		}
 
+		if (runtimeConfig.posSession.lockItemsAfterMidTicket) {
+			const item = orderTab.items.find((i) => i._id.toString() === tabItemId);
+			if (item && (item.printedQuantity ?? 0) > 0) {
+				return fail(403, { error: 'itemPrintedCannotDelete' });
+			}
+		}
+
 		await removeFromOrderTab({ tabSlug, tabItemId });
 	},
 	removeTab: async ({ request }) => {
@@ -114,6 +121,12 @@ export const actions: Actions = {
 		const orderTab = await getOrCreateOrderTab({ slug: tabSlug });
 		if (await hasSharesPaymentStarted(orderTab._id)) {
 			return fail(403, { error: 'sharesPaymentStarted' });
+		}
+
+		if (runtimeConfig.posSession.lockItemsAfterMidTicket) {
+			if (orderTab.items.some((i) => (i.printedQuantity ?? 0) > 0)) {
+				return fail(403, { error: 'poolHasPrintedItems' });
+			}
 		}
 
 		await removeOrderTab({ tabSlug });

--- a/src/routes/(app)/pos/touch/tab/[slug]/items/+server.ts
+++ b/src/routes/(app)/pos/touch/tab/[slug]/items/+server.ts
@@ -19,6 +19,7 @@ type HydratedItem = {
 	_id: string;
 	product: ProductProjection;
 	quantity: number;
+	printedQuantity?: number;
 	internalNote?: {
 		value: string;
 		updatedAt: Date;
@@ -55,6 +56,7 @@ async function hydratedOrderItems(
 				_id: item._id.toString(),
 				product: { ...product, vatProfileId: product.vatProfileId?.toString() },
 				quantity: item.quantity,
+				printedQuantity: item.printedQuantity,
 				internalNote: item.internalNote && {
 					value: item.internalNote.value,
 					updatedAt: item.internalNote.updatedAt


### PR DESCRIPTION
After printing a kitchen ticket (mid-ticket) in POS Touch, printed items are now protected: they cannot be deleted, and their quantity cannot be reduced below the printed amount. Pools containing printed items cannot be deleted either. This prevents revenue loss when staff removes items after they have already been sent to the kitchen/bar.

- Quantity increase and adding new items remain unrestricted
- Moving items between pools is allowed — printedQuantity transfers
    correctly using "unprinted first" principle
- Config toggle in Admin → POS: "Forbid item deletion / qty reduction,
    after mid-ticket print" (enabled by default)