### PR TITLE
🦋🤖 Add warning on PoS Session closing when pools aren't empty (#2426)

### DIFF
--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -676,6 +676,7 @@
 		},
 		"sessionLink": "POS-Sitzung",
 		"sessionTouchLink": "POS-Sitzung - Touchscreen",
+		"nonEmptyPoolsWarning": "Achtung: Es gibt nicht leere Tische. Bitte verarbeiten Sie diese ordnungsgemäß, bevor Sie Ihre POS-Sitzung schließen.",
 		"tapToPay": {
 			"inProgress": "Die Zahlung wird automatisch bestätigt, sobald die externe Transaktion erfasst und bestätigt wurde.",
 			"inUseByOtherOrder": "Die Tap-to-Pay-Zahlung ist deaktiviert, da eine andere Bestellung diesen Zahlungsmodus verwendet. Sie können die Zahlung manuell entgegennehmen und anschließend die Transaktionsnummer in dieses Feld eintragen."

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -649,6 +649,7 @@
 		},
 		"sessionLink": "POS session",
 		"sessionTouchLink": "POS session - touch screen",
+		"nonEmptyPoolsWarning": "Warning: there are non-empty pools. Please process them properly before closing your PoS Session.",
 		"useSelectForTags": "Use select menu for product tag selection",
 		"tapToPay": {
 			"inProgress": "The payment will be automatically validated once the external transaction is recorded and validated.",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -676,6 +676,7 @@
 		},
 		"sessionLink": "Sesión POS",
 		"sessionTouchLink": "Sesión POS - pantalla táctil",
+		"nonEmptyPoolsWarning": "Advertencia: hay mesas no vacías. Por favor, procéselas correctamente antes de cerrar su sesión PoS.",
 		"tapToPay": {
 			"inProgress": "El pago se validará automáticamente cuando la transacción externa haya sido registrada y validada.",
 			"inUseByOtherOrder": "El pago por Tap-to-pay está desactivado porque hay otro pedido en curso usando este método de pago. Se puede cobrar manualmente e ingresar luego el número de transacción en este campo."

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -676,6 +676,7 @@
 		},
 		"sessionLink": "Session point de vente",
 		"sessionTouchLink": "Session point de vente - écran tactile",
+		"nonEmptyPoolsWarning": "Attention : il y a des tables non vides. Veuillez les traiter correctement avant de fermer votre session PoS.",
 		"tapToPay": {
 			"inProgress": "Le paiement sera validé automatiquement quand la transaction externe sera enregistrée et validée.",
 			"inUseByOtherOrder": "L'encaissement tap-to-pay est désactivé car une autre commande est en cours avec ce mode d'encaissement. Vous pouvez encaisser manuellement et indiquer ensuite le numéro de transaction dans ce champ."

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -676,6 +676,7 @@
 		},
 		"sessionLink": "Sessione POS",
 		"sessionTouchLink": "Sessione POS - touch screen",
+		"nonEmptyPoolsWarning": "Attenzione: ci sono tavoli non vuoti. Si prega di gestirli correttamente prima di chiudere la sessione PoS.",
 		"tapToPay": {
 			"inProgress": "Il pagamento sarà convalidato automaticamente quando la transazione esterna sarà registrata e convalidata.",
 			"inUseByOtherOrder": "Il pagamento tap-to-pay è disattivato perché un altro ordine è in corso con questo metodo di pagamento. Puoi incassare manualmente e poi inserire il numero di transazione in questo campo."

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -676,6 +676,7 @@
 		},
 		"sessionLink": "Bezit",
 		"sessionTouchLink": "POS-sessie - touchscreen",
+		"nonEmptyPoolsWarning": "Waarschuwing: er zijn niet-lege tafels. Verwerk deze correct voordat u uw POS-sessie sluit.",
 		"tapToPay": {
 			"inProgress": "De betaling wordt automatisch gevalideerd zodra de externe transactie is geregistreerd en gevalideerd.",
 			"inUseByOtherOrder": "Tap-to-pay is uitgeschakeld omdat er al een andere bestelling bezig is met deze betaalmethode. U kunt handmatig afrekenen en daarna het transactie­nummer in dit veld invullen."

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -676,6 +676,7 @@
 		},
 		"sessionLink": "Sessão POS",
 		"sessionTouchLink": "Sessão POS - ecrã tátil",
+		"nonEmptyPoolsWarning": "Aviso: existem mesas não vazias. Por favor, processe-as corretamente antes de fechar a sua sessão PoS.",
 		"tapToPay": {
 			"inProgress": "O pagamento será validado automaticamente quando a transação externa for registrada e validada.",
 			"inUseByOtherOrder": "O pagamento via tap-to-pay está desativado porque há outro pedido em andamento usando este método. Você pode cobrar manualmente e depois inserir o número da transação neste campo."

--- a/src/routes/(app)/pos/+page.svelte
+++ b/src/routes/(app)/pos/+page.svelte
@@ -87,6 +87,16 @@
 					{/if}
 					<a href="/pos/closing" class="btn btn-green"> Close the PoS & generate Z ticket </a>
 				</div>
+				{#if data.nonEmptyPoolLabels.length > 0}
+					<p class="text-red-600 font-semibold mt-3">
+						{t('pos.nonEmptyPoolsWarning')}
+					</p>
+					<ul class="text-red-600 text-sm ml-4 list-disc">
+						{#each data.nonEmptyPoolLabels as label}
+							<li>{label}</li>
+						{/each}
+					</ul>
+				{/if}
 			{:else}
 				<p class="text-sm text-gray-600 mb-3">
 					No active POS session. Start your day by opening the POS.

--- a/src/routes/(app)/pos/closing/+page.svelte
+++ b/src/routes/(app)/pos/closing/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import IconWarning from '~icons/ant-design/warning-outlined';
+	import { useI18n } from '$lib/i18n';
+
+	const { t } = useI18n();
 
 	export let data;
 
@@ -27,6 +30,17 @@
 		<h2 class="text-xl font-bold mb-4">
 			Hello {data.user?.alias || data.user?.login || 'User'}!
 		</h2>
+
+		{#if data.nonEmptyPoolLabels.length > 0}
+			<p class="text-red-600 font-semibold mb-2">
+				{t('pos.nonEmptyPoolsWarning')}
+			</p>
+			<ul class="text-red-600 text-sm ml-4 list-disc mb-4">
+				{#each data.nonEmptyPoolLabels as label}
+					<li>{label}</li>
+				{/each}
+			</ul>
+		{/if}
 
 		<div class="space-y-4">
 			<!-- Daily Incomes -->


### PR DESCRIPTION
Show a red warning message on /pos (after X/Z ticket buttons) and /pos/closing (after greeting) when at least one pool has products in it, reminding employees to process pools before closing. Includes i18n translations for all 7 locales.

Closes #2426 