### PR TITLE
🦋🤖 Allow yearly subscription (#2385)

### DIFF
--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -3,6 +3,7 @@ import { ObjectId } from 'mongodb';
 import { collections } from './database';
 import { defaultExchangeRate, exchangeRate } from '$lib/stores/exchangeRate';
 import type { Currency } from '$lib/types/Currency';
+import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
 import type { DeliveryFees } from '$lib/types/DeliveryFees';
 import { currencies } from '$lib/stores/currencies';
 import {
@@ -71,7 +72,7 @@ const baseConfig = {
 	lightningQrCodeDescription: 'brand' as 'orderUrl' | 'brand' | 'brandAndOrderNumber' | 'none',
 	maintenanceIps: '',
 	brandName: 'My be-BOP',
-	subscriptionDuration: 'month' as 'month' | 'day' | 'hour',
+	subscriptionDuration: 'month' satisfies SubscriptionDuration,
 	subscriptionReminderSeconds: 24 * 60 * 60,
 	reserveStockInMinutes: 20,
 	confirmationBlocksThresholds: {

--- a/src/lib/types/SubscriptionDuration.ts
+++ b/src/lib/types/SubscriptionDuration.ts
@@ -1,0 +1,2 @@
+export const SUBSCRIPTION_DURATIONS = ['year', 'month', 'week', 'day', 'hour'] as const;
+export type SubscriptionDuration = (typeof SUBSCRIPTION_DURATIONS)[number];

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
@@ -2,6 +2,7 @@ import { ORIGIN } from '$lib/server/env-config';
 import { collections } from '$lib/server/database';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { CURRENCIES } from '$lib/types/Currency';
+import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 import { toCurrency } from '$lib/utils/toCurrency';
 import { typedKeys } from '$lib/utils/typedKeys.js';
 import { adminPrefix } from '$lib/server/admin';
@@ -89,7 +90,7 @@ export const actions = {
 				copyOrderEmailsToAdmin: z.boolean({ coerce: true }),
 				hideShopBankOnReceipt: z.boolean({ coerce: true }),
 				hideShopBankOnTicket: z.boolean({ coerce: true }),
-				subscriptionDuration: z.enum(['month', 'day', 'hour']),
+				subscriptionDuration: z.enum(SUBSCRIPTION_DURATIONS),
 				mainCurrency: z.enum([CURRENCIES[0], ...CURRENCIES.slice(1).filter((c) => c !== 'SAT')]),
 				secondaryCurrency: z
 					.enum([CURRENCIES[0], ...CURRENCIES.slice(1).filter((c) => c !== 'SAT'), ''])

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
@@ -5,6 +5,7 @@
 	import IconDownArrow from '~icons/ant-design/arrow-down-outlined';
 
 	import { CURRENCIES } from '$lib/types/Currency';
+	import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 	import { formatDistance } from 'date-fns';
 	import { exchangeRate } from '$lib/stores/exchangeRate';
 	import { useI18n } from '$lib/i18n.js';
@@ -499,7 +500,7 @@
 			class="form-input max-w-[25rem]"
 			value={data.subscriptionDuration}
 		>
-			{#each ['month', 'day', 'hour'] as duration}
+			{#each SUBSCRIPTION_DURATIONS as duration}
 				<option value={duration}>{duration}</option>
 			{/each}
 		</select>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/subscribers/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/subscribers/+page.server.ts
@@ -1,5 +1,4 @@
 import { collections } from '$lib/server/database';
-import { pojo } from '$lib/server/pojo';
 import { error, fail } from '@sveltejs/kit';
 import { userQuery } from '$lib/server/user';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
@@ -17,11 +16,15 @@ export const load = async ({ params }) => {
 	}
 
 	return {
-		product: pojo(product),
 		subscriptions: subscriptions.map((subscription) => ({
-			...pojo(subscription),
-			user: pojo(subscription.user),
-			notifications: subscription.notifications.map(pojo)
+			_id: subscription._id,
+			paidUntil: subscription.paidUntil,
+			updatedAt: subscription.updatedAt,
+			cancelledAt: subscription.cancelledAt,
+			user: {
+				email: subscription.user.email,
+				npub: subscription.user.npub
+			}
 		}))
 	};
 };

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/subscribers/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/subscribers/+page.svelte
@@ -87,8 +87,7 @@
 			paidUntil: subscription.paidUntil.toLocaleString($locale, dateTimeFormat),
 			cancelled,
 			nostr: subscription.user?.npub ?? '',
-			email: subscription.user?.email ?? '',
-			originalSubscription: subscription
+			email: subscription.user?.email ?? ''
 		};
 	});
 


### PR DESCRIPTION
Adds "yearly" and "weekly" option to the subscription duration setting.

Administrators can now select "year" or "week" as subscription duration in **Settings > General** (Timing section). When chosen, subscription-type products grant access for one full year/week from purchase date, or one year/week from the current expiration on renewal.
Fixes #2385