### PR TITLE
🦋 Clean order page layout for POS touch mode

### DIFF
--- a/src/lib/components/Order/CardPayment.svelte
+++ b/src/lib/components/Order/CardPayment.svelte
@@ -8,10 +8,15 @@
 
 	export let payment: SerializedOrderPayment;
 	export let orderId: string;
+	export let returnTo: string | undefined = undefined;
+
+	$: payUrl = returnTo
+		? `/order/${orderId}/payment/${payment.id}/pay?returnTo=${encodeURIComponent(returnTo)}`
+		: `/order/${orderId}/payment/${payment.id}/pay`;
 </script>
 
 {#if payment.status === 'pending'}
-	<a href="/order/{orderId}/payment/{payment.id}/pay" class="body-hyperlink">
+	<a href={payUrl} class="body-hyperlink">
 		<span>{t('order.paymentLink')}</span>
 		{#if payment.processor === 'sumup'}
 			<IconSumupWide class="h-12 order-creditCard-svg" />
@@ -23,6 +28,8 @@
 				alt="PayPal"
 				class="h-12"
 			/>
+		{:else if payment.processor}
+			<span class="text-sm text-gray-500">{payment.processor}</span>
 		{/if}
 	</a>
 {/if}

--- a/src/lib/components/Order/PayPalPayment.svelte
+++ b/src/lib/components/Order/PayPalPayment.svelte
@@ -6,13 +6,15 @@
 
 	export let payment: SerializedOrderPayment;
 	export let orderId: string;
+	export let returnTo: string | undefined = undefined;
+
+	$: payUrl = returnTo
+		? `/order/${orderId}/payment/${payment.id}/pay?returnTo=${encodeURIComponent(returnTo)}`
+		: `/order/${orderId}/payment/${payment.id}/pay`;
 </script>
 
 {#if payment.status === 'pending'}
-	<a
-		href="/order/{orderId}/payment/{payment.id}/pay"
-		class="paypal-payment-link body-hyperlink flex items-center gap-2"
-	>
+	<a href={payUrl} class="paypal-payment-link body-hyperlink flex items-center gap-2">
 		<img
 			src="https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-200px.png"
 			alt="PayPal"

--- a/src/lib/components/Order/PaymentActions.svelte
+++ b/src/lib/components/Order/PaymentActions.svelte
@@ -59,7 +59,7 @@
 			disabled={!receiptReady}
 			on:click={printReceipt}
 		>
-			Print receipt (A4)
+			{posMode ? t('pos.receipt.invoice') : 'Print receipt (A4)'}
 		</button>
 		<button
 			class="body-hyperlink self-start"
@@ -67,7 +67,7 @@
 			disabled={!ticketReady}
 			on:click={printTicket}
 		>
-			Print receipt (ticket)
+			{posMode ? t('pos.receipt.ticket') : 'Print receipt (ticket)'}
 		</button>
 	{/if}
 
@@ -89,7 +89,7 @@
 			disabled={!receiptReady}
 			on:click={printReceipt}
 		>
-			Print receipt (A4)
+			{posMode ? t('pos.receipt.invoice') : 'Print receipt (A4)'}
 		</button>
 		<button
 			class="btn btn-black self-start"
@@ -97,7 +97,7 @@
 			disabled={!ticketReady}
 			on:click={printTicket}
 		>
-			Print receipt (ticket)
+			{posMode ? t('pos.receipt.ticket') : 'Print receipt (ticket)'}
 		</button>
 	{/if}
 
@@ -357,8 +357,10 @@
 			<input
 				class="form-input"
 				type="text"
-				name={payment.method === 'bank-transfer' ? 'bankTransferNumber' : 'detail'}
-				value={payment.method === 'bank-transfer' ? payment.bankTransferNumber : payment.detail}
+				name="paymentDetail"
+				value={payment.method === 'bank-transfer'
+					? payment.bankTransferNumber ?? ''
+					: payment.detail ?? ''}
 				disabled={disableInfoChange}
 			/>
 			<button type="submit" class="btn btn-blue" disabled={disableInfoChange}>

--- a/src/lib/components/Order/PaymentItem.svelte
+++ b/src/lib/components/Order/PaymentItem.svelte
@@ -20,6 +20,7 @@
 	export let hideCreditCardQrCode: boolean | undefined = undefined;
 	export let sellerIdentity: SellerIdentity | null | undefined = undefined;
 	export let posSubtypes: Array<{ slug: string; name: string }> | undefined = undefined;
+	export let returnTo: string | undefined = undefined;
 
 	// Registry of dynamic components
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -35,9 +36,9 @@
 
 <details
 	class="payment-item border border-gray-300 rounded-xl p-4"
-	open={posMode || payment.status === 'pending'}
+	open={payment.status === 'pending'}
 >
-	<summary class="lg:text-xl cursor-pointer">
+	<summary class="{posMode ? 'text-xl' : 'lg:text-xl'} cursor-pointer">
 		<span class="items-center inline-flex gap-2">
 			{t(`checkout.paymentMethod.${payment.method}`)}
 
@@ -67,6 +68,7 @@
 				{orderId}
 				{sellerIdentity}
 				{posMode}
+				{returnTo}
 			/>
 		{:else if payment.method === 'point-of-sale'}
 			<PointOfSalePayment />

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -740,7 +740,7 @@
 			"shares": "Anteile",
 			"itemize": "aufschlüsseln",
 			"return": "Zurück",
-			"continueSplit": "Aufteilung fortsetzen ({mode})",
+			"continueSplit": "Weiter",
 			"paySelected": "Auswahl bezahlen",
 			"includingVatIncluded": "Davon (inkl. MwSt):",
 			"tagProducts": "Produkte \"{name}\"",
@@ -760,6 +760,11 @@
 			"beforeDiscount": "VOR RABATT",
 			"afterDiscount": "NACH RABATT"
 		},
+		"receipt": {
+			"ticket": "Beleg (Ticket)",
+			"invoice": "Rechnung (A4)"
+		},
+		"staffNotes": "Mitarbeiternotizen",
 		"discount": {
 			"title": "Rabatt",
 			"noDiscount": "Kein Rabatt",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -713,7 +713,7 @@
 			"shares": "shares",
 			"itemize": "itemize",
 			"return": "Return",
-			"continueSplit": "Continue split ({mode})",
+			"continueSplit": "Continue",
 			"paySelected": "Pay selected",
 			"includingVatIncluded": "Including (VAT included):",
 			"tagProducts": "Tag \"{name}\" products",
@@ -733,6 +733,11 @@
 			"beforeDiscount": "BEFORE DISCOUNT",
 			"afterDiscount": "AFTER DISCOUNT"
 		},
+		"receipt": {
+			"ticket": "Receipt (ticket)",
+			"invoice": "Invoice (A4)"
+		},
+		"staffNotes": "Staff notes",
 		"btn": {
 			"add": "Add",
 			"cancel": "Cancel",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -739,7 +739,7 @@
 			"shares": "partes",
 			"itemize": "detallar",
 			"return": "Volver",
-			"continueSplit": "Continuar división ({mode})",
+			"continueSplit": "Continuar",
 			"paySelected": "Pagar selección",
 			"includingVatIncluded": "Incluyendo (IVA incluido):",
 			"tagProducts": "Productos \"{name}\"",
@@ -759,6 +759,11 @@
 			"beforeDiscount": "ANTES DEL DESCUENTO",
 			"afterDiscount": "DESPUÉS DEL DESCUENTO"
 		},
+		"receipt": {
+			"ticket": "Recibo (ticket)",
+			"invoice": "Factura (A4)"
+		},
+		"staffNotes": "Notas del personal",
 		"discount": {
 			"title": "Descuento",
 			"noDiscount": "Sin descuento",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -740,7 +740,7 @@
 			"shares": "parts",
 			"itemize": "détailler",
 			"return": "Retour",
-			"continueSplit": "Continuer division ({mode})",
+			"continueSplit": "Continuer",
 			"paySelected": "Payer la sélection",
 			"includingVatIncluded": "Dont (TTC):",
 			"tagProducts": "Produits \"{name}\"",
@@ -760,6 +760,11 @@
 			"beforeDiscount": "AVANT REMISE",
 			"afterDiscount": "APRÈS REMISE"
 		},
+		"receipt": {
+			"ticket": "Reçu (ticket)",
+			"invoice": "Facture (A4)"
+		},
+		"staffNotes": "Notes du personnel",
 		"discount": {
 			"title": "Remise",
 			"noDiscount": "Pas de remise",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -739,7 +739,7 @@
 			"shares": "quote",
 			"itemize": "dettagliare",
 			"return": "Indietro",
-			"continueSplit": "Continua divisione ({mode})",
+			"continueSplit": "Continua",
 			"paySelected": "Paga selezionati",
 			"includingVatIncluded": "Di cui (IVA inclusa):",
 			"tagProducts": "Prodotti \"{name}\"",
@@ -759,6 +759,11 @@
 			"beforeDiscount": "PRIMA DELLO SCONTO",
 			"afterDiscount": "DOPO LO SCONTO"
 		},
+		"receipt": {
+			"ticket": "Ricevuta (ticket)",
+			"invoice": "Fattura (A4)"
+		},
+		"staffNotes": "Note del personale",
 		"discount": {
 			"title": "Sconto",
 			"noDiscount": "Nessuno sconto",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -739,7 +739,7 @@
 			"shares": "delen",
 			"itemize": "specificeren",
 			"return": "Terug",
-			"continueSplit": "Verdeel voortzetten ({mode})",
+			"continueSplit": "Doorgaan",
 			"paySelected": "Selectie betalen",
 			"includingVatIncluded": "Waarvan (BTW inbegrepen):",
 			"tagProducts": "Producten \"{name}\"",
@@ -759,6 +759,11 @@
 			"beforeDiscount": "VOOR KORTING",
 			"afterDiscount": "NA KORTING"
 		},
+		"receipt": {
+			"ticket": "Bon (ticket)",
+			"invoice": "Factuur (A4)"
+		},
+		"staffNotes": "Personeelsnotities",
 		"discount": {
 			"title": "Korting",
 			"noDiscount": "Geen korting",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -740,7 +740,7 @@
 			"shares": "partes",
 			"itemize": "detalhar",
 			"return": "Voltar",
-			"continueSplit": "Continuar divisão ({mode})",
+			"continueSplit": "Continuar",
 			"paySelected": "Pagar selecionados",
 			"includingVatIncluded": "Incluindo (IVA incluído):",
 			"tagProducts": "Produtos \"{name}\"",
@@ -760,6 +760,11 @@
 			"beforeDiscount": "ANTES DO DESCONTO",
 			"afterDiscount": "APÓS O DESCONTO"
 		},
+		"receipt": {
+			"ticket": "Recibo (ticket)",
+			"invoice": "Fatura (A4)"
+		},
+		"staffNotes": "Notas da equipe",
 		"discount": {
 			"title": "Desconto",
 			"noDiscount": "Sem desconto",

--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/[id]/+page.server.ts
@@ -76,7 +76,7 @@ export const actions = {
 			}
 		);
 
-		throw redirect(303, `/order/${order._id}`);
+		throw redirect(303, request.headers.get('referer') || `/order/${order._id}`);
 	},
 	saveNote: async function ({ params, request, locals }) {
 		const data = await request.formData();
@@ -105,7 +105,7 @@ export const actions = {
 				}
 			}
 		);
