### PR TITLE
Taler payment provider

### DIFF
--- a/docs/fr/taler-configuration.md
+++ b/docs/fr/taler-configuration.md
@@ -1,0 +1,31 @@
+# Configuration de Taler pour l'application be-bop
+
+Pour intégrer Taler comme méthode de paiement dans votre application **be-bop** accedez à **Admin** > **Payment Settings** > **Taler**.
+
+![image](https://github.com/user-attachments/assets/787589ec-6745-4fb7-975b-b95dd41c4f42)
+
+## Paramètres de Configuration
+
+### 1. Backend URL
+
+- **Description** : Adresse de votre compte dans le merchant backend de Taler.
+- **Emplacement** : À entrer dans le champ **Backend URL**.
+- **Exemple** : `https://backend.demo.taler.net/instances/sandbox`
+
+### 2. Backend API Key
+
+- **Description** : Jeton d'accès (Access token) fourni par Taler pour authentifier les transactions (il faut préfixer la valeur par `secret-token:` !). Ce jeton peut être créé depuis le merchant backend Taler. Les scopes "Order Full" ou "All" sont recommandés.
+- **Emplacement** : À entrer dans le champ **API Key** dans les paramètres de configuration.
+- **Exemple** : `secret-token:sandbox`
+
+### 3. Currency
+
+- **Description** : Devise utilisée pour les transactions Taler dans votre application **be-bop**.
+- **Emplacement** : À entrer dans le champ **Currency**.
+- **Valeurs possibles** : Seules les devises supportées par votre backend Taler sont supportées. Si la valeur du champ Backend URL commence par `https://backend.demo.taler.net/`, alors les paiements seront automatiquement faits en `KUDOS`, la devise de test de Taler.
+
+## Payer avec Taler
+
+Aprés avoir configuré vous pouvez maintenant recevoir des paiements avec Taler.
+
+![image](https://github.com/user-attachments/assets/55c03be1-8ef7-4696-a163-e775229ca8c2)

--- a/src/lib/components/Order/PaymentQRCodes.svelte
+++ b/src/lib/components/Order/PaymentQRCodes.svelte
@@ -10,10 +10,23 @@
 	export let hideCreditCardQrCode: boolean | undefined = undefined;
 </script>
 
+<svelte:head>
+	{#if payment.status === 'pending' && payment.method === 'taler'}
+		<meta name="taler-support" content="uri" />
+	{/if}
+</svelte:head>
+
 {#if payment.status === 'pending'}
 	<!-- Lightning QR -->
 	{#if payment.method === 'lightning'}
 		<a href={lightningPaymentQrCodeString(payment.address ?? '')}>
+			<img src="{$page.url.pathname}/payment/{payment.id}/qrcode" class="w-96 h-96" alt="QR code" />
+		</a>
+	{/if}
+
+	<!-- Taler QR -->
+	{#if payment.method === 'taler'}
+		<a href={payment.address ?? ''}>
 			<img src="{$page.url.pathname}/payment/{payment.id}/qrcode" class="w-96 h-96" alt="QR code" />
 		</a>
 	{/if}

--- a/src/lib/components/PriceTag.svelte
+++ b/src/lib/components/PriceTag.svelte
@@ -44,6 +44,7 @@
 		if (!force && actualCurrency === 'SAT' && actualAmount >= 1_000_000) {
 			return [actualAmount / SATOSHIS_PER_BTC, 'BTC'] as const;
 		}
+
 		return [actualAmount, actualCurrency || 'BTC'] as const;
 	})() as [number, Currency];
 

--- a/src/lib/server/locks/order-lock.ts
+++ b/src/lib/server/locks/order-lock.ts
@@ -16,6 +16,7 @@ import { sbpGetCheckoutStatus } from '../swiss-bitcoin-pay';
 import { CURRENCIES, CURRENCY_UNIT, FRACTION_DIGITS_PER_CURRENCY } from '$lib/types/Currency';
 import { typedInclude } from '$lib/utils/typedIncludes';
 import { isPaypalEnabled, paypalGetCheckout } from '../paypal';
+import { handleDemoCurrency, isTalerEnabled, talerGetOrder } from '../taler';
 import { isStripeEnabled } from '../stripe';
 import { differenceInMinutes } from 'date-fns';
 import { z } from 'zod';
@@ -215,6 +216,7 @@ async function maintainOrders() {
 								case 'bitcoind':
 								case 'stripe':
 								case 'paypal':
+								case 'taler':
 								case 'bitcoin-nodeless':
 									throw new Error(
 										`Unsupported processor ${payment.processor} for lightning payments`
@@ -486,6 +488,49 @@ async function maintainOrders() {
 						} catch (err) {
 							console.error(inspect(err, { depth: 10 }));
 						}
+						break;
+					case 'taler':
+						try {
+							if (!isTalerEnabled()) {
+								throw new Error('Missing Taler credentials');
+							}
+
+							if (!payment.checkoutId) {
+								throw new Error('Missing checkout ID on Taler order');
+							}
+
+							const talerOrder = await talerGetOrder(payment.checkoutId);
+
+							if (talerOrder === 'not_found') {
+								order = await onOrderPaymentFailed(order, payment, 'failed');
+							} else if (talerOrder.order_status === 'paid') {
+								const talerAmountStr = talerOrder.contract_terms.amount;
+
+								if (!talerAmountStr || !talerAmountStr.includes(':')) {
+									throw new Error(`Invalid amount format in contract_terms: ${talerAmountStr}`);
+								}
+
+								const talerCurrency = talerAmountStr.split(':')[0];
+								const currency = handleDemoCurrency(talerCurrency);
+
+								const amountStr = talerAmountStr.split(':')[1];
+								if (!amountStr || isNaN(Number(amountStr))) {
+									throw new Error(`Invalid amount in deposit_total: ${amountStr}`);
+								}
+								const amount = Number(amountStr);
+
+								if (!typedInclude(CURRENCIES, currency)) {
+									throw new Error('Unknown currency ' + currency);
+								}
+
+								order = await onOrderPayment(order, payment, { amount, currency });
+							} else if (payment.expiresAt && payment.expiresAt < new Date()) {
+								order = await onOrderPaymentFailed(order, payment, 'expired');
+							}
+						} catch (err) {
+							console.error(inspect(err, { depth: 10 }));
+						}
+						break;
 					case 'point-of-sale':
 						try {
 							if (payment.posTapToPay && payment.posTapToPay.expiresAt > new Date()) {
@@ -511,6 +556,7 @@ async function maintainOrders() {
 										break;
 									case 'btcpay-server':
 									case 'paypal':
+									case 'taler':
 									case 'phoenixd':
 									case 'sumup':
 									case 'bitcoind':

--- a/src/lib/server/locks/order-notifications.ts
+++ b/src/lib/server/locks/order-notifications.ts
@@ -209,6 +209,9 @@ async function handleOrderNotification(order: Order): Promise<void> {
 							case 'paypal':
 								templateKey = 'order.payment.pending.paypal';
 								break;
+							case 'taler':
+								templateKey = 'order.payment.pending.taler';
+								break;
 							case 'point-of-sale':
 							case 'free':
 								// no email

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -86,6 +86,8 @@ import { toZonedTime } from 'date-fns-tz';
 import { isSwissBitcoinPayConfigured, sbpCreateCheckout } from './swiss-bitcoin-pay';
 import type { PaidSubscription } from '$lib/types/PaidSubscription';
 import { btcpayCreateLnInvoice, isBtcpayServerConfigured } from './btcpay-server';
+import { getCurrencyForPayment, talerPaymentUnpaidResponseSchema } from './taler';
+import type { TalerPaymentUnpaidResponse } from './taler';
 
 export async function conflictingTapToPayOrder(orderId: string): Promise<string | null> {
 	const other = await collections.orders.findOne({
@@ -1905,6 +1907,8 @@ async function generatePaymentInfo(params: {
 			return await generateCardPaymentInfo(params);
 		case 'paypal':
 			return await generatePaypalPaymentInfo(params);
+		case 'taler':
+			return await generateTalerPaymentInfo(params);
 	}
 }
 
@@ -2131,6 +2135,91 @@ async function generatePaypalPaymentInfo(params: {
 	};
 }
 
+async function generateTalerPaymentInfo(params: {
+	orderId: string;
+	orderNumber: number;
+	toPay: Price;
+	paymentId: ObjectId;
+}): Promise<{
+	checkoutId: string;
+	meta: unknown;
+	address: string;
+	processor: PaymentProcessor;
+}> {
+	const amount = toCurrency(
+		runtimeConfig.taler.currency,
+		params.toPay.amount,
+		params.toPay.currency
+	).toFixed(FRACTION_DIGITS_PER_CURRENCY[runtimeConfig.taler.currency]);
+
+	const talerCurrency = getCurrencyForPayment();
+
+	const response = await fetch(`${runtimeConfig.taler.backendUrl}/private/orders`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${runtimeConfig.taler.backendApiKey}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			order: {
+				order_id: params.paymentId,
+				amount: `${talerCurrency}:${amount}`,
+				summary: `${runtimeConfig.sellerIdentity?.businessName} - Order #${params.orderNumber}`,
+				// default Taler expiration for orders is 5 minutes, we override with be-BOP's default
+				pay_deadline: {
+					t_s: Math.floor(Date.now() / 1000) + runtimeConfig.desiredPaymentTimeout * 60
+				},
+				fulfillment_url: `${ORIGIN}/order/${params.orderId}`
+			}
+		})
+	});
+
+	if (!response.ok) {
+		console.error(await response.text());
+		throw error(402, 'Taler order creation failed');
+	}
+
+	const orderResponse = await fetch(
+		`${runtimeConfig.taler.backendUrl}/private/orders/${params.paymentId}`,
+		{
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${runtimeConfig.taler.backendApiKey}`,
+				'Content-Type': 'application/json'
+			}
+		}
+	);
+
+	if (!orderResponse.ok) {
+		console.error(await orderResponse.text());
+		throw error(402, 'Taler order fetching failed');
+	}
+
+	const rawOrder = await orderResponse.json();
+	const parsed = talerPaymentUnpaidResponseSchema.safeParse(rawOrder);
+
+	if (!parsed.success) {
+		console.error('Invalid Taler order response:', parsed.error.message, rawOrder);
+		throw error(402, 'Taler order response validation failed');
+	}
+
+	const order: TalerPaymentUnpaidResponse = parsed.data;
+
+	if (order.creation_time.t_s === 'never') {
+		throw error(402, 'Invalid Taler Order creation_time received');
+	}
+
+	return {
+		checkoutId: params.paymentId.toString(),
+		meta: {
+			...order,
+			creation_time: new Date(order.creation_time.t_s * 1000).toISOString()
+		},
+		address: order.taler_pay_uri,
+		processor: 'taler'
+	};
+}
+
 export function paymentMethodExpiration(
 	paymentMethod: PaymentMethod,
 	opts?: { paymentTimeout?: number }
@@ -2180,6 +2269,11 @@ function paymentPrice(paymentMethod: PaymentMethod, price: Price): Price {
 			return {
 				amount: toCurrency(runtimeConfig.paypal.currency, price.amount, price.currency),
 				currency: runtimeConfig.paypal.currency
+			};
+		case 'taler':
+			return {
+				amount: toCurrency(runtimeConfig.taler.currency, price.amount, price.currency),
+				currency: runtimeConfig.taler.currency
 			};
 		case 'bitcoin':
 			return {

--- a/src/lib/server/payment-methods.ts
+++ b/src/lib/server/payment-methods.ts
@@ -6,6 +6,7 @@ import { runtimeConfig } from './runtime-config';
 import { isSumupEnabled } from './sumup';
 import { isStripeEnabled } from './stripe';
 import { isPaypalEnabled } from './paypal';
+import { isTalerEnabled } from './taler';
 import { isBitcoinNodelessConfigured } from './bitcoin-nodeless';
 import { isSwissBitcoinPayConfigured } from './swiss-bitcoin-pay';
 import { isBtcpayServerConfigured } from './btcpay-server';
@@ -17,7 +18,8 @@ export const ALL_PAYMENT_METHODS = [
 	'lightning',
 	'point-of-sale',
 	'free',
-	'paypal'
+	'paypal',
+	'taler'
 ] as const;
 export type PaymentMethod = (typeof ALL_PAYMENT_METHODS)[number];
 
@@ -30,7 +32,8 @@ export const ALL_PAYMENT_PROCESSORS = [
 	'phoenixd',
 	'stripe',
 	'sumup',
-	'swiss-bitcoin-pay'
+	'swiss-bitcoin-pay',
+	'taler'
 ] as const;
 export type PaymentProcessor = (typeof ALL_PAYMENT_PROCESSORS)[number];
 
@@ -55,6 +58,8 @@ export const paymentMethods = (opts?: {
 							return isSumupEnabled() || isStripeEnabled();
 						case 'paypal':
 							return isPaypalEnabled();
+						case 'taler':
+							return isTalerEnabled();
 						case 'bank-transfer':
 							return runtimeConfig.sellerIdentity?.bank;
 						case 'bitcoin':

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -225,6 +225,11 @@ const baseConfig = {
 	swissBitcoinPay: {
 		apiKey: ''
 	},
+	taler: {
+		backendUrl: '',
+		backendApiKey: '',
+		currency: 'CHF' as Currency
+	},
 	bity: {
 		clientId: ''
 	},
@@ -348,6 +353,12 @@ Amount: {{amount}} {{currency}}</p>`,
 			default: true as boolean
 		},
 		'order.payment.pending.paypal': {
+			subject: 'Order #{{orderNumber}}',
+			html: `<p>Payment for order #{{orderNumber}} is pending, see <a href="{{orderLink}}">{{orderLink}}</a></p>
+<p>Please pay using this link: <a href="{{paymentLink}}">{{paymentLink}}</a></p>`,
+			default: true as boolean
+		},
+		'order.payment.pending.taler': {
 			subject: 'Order #{{orderNumber}}',
 			html: `<p>Payment for order #{{orderNumber}} is pending, see <a href="{{orderLink}}">{{orderLink}}</a></p>
 <p>Please pay using this link: <a href="{{paymentLink}}">{{paymentLink}}</a></p>`,

--- a/src/lib/server/taler.ts
+++ b/src/lib/server/taler.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+import { runtimeConfig } from './runtime-config';
+
+const timestampSchema = z.object({
+	t_s: z.union([z.number().int().min(0), z.literal('never')])
+});
+
+const contractTermsSchema = z.object({
+	amount: z.string()
+});
+
+export const talerPaymentUnpaidResponseSchema = z.object({
+	order_status: z.literal('unpaid'),
+	creation_time: timestampSchema,
+	summary: z.string(),
+	total_amount: z.string(),
+	taler_pay_uri: z.string(),
+	order_status_url: z.string()
+});
+
+export const talerPaymentClaimedResponseSchema = z.object({
+	order_status: z.literal('claimed'),
+	contract_terms: contractTermsSchema
+});
+
+export const talerPaymentPaidResponseSchema = z.object({
+	order_status: z.literal('paid'),
+	contract_terms: contractTermsSchema,
+	order_status_url: z.string()
+});
+
+export type TalerPaymentPaidResponse = z.infer<typeof talerPaymentPaidResponseSchema>;
+export type TalerPaymentClaimedResponse = z.infer<typeof talerPaymentClaimedResponseSchema>;
+export type TalerPaymentUnpaidResponse = z.infer<typeof talerPaymentUnpaidResponseSchema>;
+
+export const talerMerchantOrderStatusResponseSchema = z.discriminatedUnion('order_status', [
+	talerPaymentPaidResponseSchema,
+	talerPaymentClaimedResponseSchema,
+	talerPaymentUnpaidResponseSchema
+]);
+
+export type TalerMerchantOrderStatusResponse = z.infer<
+	typeof talerMerchantOrderStatusResponseSchema
+>;
+
+export function isTalerEnabled() {
+	return !!runtimeConfig.taler.backendUrl && !!runtimeConfig.taler.backendApiKey;
+}
+
+// test if we need to use KUDOS
+export function isDemoMerchantBackend() {
+	return runtimeConfig.taler?.backendUrl?.startsWith('https://backend.demo.taler.net');
+}
+
+// In Taler, `KUDOS` is used as a demo currency.
+// be-BOP cannot store payments with an unexisting currency (because it calculates exchange rates).
+// When reading payments, we fallback to the configured currency if `KUDOS` was used and the demo backend is used
+export function handleDemoCurrency(currency: string | undefined): string {
+	return currency && currency !== 'KUDOS' && !isDemoMerchantBackend()
+		? currency
+		: runtimeConfig.taler.currency;
+}
+
+// In Taler, `KUDOS` is used as a demo currency.
+// be-BOP cannot store payments with an unexisting currency (because it calculates exchange rates).
+// When creating a payment, we manually change the currency to `KUDOS` if the demo backend is used.
+export function getCurrencyForPayment(): string {
+	return isDemoMerchantBackend() ? 'KUDOS' : runtimeConfig.taler.currency;
+}
+
+export async function talerGetOrder(
+	orderId: string
+): Promise<TalerMerchantOrderStatusResponse | 'not_found'> {
+	const response = await fetch(`${runtimeConfig.taler.backendUrl}/private/orders/${orderId}`, {
+		method: 'GET',
+		headers: {
+			Authorization: `Bearer ${runtimeConfig.taler.backendApiKey}`,
+			'Content-Type': 'application/json'
+		}
+	});
+
+	if (response.status === 404) {
+		return 'not_found';
+	}
+
+	if (!response.ok) {
+		throw new Error(`Failed to get Taler order: ${response.status} ${response.statusText}`);
+	}
+
+	const rawOrder = await response.json();
+	const parsed = talerMerchantOrderStatusResponseSchema.safeParse(rawOrder);
+
+	if (!parsed.success) {
+		throw new Error(
+			`Invalid Taler order response: ${parsed.error.message}\n${JSON.stringify(
+				parsed.error.errors,
+				null,
+				2
+			)}`
+		);
+	}
+
+	return parsed.data;
+}

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -122,6 +122,7 @@
 			"free": "Nichts zu bezahlen (kostenloser Warenkorb)",
 			"lightning": "Lightning",
 			"paypal": "Paypal",
+			"taler": "Taler",
 			"point-of-sale": "Point of Sale",
 			"unavailable": "Keine Zahlungsmethoden verfügbar."
 		},
@@ -516,6 +517,7 @@
 			"free": "Nichts bezahlt",
 			"lightning": "Bezahlt mit: Lightning-Transaktion (1 {paymentCurrency} = {exchangeRate} {mainCurrency} zum Zeitpunkt der Bestellung)",
 			"paypal": "Bezahlt mit: Paypal",
+			"taler": "Bezahlt mit: Taler",
 			"point-of-sale": "Im Geschäft bezahlt"
 		},
 		"paidWithSummary": {
@@ -524,7 +526,8 @@
 			"card": "Bezahlt mit: Bankkarte",
 			"free": "Nichts bezahlt",
 			"lightning": "Bezahlt mit: Lightning-Transaktion",
-			"point-of-sale": "Im Geschäft bezahlt"
+			"point-of-sale": "Im Geschäft bezahlt",
+			"taler": "Bezahlt mit: Taler"
 		},
 		"payToComplete": "Bezahlen Sie, um die Bestellung abzuschließen.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -122,6 +122,7 @@
 			"free": "Nothing to pay (free cart)",
 			"lightning": "Lightning",
 			"paypal": "Paypal",
+			"taler": "Taler",
 			"point-of-sale": "Point of sale",
 			"unavailable": "No payment methods available."
 		},
@@ -516,6 +517,7 @@
 			"free": "Paid Nothing",
 			"lightning": "Paid with: Lightning transaction (1 {paymentCurrency} = {exchangeRate} {mainCurrency} at the time of the order)",
 			"paypal": "Paid with: paypal",
+			"taler": "Paid with: Taler",
 			"point-of-sale": "Paid in store"
 		},
 		"paidWithSummary": {
@@ -524,7 +526,8 @@
 			"card": "Paid with: bank card",
 			"free": "Paid Nothing",
 			"lightning": "Paid with: Lightning transaction",
-			"point-of-sale": "Paid in store"
+			"point-of-sale": "Paid in store",
+			"taler": "Paid with: Taler"
 		},
 		"payToComplete": "Pay to complete the order.",
 		"payToCompleteBitcoin": {
@@ -633,7 +636,7 @@
 	"pos": {
 		"adminInterface": "Admin interface",
 		"applyGiftDiscount": "As a POS user I apply a <0>gift discount</0>",
-		"cancelOrderMessage": "Are you sure you want to cnacel the entire order ?",
+		"cancelOrderMessage": "Are you sure you want to cancel the entire order ?",
 		"cta": {
 			"cancelMultiPayOrder": "Cancel order",
 			"cancelOrder": "Cancel",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -122,6 +122,7 @@
 			"free": "Nada que pagar (lista de compras de gratis)",
 			"lightning": "Lightning",
 			"paypal": "Paypal",
+			"taler": "Taler",
 			"point-of-sale": "Punto de venta",
 			"unavailable": "No hay métodos de pago disponibles."
 		},
@@ -516,6 +517,7 @@
 			"free": "No se pagó nada",
 			"lightning": "Pagado con: transacción Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento del pedido)",
 			"paypal": "Pagado con: paypal",
+			"taler": "Pagado con: Taler",
 			"point-of-sale": "Pagado en tienda"
 		},
 		"paidWithSummary": {
@@ -524,7 +526,8 @@
 			"card": "Pagado con: tarjeta bancaria",
 			"free": "No se pagó nada",
 			"lightning": "Pagado con: transacción Lightning",
-			"point-of-sale": "Pagado en tienda"
+			"point-of-sale": "Pagado en tienda",
+			"taler": "Pagado con: Taler"
 		},
 		"payToComplete": "Pagar para completar el pedido.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -122,6 +122,7 @@
 			"free": "Rien à payer (panier gratuit)",
 			"lightning": "Lightning",
 			"paypal": "Paypal",
+			"taler": "Taler",
 			"point-of-sale": "Point of sale",
 			"unavailable": "Aucun mode de paiement disponible."
 		},
@@ -516,6 +517,7 @@
 			"free": "N'a rien payé",
 			"lightning": "Payé avec : Transaction Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} au moment de la commande)",
 			"paypal": "Payé avec: paypal",
+			"taler": "Payé avec: Taler",
 			"point-of-sale": "Payé en magasin"
 		},
 		"paidWithSummary": {
@@ -524,7 +526,8 @@
 			"card": "Payé avec : carte bancaire",
 			"free": "N'a rien payé",
 			"lightning": "Payé avec : Transaction Lightning",
-			"point-of-sale": "Payé en magasin"
+			"point-of-sale": "Payé en magasin",
+			"taler": "Payé avec : Taler"
 		},
 		"payToComplete": "Payez pour finaliser la commande.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -122,6 +122,7 @@
 			"free": "Niente da pagare (cartello vuoto)",
 			"lightning": "Lightning",
 			"paypal": "PayPal",
+			"taler": "Taler",
 			"point-of-sale": "Punto di vendita",
 			"unavailable": "Nessun metodo di pagamento valido."
 		},
@@ -515,7 +516,8 @@
 			"card": "Pagato con: carta bancaria",
 			"free": "Nessun pagamento",
 			"lightning": "Pagato con: transazione Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento dell'ordine)",
-			"paypal": "Pagato con:  paypal",
+			"paypal": "Pagato con: paypal",
+			"taler": "Pagato con: Taler",
 			"point-of-sale": "Pagato in magazzino"
 		},
 		"paidWithSummary": {
@@ -524,7 +526,8 @@
 			"card": "Pagato con: carta bancaria",
 			"free": "Nessun pagamento",
 			"lightning": "Pagato con: transazione Lightning",
-			"point-of-sale": "Pagato in magazzino"
+			"point-of-sale": "Pagato in magazzino",
+			"taler": "Pagato con: Taler"
 		},
 		"payToComplete": "Paga per completare l'ordine.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -122,6 +122,7 @@
 			"free": "Niets te betalen (gratis winkelwagen)",
 			"lightning": "Bliksem",
 			"paypal": "Paypal",
+			"taler": "Taler",
 			"point-of-sale": "Verkooppunt",
 			"unavailable": "Geen betaalmethoden beschikbaar."
 		},
@@ -516,6 +517,7 @@
 			"free": "Niets betaald",
 			"lightning": "Betaald met: Lightning-transactie (1 {paymentCurrency} = {exchangeRate} {mainCurrency} op het moment van de bestelling)",
 			"paypal": "Betaald met: paypal",
+			"taler": "Betaald met: Taler",
 			"point-of-sale": "Betaald in de winkel"
 		},
 		"paidWithSummary": {
@@ -524,7 +526,8 @@
 			"card": "Betaald met: bankkaart",
 			"free": "Niets betaald",
 			"lightning": "Betaald met: Lightning-transactie",
-			"point-of-sale": "Betaald in de winkel"
+			"point-of-sale": "Betaald in de winkel",
+			"taler": "Betaald met: Taler"
 		},
 		"payToComplete": "Betaal om de bestelling af te ronden.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -122,6 +122,7 @@
 			"free": "Nada a pagar (carrinho gratuito)",
 			"lightning": "Lightning",
 			"paypal": "Paypal",
+			"taler": "Taler",
 			"point-of-sale": "Ponto de venda",
 			"unavailable": "Nenhum método de pagamento disponível."
 		},
@@ -516,6 +517,7 @@
 			"free": "Pago nada",
 			"lightning": "Pago com: transação Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} no momento da encomenda)",
 			"paypal": "Pago com: paypal",
+			"taler": "Paga com: Taler",
 			"point-of-sale": "Pago na loja"
 		},
 		"paidWithSummary": {
@@ -524,7 +526,8 @@
 			"card": "Pago com: cartão bancário",
 			"free": "Pago nada",
 			"lightning": "Pago com: transação Lightning",
-			"point-of-sale": "Pago na loja"
+			"point-of-sale": "Pago na loja",
+			"taler": "Pago com: Taler"
 		},
 		"payToComplete": "Pague para completar a encomenda.",
 		"payToCompleteBitcoin": {

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -402,7 +402,8 @@ export const PAYMENT_METHOD_EMOJI: Record<PaymentMethod, string> = {
 	'point-of-sale': '🛒',
 	lightning: '⚡',
 	bitcoin: '₿',
-	free: '🆓'
+	free: '🆓',
+	taler: '🅣' // maybe 🪙 (taler = old silver coin, but also resembles cash)
 };
 
 export const ORDER_PAGINATION_LIMIT = 50;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
@@ -147,6 +147,10 @@ export const adminLinks: AdminLinks = [
 				label: 'Lightning LND node'
 			},
 			{
+				href: '/admin/taler',
+				label: 'Taler'
+			},
+			{
 				href: '/admin/pos-payments',
 				label: 'PoS Payments'
 			}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.server.ts
@@ -1,0 +1,55 @@
+import { collections } from '$lib/server/database.js';
+import { runtimeConfig } from '$lib/server/runtime-config';
+import { CURRENCIES, type Currency } from '$lib/types/Currency.js';
+import { z } from 'zod';
+
+export async function load() {
+	return {
+		taler: runtimeConfig.taler
+	};
+}
+
+export const actions = {
+	save: async function ({ request }) {
+		const taler = z
+			.object({
+				backendUrl: z
+					.string()
+					.min(1)
+					.transform((url) => url.replace(/\/+$/, '')),
+				backendApiKey: z.string().min(1),
+				currency: z.enum(
+					CURRENCIES.filter((c) => c !== 'BTC' && c !== 'SAT') as [Currency, ...Currency[]]
+				)
+			})
+			.parse(Object.fromEntries(await request.formData()));
+
+		await collections.runtimeConfig.updateOne(
+			{
+				_id: 'taler'
+			},
+			{
+				$set: {
+					data: taler,
+					updatedAt: new Date()
+				}
+			},
+			{
+				upsert: true
+			}
+		);
+
+		runtimeConfig.taler = taler;
+	},
+	delete: async function () {
+		await collections.runtimeConfig.deleteOne({
+			_id: 'taler'
+		});
+
+		runtimeConfig.taler = {
+			backendUrl: '',
+			backendApiKey: '',
+			currency: 'CHF'
+		};
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { CURRENCIES } from '$lib/types/Currency';
+
+	export let data;
+</script>
+
+<h1 class="text-3xl">Taler</h1>
+
+<form class="contents" method="post" action="?/save">
+	<label class="form-label">
+		Backend URL
+		<input
+			class="form-input"
+			type="text"
+			name="backendUrl"
+			value={data.taler.backendUrl}
+			required
+		/>
+	</label>
+
+	<label class="form-label">
+		Backend API Key
+		<input
+			class="form-input"
+			type="password"
+			name="backendApiKey"
+			value={data.taler.backendApiKey}
+			required
+		/>
+	</label>
+
+	<label class="form-label">
+		Currency
+		<select class="form-input" name="currency" bind:value={data.taler.currency} required>
+			{#each CURRENCIES.filter((c) => c !== 'BTC' && c !== 'SAT') as currency}
+				<option value={currency}>{currency}</option>
+			{/each}
+		</select>
+	</label>
+
+	<div class="flex justify-between">
+		<button class="btn btn-black" type="submit">Save</button>
+		<button class="btn btn-red" type="submit" form="delete-form">Reset</button>
+	</div>
+</form>
+<form class="contents" method="post" action="?/delete" id="delete-form"></form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.ts
@@ -1,0 +1,6 @@
+export async function load({ data }) {
+	return {
+		...data,
+		bodyClass: 'max-w-7xl mx-auto'
+	};
+}

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/qrcode/+server.ts
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/qrcode/+server.ts
@@ -23,7 +23,12 @@ export async function GET({ params, url }) {
 		throw error(404, 'Payment not found');
 	}
 
-	if (payment.method !== 'bitcoin' && payment.method !== 'lightning' && payment.method !== 'card') {
+	if (
+		payment.method !== 'bitcoin' &&
+		payment.method !== 'lightning' &&
+		payment.method !== 'card' &&
+		payment.method !== 'taler'
+	) {
 		throw error(400, 'Invalid payment method for QR Code generation');
 	}
 


### PR DESCRIPTION
This adds the Taler payment provider.

I've tested standard online checkout and POS checkout.

~~One thing that does not work yet is split paying in POS (I'm working on it).~~
EDIT: the UI was automatically creating the second payment in cash, not sure if intended, but it seems to work as expected.

To test, you can go to http://localhost:5173/admin/taler and configure like this:
Backend URL: `https://backend.demo.taler.net/instances/sandbox`
Backend API Key: `secret-token:sandbox`

If the backend URL starts with `https://backend.demo.taler.net`, then the `KUDOS` demo currency is used.
You then need the Taler Wallet app and `KUDOS` which you can withdraw from the preferences.

You can then buy and pay with Taler.

I'm open for feedback since this is my first bigger contribution.


EDIT: you can see what happens on the Taler side by going to https://backend.demo.taler.net/webui/#/, user and password is `sandbox`