### PR TITLE
🦋🤖 Forward receipt to customer from order page (#2375)

### DIFF
--- a/src/lib/components/Order/ForwardReceiptForm.svelte
+++ b/src/lib/components/Order/ForwardReceiptForm.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { useI18n } from '$lib/i18n';
+
+	const { t } = useI18n();
+
+	export let actionUrl: string;
+	export let paymentId: string;
+
+	let isOpen = false;
+	let isSuccess = false;
+</script>
+
+{#if isSuccess}
+	<p class="text-green-500">{t('order.forwardReceipt.success')}</p>
+{:else if isOpen}
+	<form
+		action={actionUrl}
+		method="post"
+		class="flex flex-col gap-2"
+		use:enhance={() => {
+			return async ({ result, update }) => {
+				if (result.type === 'success') {
+					isOpen = false;
+					isSuccess = true;
+				} else {
+					await update();
+				}
+			};
+		}}
+	>
+		<input type="hidden" name="paymentId" value={paymentId} />
+		<label class="form-label body-secondaryText">
+			{t('login.authenticate.inputLabel')}
+			<input
+				class="form-input"
+				type="text"
+				name="address"
+				placeholder="email / npub1..."
+				required
+				pattern="^(?!nsec).*"
+				title={t('login.nsecBlockTitle')}
+			/>
+		</label>
+		<div class="flex gap-2">
+			<button type="submit" class="btn btn-black">
+				{t('order.forwardReceipt.send')}
+			</button>
+			<button type="button" class="btn btn-gray" on:click={() => (isOpen = false)}>
+				{t('order.forwardReceipt.cancel')}
+			</button>
+		</div>
+	</form>
+{:else}
+	<button class="body-hyperlink self-start" type="button" on:click={() => (isOpen = true)}>
+		{t('order.forwardReceipt.title')}
+	</button>
+{/if}

--- a/src/lib/components/Order/PaymentActions.svelte
+++ b/src/lib/components/Order/PaymentActions.svelte
@@ -2,6 +2,7 @@
 	import type { SerializedOrderPayment } from '$lib/types/Order';
 	import { useI18n } from '$lib/i18n';
 	import PaymentForm from './PaymentForm.svelte';
+	import ForwardReceiptForm from './ForwardReceiptForm.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 
 	const { t } = useI18n();
@@ -99,6 +100,13 @@
 		>
 			{posMode ? t('pos.receipt.ticket') : 'Print receipt (ticket)'}
 		</button>
+	{/if}
+
+	{#if payment.status === 'paid' && roleIsStaff}
+		<ForwardReceiptForm
+			actionUrl="{orderStaffActionBaseUrl}?/forwardReceipt"
+			paymentId={payment.id}
+		/>
 	{/if}
 
 	{#if showInvoice && !roleIsStaff}

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -582,6 +582,12 @@
 			"vatFreeReason": "MwSt.-befreit: {reason}",
 			"peopleCount": "Anzahl der Personen"
 		},
+		"forwardReceipt": {
+			"cancel": "Abbrechen",
+			"send": "Senden",
+			"success": "Quittung weitergeleitet!",
+			"title": "Quittung weiterleiten"
+		},
 		"receiptFullyPaid": "Quittung erstellen (vollständig bezahlt)",
 		"receiptPending": "Quittung erstellen (ausstehende Zahlung)",
 		"related": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -582,6 +582,12 @@
 			"vatFreeReason": "Vat exempted: {reason}",
 			"peopleCount": "Number of people"
 		},
+		"forwardReceipt": {
+			"cancel": "Cancel",
+			"send": "Send",
+			"success": "Receipt forwarded!",
+			"title": "Forward receipt"
+		},
 		"receiptFullyPaid": "Generate receipt(fully paid)",
 		"receiptPending": "Generate receipt(pending payment)",
 		"related": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -582,6 +582,12 @@
 			"vatFreeReason": "Exento de IVA: {reason}",
 			"peopleCount": "Número de personas"
 		},
+		"forwardReceipt": {
+			"cancel": "Cancelar",
+			"send": "Enviar",
+			"success": "Recibo reenviado!",
+			"title": "Reenviar recibo"
+		},
 		"receiptFullyPaid": "Generar recibo (completamente pagado)",
 		"receiptPending": "Generar recibo (pago pendiente)",
 		"related": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -582,6 +582,12 @@
 			"vatFreeReason": "Exempt de TVA: {reason}",
 			"peopleCount": "Nombre de personnes"
 		},
