### PR TITLE
Add link to ethereal.email in console while in dev

### DIFF
--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -1,4 +1,10 @@
-import { createTestAccount, createTransport, type Transporter } from 'nodemailer';
+import {
+	createTestAccount,
+	createTransport,
+	getTestMessageUrl,
+	type Transporter
+} from 'nodemailer';
+import { dev } from '$app/environment';
 import { ORIGIN } from '$lib/server/env-config';
 import type SMTPTransport from 'nodemailer/lib/smtp-transport';
 import { htmlToText } from 'html-to-text';
@@ -82,6 +88,10 @@ export async function sendEmail(params: {
 	});
 
 	console.log(`✅ Email sent [${params.subject}] → ${params.to}`, res);
+
+	if (dev && runtimeConfig.smtp.fake) {
+		console.log(`📬 Preview URL: ${getTestMessageUrl(res)}`);
+	}
 }
 
 export async function queueEmail(


### PR DESCRIPTION
I'm starting to work on the GNU Taler integration. 
Here's a first very small PR that adds direct links to the ethereal.email messages. That was useful for me to find password reset links while developing.
Feel free to merge if it seems useful.

Before:

<img width="965" height="217" alt="Screenshot 2026-02-24 at 14 07 54" src="https://github.com/user-attachments/assets/dd554022-1caa-4107-9ccd-0f6c684c2da1" />

After, with a clickable preview link to the email:

<img width="969" height="254" alt="Screenshot 2026-02-24 at 14 08 42" src="https://github.com/user-attachments/assets/b7994d84-5d8f-4792-984d-a83df2fed984" />
