### PR TITLE
🦋 POS: hide Continue button until payment paid, redirect to split after cancel

### DIFF
--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -744,6 +744,7 @@
 			"itemize": "aufschlüsseln",
 			"return": "Zurück",
 			"continueSplit": "Weiter",
+			"skipForNow": "Vorerst überspringen",
 			"paySelected": "Auswahl bezahlen",
 			"includingVatIncluded": "Davon (inkl. MwSt):",
 			"tagProducts": "Produkte \"{name}\"",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -717,6 +717,7 @@
 			"itemize": "itemize",
 			"return": "Return",
 			"continueSplit": "Continue",
+			"skipForNow": "Skip for now",
 			"paySelected": "Pay selected",
 			"includingVatIncluded": "Including (VAT included):",
 			"tagProducts": "Tag \"{name}\" products",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -743,6 +743,7 @@
 			"itemize": "detallar",
 			"return": "Volver",
 			"continueSplit": "Continuar",
+			"skipForNow": "Omitir por ahora",
 			"paySelected": "Pagar selección",
 			"includingVatIncluded": "Incluyendo (IVA incluido):",
 			"tagProducts": "Productos \"{name}\"",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -744,6 +744,7 @@
 			"itemize": "détailler",
 			"return": "Retour",
 			"continueSplit": "Continuer",
+			"skipForNow": "Passer pour l'instant",
 			"paySelected": "Payer la sélection",
 			"includingVatIncluded": "Dont (TTC):",
 			"tagProducts": "Produits \"{name}\"",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -743,6 +743,7 @@
 			"itemize": "dettagliare",
 			"return": "Indietro",
 			"continueSplit": "Continua",
+			"skipForNow": "Salta per ora",
 			"paySelected": "Paga selezionati",
 			"includingVatIncluded": "Di cui (IVA inclusa):",
 			"tagProducts": "Prodotti \"{name}\"",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -743,6 +743,7 @@
 			"itemize": "specificeren",
 			"return": "Terug",
 			"continueSplit": "Doorgaan",
+			"skipForNow": "Voorlopig overslaan",
 			"paySelected": "Selectie betalen",
 			"includingVatIncluded": "Waarvan (BTW inbegrepen):",
 			"tagProducts": "Producten \"{name}\"",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -744,6 +744,7 @@
 			"itemize": "detalhar",
 			"return": "Voltar",
 			"continueSplit": "Continuar",
+			"skipForNow": "Pular por agora",
 			"paySelected": "Pagar selecionados",
 			"includingVatIncluded": "Incluindo (IVA incluído):",
 			"tagProducts": "Produtos \"{name}\"",

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -60,6 +60,10 @@
 	$: remainingAmount = orderAmountWithNoPaymentsCreated(data.order, {
 		ignorePendingPayments: true
 	});
+	$: lastPayment = data.order.payments[data.order.payments.length - 1];
+	$: showContinue = !(lastPayment?.status === 'pending' && lastPayment?.method === 'point-of-sale');
+	$: skipMode = lastPayment?.status === 'pending' && lastPayment?.method !== 'point-of-sale';
+
 	function confirmCancelOrder(event: Event) {
 		if (!confirm(t('pos.cancelOrderMessage'))) {
 			event.preventDefault();
@@ -439,15 +443,19 @@
 					</div>
 				{/if}
 
-				<!-- POS MODE: "Continue"  -->
-				{#if data.posMode && data.order.orderTabSlug}
+				<!-- POS MODE: "Continue" - only show when last payment is paid -->
+				{#if data.posMode && data.order.orderTabSlug && showContinue}
 					<a
 						href={data.splitMode
 							? `/pos/touch/tab/${data.order.orderTabSlug}/split?mode=${data.splitMode}`
 							: `/pos/touch/tab/${data.order.orderTabSlug}`}
 						class="btn btn-black w-full text-center text-2xl py-4"
 					>
-						{data.splitMode ? t('pos.split.continueSplit') : t('pos.split.return')}
+						{skipMode
+							? t('pos.split.skipForNow')
+							: data.splitMode
+							? t('pos.split.continueSplit')
+							: t('pos.split.return')}
 					</a>
 				{/if}
 
@@ -517,12 +525,12 @@
 									{t('order.note.seeText')}
 								</a>
 								{#if data.order.orderTabSlug}
-									{#if data.splitMode}
+									{#if data.splitMode && showContinue}
 										<a
 											href="/pos/touch/tab/{data.order.orderTabSlug}/split?mode={data.splitMode}"
 											class="btn lg:w-auto w-full btn-black self-end"
 										>
-											{t('pos.split.continueSplit')}
+											{skipMode ? t('pos.split.skipForNow') : t('pos.split.continueSplit')}
 										</a>
 									{/if}
 									<a


### PR DESCRIPTION
Waiters no longer see "Continue" button while payment is pending — only after clicking "Paid". Cancel now redirects back to split page instead of staying on order page.

Closes #2370