### PR TITLE
CI: Replace artifact.ci with actions/upload-artifact

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -35,16 +35,7 @@ jobs:
           zip -r ./be-BOP-release.zip "$RELEASE_NAME"
           rm -fr "$RELEASE_NAME"
           cd ..
-      - name: Upload artifact (PR)
-        if: github.ref != 'refs/heads/main'
-        uses: mmkal/artifact.ci/upload@main
-        with:
-          name: be-BOP-release
-          path: release/
-          artifactci-visibility: public
-          artifactci-mode: eager
-      - name: Upload artifact (main)
-        if: github.ref == 'refs/heads/main'
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: be-BOP-release


### PR DESCRIPTION
This release contains only CI changes pertaining our tooling. There are no functional changes, you get the same ol' be-BOP :)

This release simply fixes some steps in our release pipeline that depend on external services.
We tried reaching out upstream, unfortunately to no avail. https://x.com/beBOPcommunity/status/2019433425036521710#m

