### PR TITLE
🦋🤖 Fix: use pool label instead of slug on mid-ticket print (#2379)

### DIFF
--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -729,8 +729,8 @@
 		},
 		"split": {
 			"notAvailableYet": "Noch nicht verfügbar",
-			"tabHeader": "Tab {slug}",
-			"tabToPayNow": "Tab {slug} (jetzt zu bezahlen)",
+			"tabHeader": "Tab {poolLabel}",
+			"tabToPayNow": "Tab {poolLabel} (jetzt zu bezahlen)",
 			"pool": "POOL",
 			"poolRemainingToPay": "POOL (noch zu bezahlen)",
 			"exclVat": "ohne MwSt",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -702,8 +702,8 @@
 		},
 		"split": {
 			"notAvailableYet": "Not available yet",
-			"tabHeader": "Tab {slug}",
-			"tabToPayNow": "Tab {slug} (to pay now)",
+			"tabHeader": "Tab {poolLabel}",
+			"tabToPayNow": "Tab {poolLabel} (to pay now)",
 			"pool": "POOL",
 			"poolRemainingToPay": "POOL (remaining to be paid)",
 			"exclVat": "excl. VAT",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -728,8 +728,8 @@
 		},
 		"split": {
 			"notAvailableYet": "Aún no disponible",
-			"tabHeader": "Pestaña {slug}",
-			"tabToPayNow": "Pestaña {slug} (a pagar ahora)",
+			"tabHeader": "Pestaña {poolLabel}",
+			"tabToPayNow": "Pestaña {poolLabel} (a pagar ahora)",
 			"pool": "POOL",
 			"poolRemainingToPay": "POOL (pendiente de pago)",
 			"exclVat": "sin IVA",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -729,8 +729,8 @@
 		},
 		"split": {
 			"notAvailableYet": "Pas encore disponible",
-			"tabHeader": "Onglet {slug}",
-			"tabToPayNow": "Onglet {slug} (à payer maintenant)",
+			"tabHeader": "Onglet {poolLabel}",
+			"tabToPayNow": "Onglet {poolLabel} (à payer maintenant)",
 			"pool": "POOL",
 			"poolRemainingToPay": "POOL (reste à payer)",
 			"exclVat": "HT",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -728,8 +728,8 @@
 		},
 		"split": {
 			"notAvailableYet": "Non ancora disponibile",
-			"tabHeader": "Scheda {slug}",
-			"tabToPayNow": "Scheda {slug} (da pagare ora)",
+			"tabHeader": "Scheda {poolLabel}",
+			"tabToPayNow": "Scheda {poolLabel} (da pagare ora)",
 			"pool": "POOL",
 			"poolRemainingToPay": "POOL (da pagare)",
 			"exclVat": "esclusa IVA",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -728,8 +728,8 @@
 		},
 		"split": {
 			"notAvailableYet": "Nog niet beschikbaar",
-			"tabHeader": "Tab {slug}",
-			"tabToPayNow": "Tab {slug} (nu te betalen)",
+			"tabHeader": "Tab {poolLabel}",
+			"tabToPayNow": "Tab {poolLabel} (nu te betalen)",
 			"pool": "POOL",
 			"poolRemainingToPay": "POOL (nog te betalen)",
 			"exclVat": "excl. BTW",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -729,8 +729,8 @@
 		},
 		"split": {
 			"notAvailableYet": "Ainda não disponível",
-			"tabHeader": "Separador {slug}",
-			"tabToPayNow": "Separador {slug} (a pagar agora)",
+			"tabHeader": "Separador {poolLabel}",
+			"tabToPayNow": "Separador {poolLabel} (a pagar agora)",
 			"pool": "POOL",
 			"poolRemainingToPay": "POOL (a pagar)",
 			"exclVat": "sem IVA",

--- a/src/lib/types/PosTabGroup.ts
+++ b/src/lib/types/PosTabGroup.ts
@@ -31,3 +31,16 @@ export function sluggifyTab(
 		.replace(/[^a-z0-9]+/g, '-')
 		.replace(/^-|-$/g, '');
 }
+
+export function resolvePoolLabel(posTabGroups: PosTabGroup[], tabSlug: string): string {
+	return (
+		posTabGroups
+			.flatMap((group, g) =>
+				group.tabs.map((tab, i) => ({
+					slug: sluggifyTab(posTabGroups, g, i),
+					label: tab.label ?? `${group.name} ${i + 1}`
+				}))
+			)
+			.find(({ slug }) => slug === tabSlug)?.label ?? tabSlug
+	);
+}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/kitchen-ticket/+page.server.ts
@@ -1,14 +1,12 @@
 import { collections } from '$lib/server/database';
 import { buildTagGroupsForPrint, getOrCreateOrderTab } from '$lib/server/orderTab';
 import { runtimeConfig } from '$lib/server/runtime-config';
+import { resolvePoolLabel } from '$lib/types/PosTabGroup';
 
 export async function load({ locals, params, url }) {
 	const tab = await getOrCreateOrderTab({ slug: params.orderTabSlug });
 
-	const poolLabel = params.orderTabSlug
-		.split('-')
-		.map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
-		.join(' ');
+	const poolLabel = resolvePoolLabel(runtimeConfig.posTabGroups, params.orderTabSlug);
 
 	const mode = (url.searchParams.get('mode') ?? 'all') as 'all' | 'newlyOrdered';
 	const tagFilter = url.searchParams.get('tagFilter');

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
@@ -17,6 +17,7 @@ import { orderRemainingToPay } from '$lib/types/Order';
 import { CURRENCY_UNIT } from '$lib/types/Currency';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { paymentMethods, type PaymentMethod } from '$lib/server/payment-methods';
+import { resolvePoolLabel } from '$lib/types/PosTabGroup';
 
 type Locale = App.Locals['language'];
 type ProductProjection = ProductForPriceInfo & { name: string };
@@ -102,6 +103,8 @@ export const load = async ({ depends, locals, params }) => {
 		clearAbandonedCartsAndOrdersFromTab(tab)
 	]);
 
+	const poolLabel = resolvePoolLabel(runtimeConfig.posTabGroups, tabSlug);
+
 	const sellerIdentity = runtimeConfig.sellerIdentity;
 
 	depends(UrlDependency.orderTab(tabSlug));
@@ -162,6 +165,7 @@ export const load = async ({ depends, locals, params }) => {
 	return {
 		orderTab,
 		tabSlug,
+		poolLabel,
 		posMobileBreakpoint: runtimeConfig.posMobileBreakpoint ?? 1024,
 		sharesOrder: sharesOrderData,
 		availablePaymentMethods: methods,

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
@@ -351,7 +351,7 @@
 					{:else if tab.items.length}
 						<div class="flex-1 overflow-y-auto min-h-0">
 							<h3 class="font-semibold text-3xl">
-								{t('pos.split.tabHeader', { slug: tab.slug })}
+								{t('pos.split.tabHeader', { poolLabel: data.poolLabel })}
 							</h3>
 							{#each tab.items as item, i}
 								{@const remainingQty = item.quantity - (splitTabQuantities[i] || 0)}
@@ -454,7 +454,7 @@
 								<h3 class="font-semibold text-3xl">
 									{isPoolFullyPaid
 										? t('pos.split.poolRemainingToPay')
-										: t('pos.split.tabToPayNow', { slug: tab.slug })}
+										: t('pos.split.tabToPayNow', { poolLabel: data.poolLabel })}
 								</h3>
 								{#each splitTabItems as item, i}
 									{@const qtyInCart = splitTabQuantities[i] || 0}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/ticket/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/ticket/+page.server.ts
@@ -2,6 +2,7 @@ import { collections } from '$lib/server/database';
 import { getOrCreateOrderTab } from '$lib/server/orderTab';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { UNDERLYING_CURRENCY, type Currency } from '$lib/types/Currency';
+import { resolvePoolLabel } from '$lib/types/PosTabGroup';
 import { ObjectId } from 'mongodb';
 
 export async function load({ locals, params }) {
@@ -82,10 +83,7 @@ export async function load({ locals, params }) {
 		productById.get(tab.items[0].productId.toString())?.price.currency) ??
 		UNDERLYING_CURRENCY) as Currency;
 
-	const poolLabel = params.orderTabSlug
-		.split('-')
-		.map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
-		.join(' ');
+	const poolLabel = resolvePoolLabel(runtimeConfig.posTabGroups, params.orderTabSlug);
 
 	const sellerIdentity = runtimeConfig.sellerIdentity;
 	const companyLogoId = runtimeConfig.ticketLogoId || runtimeConfig.logo?.pictureId;


### PR DESCRIPTION
  When printing a mid-ticket from POS Touch, the ticket header shows the pool slug     
  (e.g. "Tables 1") instead of the custom label defined in /admin/pos tab management.  

  The mid-ticket now uses the actual pool label configured in admin.