### PR TITLE
🦋 Forbid deleting Product if it's in an open Pool

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -314,6 +314,20 @@ export const actions: Actions = {
 	},
 
 	delete: async ({ params }) => {
+		// Check if product is in any open pool
+		const poolsWithProduct = await collections.orderTabs.countDocuments({
+			'items.productId': params.id
+		});
+
+		if (poolsWithProduct > 0) {
+			throw error(
+				400,
+				`Cannot delete product. It is present in ${poolsWithProduct} open pool${
+					poolsWithProduct > 1 ? 's' : ''
+				}. Please remove the product from all pools first.`
+			);
+		}
+
 		// Check if other products reference this product's stock
 		const dependentProducts = await collections.products.countDocuments({
 			'stockReference.productId': params.id


### PR DESCRIPTION
Products can no longer be deleted from admin panel while they exist in any open pool (POS session). Admin receives clear error message indicating how many pools contain the product.

Closes #2365