### PR TITLE
🦋 Add hours filters to /admin/reporting

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.server.ts
@@ -97,6 +97,8 @@ export async function load({ url }) {
 		})),
 		beginsAt,
 		endsAt,
+		beginsAtStr: url.searchParams.get('beginsAt'),
+		endsAtStr: url.searchParams.get('endsAt'),
 		paymentMethods: methods,
 		paymentMethod,
 		posSubtype,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.svelte
@@ -36,12 +36,21 @@
 			label: employee
 		})) ?? [];
 
-	$: beginsAt = startOfDay(data.beginsAt);
-	$: endsAt = endOfDay(data.endsAt);
+	$: beginsAt = data.beginsAtStr ? new Date(data.beginsAtStr) : startOfDay(data.beginsAt);
+	$: endsAt = data.endsAtStr
+		? (() => {
+				const d = new Date(data.endsAtStr);
+				d.setSeconds(59, 999);
+				return d;
+		  })()
+		: endOfDay(data.endsAt);
 
-	function dateString(date: Date) {
+	function dateTimeLocalString(date: Date) {
 		return `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date
 			.getDate()
+			.toString()
+			.padStart(2, '0')}T${date.getHours().toString().padStart(2, '0')}:${date
+			.getMinutes()
 			.toString()
 			.padStart(2, '0')}`;
 	}
@@ -291,13 +300,23 @@
 	<div class="col-span-3">
 		<label class="form-label">
 			BeginsAt
-			<input class="form-input" name="beginsAt" type="date" value={dateString(beginsAt)} />
+			<input
+				class="form-input"
+				type="datetime-local"
+				name="beginsAt"
+				value={dateTimeLocalString(beginsAt)}
+			/>
 		</label>
 	</div>
 	<div class="col-span-3">
 		<label class="form-label">
 			EndsAt
-			<input class="form-input" type="date" name="endsAt" value={dateString(endsAt)} />
+			<input
+				class="form-input"
+				type="datetime-local"
+				name="endsAt"
+				value={dateTimeLocalString(endsAt)}
+			/>
 		</label>
 	</div>
 	<div class="col-span-2">


### PR DESCRIPTION
Reporting page now supports time-based filtering alongside dates, allowing businesses that operate past midnight to generate accurate "business day" reports (e.g., Thursday 2 PM to Friday 2 AM) without splitting data across calendar days.

Closes #2412