### PR TITLE
🦋 POS tickets - show datetime when first item was added to pool

### DIFF
--- a/src/lib/components/PrintableTicket.svelte
+++ b/src/lib/components/PrintableTicket.svelte
@@ -61,6 +61,9 @@
 	// Number of blank lines at top of each kitchen ticket section (for clamping)
 	export let topBlankLines = 0;
 
+	export let poolOpenedAt: Date | undefined = undefined;
+	export let orderCreatedAt: Date | undefined = undefined;
+
 	// ESC/POS Command Constants
 	const ESC = {
 		// Text formatting
@@ -330,7 +333,6 @@
 
 		// Ticket header
 		if (isCustomerReceipt && priceInfo) {
-			lines.push('');
 			if (useEscPos) {
 				lines.push(ESC.DOUBLE_WIDTH + centerText(`TICKET "${poolLabel}"`, 16) + ESC.NORMAL);
 			} else {
@@ -338,7 +340,14 @@
 			}
 
 			if (generatedAt) {
-				lines.push(centerText(format(generatedAt, 'dd/MM/yyyy HH:mm')));
+				lines.push(
+					centerText(
+						t('pos.midTicket.printedAt', {
+							date: format(generatedAt, 'dd/MM/yyyy'),
+							time: format(generatedAt, 'HH:mm:ss')
+						})
+					)
+				);
 			}
 
 			lines.push(separator('-'));
@@ -565,16 +574,29 @@
 
 				lines.push(separator('═'));
 				if (useEscPos) {
-					lines.push(ESC.DOUBLE_HEIGHT + bold(centerText(`TICKET ${poolLabel.toUpperCase()}`, 16)));
+					lines.push(ESC.DOUBLE_HEIGHT + bold(centerText(`TICKET "${poolLabel}"`, 16)));
 					if (generatedAt) {
 						lines.push(
-							ESC.DOUBLE_WIDTH + centerText(format(generatedAt, 'HH:mm'), 16) + ESC.NORMAL
+							ESC.NORMAL +
+								centerText(
+									t('pos.midTicket.printedAt', {
+										date: format(generatedAt, 'dd/MM/yyyy'),
+										time: format(generatedAt, 'HH:mm:ss')
+									})
+								)
 						);
 					}
 				} else {
-					lines.push(centerText(`TICKET ${poolLabel.toUpperCase()}`));
+					lines.push(centerText(`TICKET "${poolLabel}"`));
 					if (generatedAt) {
-						lines.push(centerText(format(generatedAt, 'HH:mm')));
+						lines.push(
+							centerText(
+								t('pos.midTicket.printedAt', {
+									date: format(generatedAt, 'dd/MM/yyyy'),
+									time: format(generatedAt, 'HH:mm:ss')
+								})
+							)
+						);
 					}
 				}
 				lines.push(separator('═'));
@@ -659,6 +681,14 @@
 		.printable .ticket-header-centered .company-name {
 			font-weight: bold;
 			font-size: 12px;
+		}
+
+		/* Date/time information */
+		.printable .ticket-dates {
+			font-size: 9px;
+			line-height: 1.4;
+			margin-bottom: 2mm;
+			padding-left: 5px;
 		}
 
 		/* Be-Bop footer */
@@ -780,6 +810,28 @@
 				{/if}
 			</div>
 		{/if}
+	{/if}
+
+	<!-- Date/time information -->
+	{#if poolOpenedAt || orderCreatedAt}
+		<div class="ticket-dates">
+			{#if poolOpenedAt}
+				<div>
+					{t('pos.midTicket.poolFirstItemAdded', {
+						date: format(poolOpenedAt, 'dd/MM/yyyy'),
+						time: format(poolOpenedAt, 'HH:mm:ss')
+					})}
+				</div>
+			{/if}
+			{#if orderCreatedAt}
+				<div>
+					{t('pos.midTicket.orderCreatedAt', {
+						date: format(orderCreatedAt, 'dd/MM/yyyy'),
+						time: format(orderCreatedAt, 'HH:mm:ss')
+					})}
+				</div>
+			{/if}
+		</div>
 	{/if}
 
 	<!-- Ticket content -->

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -785,7 +785,10 @@
 		"midTicket": {
 			"title": "Küchen-/Zwischenticket-Einstellungen",
 			"topBlankLines": "Anzahl der Leerzeilen oben auf dem Ticket (zum Einspannen)",
-			"topBlankLinesHint": "Standard: 0"
+			"topBlankLinesHint": "Standard: 0",
+			"printedAt": "Gedruckt am {date} um {time}",
+			"poolFirstItemAdded": "Tisch eröffnet am {date} um {time}",
+			"orderCreatedAt": "Bestellung erstellt am {date} um {time}"
 		}
 	},
 	"product": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -785,7 +785,10 @@
 		"midTicket": {
 			"title": "Kitchen/Mid-Ticket Settings",
 			"topBlankLines": "Number of blank lines at the top of mid-ticket (for clamping)",
-			"topBlankLinesHint": "Default: 0"
+			"topBlankLinesHint": "Default: 0",
+			"printedAt": "Printed on {date} at {time}",
+			"poolFirstItemAdded": "Table opened on {date} at {time}",
+			"orderCreatedAt": "Order created on {date} at {time}"
 		}
 	},
 	"product": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -784,7 +784,10 @@
 		"midTicket": {
 			"title": "Configuración de ticket de cocina/intermedio",
 			"topBlankLines": "Número de líneas en blanco en la parte superior del ticket (para sujeción)",
-			"topBlankLinesHint": "Por defecto: 0"
+			"topBlankLinesHint": "Por defecto: 0",
+			"printedAt": "Impreso el {date} a las {time}",
+			"poolFirstItemAdded": "Mesa abierta el {date} a las {time}",
+			"orderCreatedAt": "Pedido creado el {date} a las {time}"
 		},
 		"useSelectForTags": "Usar menú desplegable para etiquetas"
 	},

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -785,7 +785,10 @@
 		"midTicket": {
 			"title": "Paramètres ticket cuisine/intermédiaire",
 			"topBlankLines": "Nombre de lignes vides en haut du ticket (pour le pince-ticket)",
-			"topBlankLinesHint": "Par défaut : 0"
+			"topBlankLinesHint": "Par défaut : 0",
+			"printedAt": "Imprimé le {date} à {time}",
+			"poolFirstItemAdded": "Table ouverte le {date} à {time}",
+			"orderCreatedAt": "Commande créée le {date} à {time}"
 		}
 	},
 	"product": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -784,7 +784,10 @@
 		"midTicket": {
 			"title": "Impostazioni ticket cucina/intermedio",
 			"topBlankLines": "Numero di righe vuote in cima al ticket (per il fissaggio)",
-			"topBlankLinesHint": "Predefinito: 0"
+			"topBlankLinesHint": "Predefinito: 0",
+			"printedAt": "Stampato il {date} alle {time}",
+			"poolFirstItemAdded": "Tavolo aperto il {date} alle {time}",
+			"orderCreatedAt": "Ordine creato il {date} alle {time}"
 		},
 		"useSelectForTags": "Usa menu a tendina per i tag"
 	},

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -784,7 +784,10 @@
 		"midTicket": {
 			"title": "Keuken-/tussenbon instellingen",
 			"topBlankLines": "Aantal lege regels bovenaan de bon (voor klemmen)",
-			"topBlankLinesHint": "Standaard: 0"
+			"topBlankLinesHint": "Standaard: 0",
+			"printedAt": "Afgedrukt op {date} om {time}",
+			"poolFirstItemAdded": "Tafel geopend op {date} om {time}",
+			"orderCreatedAt": "Bestelling aangemaakt op {date} om {time}"
 		},
 		"useSelectForTags": "Gebruik dropdown voor tags"
 	},

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -785,7 +785,10 @@
 		"midTicket": {
 			"title": "Configurações de ticket de cozinha/intermediário",
 			"topBlankLines": "Número de linhas em branco no topo do ticket (para fixação)",
-			"topBlankLinesHint": "Padrão: 0"
+			"topBlankLinesHint": "Padrão: 0",
+			"printedAt": "Impresso em {date} às {time}",
+			"poolFirstItemAdded": "Mesa aberta em {date} às {time}",
+			"orderCreatedAt": "Pedido criado em {date} às {time}"
 		}
 	},
 	"product": {

--- a/src/lib/types/OrderTab.ts
+++ b/src/lib/types/OrderTab.ts
@@ -29,6 +29,7 @@ export interface OrderTab extends Timestamps {
 		motive?: string;
 	};
 	peopleCountFromPosUi?: number;
+	poolOpenedAt?: Date;
 }
 
 export interface OrderTabPoolStatus {

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/ticket/+page.server.ts
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/ticket/+page.server.ts
@@ -1,4 +1,5 @@
 import { error } from '@sveltejs/kit';
+import { collections } from '$lib/server/database.js';
 import { runtimeConfig } from '$lib/server/runtime-config.js';
 import { fetchOrderForUser } from '../../../fetchOrderForUser.js';
 import { orderItemPrice } from '$lib/types/Order.js';
@@ -121,6 +122,13 @@ export async function load({ params }) {
 	const companyLogoId = runtimeConfig.ticketLogoId || runtimeConfig.logo?.pictureId;
 	const companyLogoUrl = companyLogoId ? `/picture/raw/${companyLogoId}/format/128` : undefined;
 
+	const orderTab = order.orderTabSlug
+		? await collections.orderTabs.findOne(
+				{ slug: order.orderTabSlug },
+				{ projection: { poolOpenedAt: 1 } }
+		  )
+		: null;
+
 	return {
 		order,
 		payment,
@@ -130,6 +138,8 @@ export async function load({ params }) {
 		companyInfo,
 		companyLogoUrl,
 		sharesInfo,
-		peopleCount: order.peopleCountFromPosUi
+		peopleCount: order.peopleCountFromPosUi,
+		orderCreatedAt: order.createdAt,
+		poolOpenedAt: orderTab?.poolOpenedAt
 	};
 }

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/ticket/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/ticket/+page.svelte
@@ -16,4 +16,6 @@
 	showGroupHeaders={true}
 	sharesInfo={data.sharesInfo}
 	peopleCount={data.peopleCount}
+	poolOpenedAt={data.poolOpenedAt}
+	orderCreatedAt={data.orderCreatedAt}
 />

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.server.ts
@@ -231,6 +231,11 @@ export const actions = {
 					}
 				}
 			);
