### PR TITLE
🦋🤖 Fix POS session history amounts not bounded by closure date (#2399)

### DIFF
--- a/src/lib/server/pos-sessions.ts
+++ b/src/lib/server/pos-sessions.ts
@@ -70,7 +70,10 @@ export async function openPosSession(params: {
 export async function calculateDailyIncomes(session: PosSession): Promise<PosSessionIncome[]> {
 	const orders = await collections.orders
 		.find({
-			createdAt: { $gte: session.openedAt },
+			createdAt: {
+				$gte: session.openedAt,
+				...(session.closedAt && { $lte: session.closedAt })
+			},
 			status: 'paid'
 		})
 		.toArray();
@@ -132,7 +135,10 @@ export async function calculateTotalCashback(
 ): Promise<{ amount: number; currency: Currency }> {
 	const orders = await collections.orders
 		.find({
-			createdAt: { $gte: session.openedAt },
+			createdAt: {
+				$gte: session.openedAt,
+				...(session.closedAt && { $lte: session.closedAt })
+			},
 			status: 'paid',
 			'payments.cashbackAmount': { $exists: true }
 		})


### PR DESCRIPTION
The amounts displayed on the /pos/history/{id} page for a closed POS session included orders created after the session was closed.

Fixes #2399 