### PR TITLE
Fix CI: update mongodb-github-action to 1.12.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.10.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: '6.0'
           mongodb-replica-set: test-rs


### PR DESCRIPTION
Docker client in 1.10.0 uses API version 1.40, which is below the minimum 1.44 required by the GitHub runner's Docker daemon.