+			// Clear poolOpenedAt if pool is now empty
+			await collections.orderTabs.updateOne(
+				{ slug: tabSlug, items: { $size: 0 } },
+				{ $unset: { poolOpenedAt: '' } }
+			);
 		} else {
 			res = await collections.orderTabs.updateOne(
 				{ slug: tabSlug },
@@ -570,6 +575,17 @@ export const actions = {
 						{ session }
 					);
 				})
+			);
+
+			// Clear poolOpenedAt for pools that became empty
+			await Promise.all(
+				affectedSlugs.map((slug) =>
+					collections.orderTabs.updateOne(
+						{ slug, items: { $size: 0 } },
+						{ $unset: { poolOpenedAt: '' } },
+						{ session }
+					)
+				)
 			);
 		});
 	}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.server.ts
@@ -20,6 +20,7 @@ export async function load({ locals, params, url }) {
 			layoutReset: true,
 			poolLabel: historyEntry?.poolLabel ?? poolLabel,
 			generatedAt: new Date(),
+			poolOpenedAt: tab.poolOpenedAt,
 			tagGroups: historyEntry?.tagGroups ?? [],
 			showBebopLogo: false,
 			topBlankLines: runtimeConfig.posMidTicketTopBlankLines
@@ -66,6 +67,7 @@ export async function load({ locals, params, url }) {
 		layoutReset: true,
 		poolLabel,
 		generatedAt: new Date(),
+		poolOpenedAt: tab.poolOpenedAt,
 		tagGroups,
 		showBebopLogo: false,
 		topBlankLines: runtimeConfig.posMidTicketTopBlankLines

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.svelte
@@ -12,4 +12,5 @@
 	showOnScreen={true}
 	showGroupHeaders={true}
 	topBlankLines={data.topBlankLines}
+	poolOpenedAt={data.poolOpenedAt}
 />

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/ticket/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/ticket/+page.server.ts
@@ -96,6 +96,7 @@ export async function load({ locals, params }) {
 		layoutReset: true,
 		poolLabel,
 		generatedAt: new Date(),
+		poolOpenedAt: tab.poolOpenedAt,
 		tagGroups: [
 			{
 				tagNames: [],

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/ticket/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/ticket/+page.svelte
@@ -13,4 +13,5 @@
 	companyLogoUrl={data.companyLogoUrl}
 	showBebopLogo={data.showBebopLogo}
 	showOnScreen={true}
+	poolOpenedAt={data.poolOpenedAt}
 />


### PR DESCRIPTION
POS tickets now display when the table was opened (first item added). This helps track service time from order start to payment.

- Timestamp recorded automatically on first item
- Resets when pool is emptied
- Shows on kitchen tickets, global tickets, and payment receipts

Closes #2237