### PR TITLE
🐛 Fix POS discount with tag filter applying to entire pool instead of matching items only

### DIFF
--- a/src/lib/components/PrintableTicket.svelte
+++ b/src/lib/components/PrintableTicket.svelte
@@ -381,6 +381,8 @@
 			};
 
 			let lastGroupKey = '';
+			const hasTagGroupHeaders = !showGroupHeaders && tagGroups.length > 1;
+
 			if (!showGroupHeaders) {
 				lines.push('');
 				renderTableHeader();
@@ -398,6 +400,15 @@
 					lines.push(separator('-'));
 					renderTableHeader();
 					lastGroupKey = groupKey;
+				} else if (hasTagGroupHeaders && groupKey !== lastGroupKey) {
+					if (lastGroupKey !== '') {
+						lines.push(separator('·'));
+					}
+					lines.push(
+						centerText((groupKey || t('pos.split.otherProducts')).toUpperCase()),
+						separator('·')
+					);
+					lastGroupKey = groupKey;
 				}
 
 				renderItem(item);
@@ -407,7 +418,8 @@
 			lines.push(separator('─'));
 
 			if (hasDiscount) {
-				const discountMultiplier = 1 - discountPercentageSafe / 100;
+				const discountMultiplier =
+					totalBeforeDiscountSafe > 0 ? priceInfo.total / totalBeforeDiscountSafe : 1;
 
 				// --- BEFORE DISCOUNT ---
 				lines.push(centerText(ticketLabels.beforeDiscount));
@@ -449,10 +461,29 @@
 
 				// --- AFTER DISCOUNT ---
 				lines.push(separator('─'));
-				lines.push(
-					centerText(`${ticketLabels.afterDiscount} (-${discountPercentageSafe.toFixed(0)}%)`)
-				);
-				lines.push(separator('─'));
+
+				if (tagGroups.length > 1) {
+					lines.push(centerText(ticketLabels.afterDiscount), separator('─'));
+					tagGroups.forEach((group) => {
+						const label = (group.tagNames[0] || t('pos.split.otherProducts')).toUpperCase();
+						lines.push(
+							tableRow([
+								{ text: label, width: 0.7, align: 'LEFT' },
+								{
+									text: `-${(group.tagNames.length ? discountPercentageSafe : 0).toFixed(2)}%`,
+									width: 0.3,
+									align: 'RIGHT'
+								}
+							])
+						);
+					});
+					lines.push(separator('·'));
+				} else {
+					lines.push(
+						centerText(`${ticketLabels.afterDiscount} (-${discountPercentageSafe.toFixed(0)}%)`),
+						separator('─')
+					);
+				}
 
 				// excl. VAT (after discount)
 				lines.push(


### PR DESCRIPTION
POS discount with a tag filter (e.g. 100% off "Alcohol") was incorrectly applied to the entire pool total in the split page and Global Ticket. Now only matching items are discounted; other items remain at full price.

Closes #2391