+		"forwardReceipt": {
+			"cancel": "Annuler",
+			"send": "Envoyer",
+			"success": "Reçu transféré !",
+			"title": "Transférer le reçu"
+		},
 		"receiptFullyPaid": "Générer un reçu (entièrement payé)",
 		"receiptPending": "Générer un reçu (en attente de paiement)",
 		"related": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -582,6 +582,12 @@
 			"vatFreeReason": "Esente dall'IVA: {reason}",
 			"peopleCount": "Numero di persone"
 		},
+		"forwardReceipt": {
+			"cancel": "Annulla",
+			"send": "Invia",
+			"success": "Ricevuta inoltrata!",
+			"title": "Inoltra ricevuta"
+		},
 		"receiptFullyPaid": "Genera il ticket (pagato completamente)",
 		"receiptPending": "Genera il ticket (pagamento in attesa)",
 		"related": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -582,6 +582,12 @@
 			"vatFreeReason": "Vrijgesteld van btw: {reason}",
 			"peopleCount": "Aantal personen"
 		},
+		"forwardReceipt": {
+			"cancel": "Annuleren",
+			"send": "Verzenden",
+			"success": "Bon doorgestuurd!",
+			"title": "Bon doorsturen"
+		},
 		"receiptFullyPaid": "Bon genereren (volledig betaald)",
 		"receiptPending": "Ontvangst genereren (betaling in behandeling)",
 		"related": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -582,6 +582,12 @@
 			"vatFreeReason": "Isento de IVA: {reason}",
 			"peopleCount": "Número de pessoas"
 		},
+		"forwardReceipt": {
+			"cancel": "Cancelar",
+			"send": "Enviar",
+			"success": "Recibo encaminhado!",
+			"title": "Encaminhar recibo"
+		},
 		"receiptFullyPaid": "Gerar recibo (totalmente pago)",
 		"receiptPending": "Gerar recibo (pagamento pendente)",
 		"related": {

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -11,6 +11,7 @@
 	import IconExternalNewWindowOpen from '$lib/components/icons/IconExternalNewWindowOpen.svelte';
 	import PaymentItem from '$lib/components/Order/PaymentItem.svelte';
 	import PaymentActions from '$lib/components/Order/PaymentActions.svelte';
+	import ForwardReceiptForm from '$lib/components/Order/ForwardReceiptForm.svelte';
 	import PaymentForm from '$lib/components/Order/PaymentForm.svelte';
 	import { useI18n } from '$lib/i18n';
 	import { FAKE_ORDER_INVOICE_NUMBER, orderAmountWithNoPaymentsCreated } from '$lib/types/Order';
@@ -195,6 +196,12 @@
 							{t('pos.receipt.invoice')}
 						</button>
 					</div>
+				{/if}
+				{#if roleIsStaff && data.order.status === 'paid'}
+					<ForwardReceiptForm
+						actionUrl="{orderStaffActionBaseUrl}?/forwardReceipt"
+						paymentId={lastPayment.id}
+					/>
 				{/if}
 			{/if}
 

--- a/src/routes/(app)/pos/order/[id]/+page.server.ts
+++ b/src/routes/(app)/pos/order/[id]/+page.server.ts
@@ -60,5 +60,23 @@ export const actions = {
 
 		// @ts-expect-error different route but compatible
 		return cancel(event);
+	},
+	forwardReceipt: async function (event) {
+		const { id } = event.params;
+		const order = await collections.orders.findOne({ _id: id });
+
+		if (!order?.user.userId?.equals(event.locals.user?._id ?? '')) {
+			if (
+				event.locals.user?.role &&
+				!isAllowedOnPage(event.locals.user.role, `${adminPrefix()}/order/${id}`, 'write')
+			) {
+				throw error(403, 'Order does not belong to this POS account.');
+			}
+		}
+
+		const forwardReceipt = adminOrderActions.forwardReceipt;
+
+		// @ts-expect-error different route but compatible
+		return forwardReceipt(event);
 	}
 };


### PR DESCRIPTION
- Employees can now forward a receipt to a customer directly from the order page     
- Available on paid orders only, for both classic POS and POS Touch
- Supports sending via email (sends the order.paid email) or Nostr DM (sends ticket content + order link)
- Inline form with contact address input (email or Nostr npub), same pattern as the RSVP form
- Success confirmation displayed after forwarding

Fixes #2375 