### PR TITLE
🦋🤖 Change default VAT rate to use seller's country (#2415)

### DIFF
--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -121,7 +121,7 @@ const baseConfig = {
 	cartPreviewInteractive: false,
 	vatExempted: false,
 	vatExemptionReason: '',
-	vatSingleCountry: false,
+	vatSingleCountry: true,
 	vatCountry: 'FR' satisfies CountryAlpha2 as CountryAlpha2,
 	vatNullOutsideSellerCountry: false,
 	displayVatIncludedInProduct: false,


### PR DESCRIPTION
Enable "Use VAT rate from seller's country" (vatSingleCountry) by default on new be-BOP instances, as it's the most common use case.

Fixes #2415 