-		throw redirect(303, `/order/${params.id}/notes`);
+		throw redirect(303, request.headers.get('referer') || `/order/${params.id}/notes`);
 	},
 	cancel: async ({ params, request }) => {
 		const order = await collections.orders.findOneAndUpdate(

--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/[id]/payment/[paymentId]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/[id]/payment/[paymentId]/+page.server.ts
@@ -204,8 +204,15 @@ export const actions = {
 		if (payment.status !== 'paid') {
 			throw error(400, 'Payment is not paid');
 		}
+
+		let required = true;
+		if (payment.method === 'point-of-sale' && payment.posSubtype) {
+			const subtype = await collections.posPaymentSubtypes.findOne({ slug: payment.posSubtype });
+			required = subtype?.paymentDetailRequired ?? false;
+		}
+
 		const formData = await request.formData();
-		const informationUpdate = z.object({ paymentDetail: paymentDetailSchema(true) }).parse({
+		const informationUpdate = z.object({ paymentDetail: paymentDetailSchema(required) }).parse({
 			paymentDetail: formData.get('paymentDetail')
 		});
 

--- a/src/routes/(app)/order/[id]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/+page.server.ts
@@ -137,7 +137,8 @@ export async function load({ params, depends, locals, url }) {
 		}),
 		overwriteCreditCardSvgColor: runtimeConfig.overwriteCreditCardSvgColor,
 		hideCreditCardQrCode: runtimeConfig.hideCreditCardQrCode,
-		labels
+		labels,
+		returnTo: returnTo ?? undefined
 	};
 }
 

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/+page.server.ts
@@ -68,6 +68,6 @@ export const actions = {
 					parsed.posSubtype && { posSubtype: parsed.posSubtype })
 			});
 		});
-		throw redirect(303, `/order/${order._id}`);
+		throw redirect(303, request.headers.get('referer') || `/order/${order._id}`);
 	}
 };

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/pay/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/pay/+page.svelte
@@ -182,7 +182,10 @@
 
 	let paymentLoading = false;
 	let stripeLoading = true;
-	$: orderPath = '/order/' + $page.params.id;
+	$: returnTo = $page.url.searchParams.get('returnTo');
+	$: orderPath = returnTo
+		? `/order/${$page.params.id}?returnTo=${encodeURIComponent(returnTo)}`
+		: `/order/${$page.params.id}`;
 
 	function mountSumUpCard() {
 		// Should always be true due to backend validation, doing this for TS


### PR DESCRIPTION
The order page (`/order/[id]`) now has a simplified, touch-friendly layout when accessed in POS mode. Print buttons appear at the top, payments are collapsible, and staff notes are displayed inline instead of
requiring navigation to a separate page.

- **Compact POS layout** — optimized for touch screens with larger tap targets
- **Preserved POS context** — changing payment method, paying by card, or saving notes no longer exits POS mode
- **Inline staff notes** — view and add notes without leaving the order page
- **Fixed "undefined" bug** — empty payment detail field no longer shows "undefined"

Closes #2354