### PR TITLE
🐛 Fix VAT showing 0% in POS Global Ticket

### DIFF
--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/ticket/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/ticket/+page.server.ts
@@ -1,6 +1,7 @@
 import { collections } from '$lib/server/database';
 import { getOrCreateOrderTab } from '$lib/server/orderTab';
 import { runtimeConfig } from '$lib/server/runtime-config';
+import { vatRate } from '$lib/types/Country';
 import { UNDERLYING_CURRENCY, type Currency } from '$lib/types/Currency';
 import { ObjectId } from 'mongodb';
 
@@ -36,11 +37,14 @@ export async function load({ locals, params }) {
 
 	const bebopCountry = runtimeConfig.vatCountry;
 	function getVatRate(vatProfileId?: string): number {
-		if (!vatProfileId || !bebopCountry) {
+		if (!bebopCountry) {
 			return 0;
 		}
+		if (!vatProfileId) {
+			return vatRate(bebopCountry);
+		}
 		const profile = vatProfileById.get(vatProfileId);
-		return profile?.rates?.[bebopCountry] ?? 0;
+		return profile?.rates?.[bebopCountry] ?? vatRate(bebopCountry);
 	}
 
 	const itemsForTicket = tab.items


### PR DESCRIPTION
Global Ticket now correctly shows VAT rate even when products don't have a custom VAT profile assigned.

Closes #2366