### PR TITLE
🦋 Add PoS payment subtype filter to reporting page

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.server.ts
@@ -8,7 +8,7 @@ import type { Filter } from 'mongodb';
 import { z } from 'zod';
 
 export async function load({ url, locals }) {
-	const methods = paymentMethods({ hasPosOptions: locals.user?.hasPosOptions });
+	const methods = paymentMethods({ hasPosOptions: locals.user?.hasPosOptions, includePOS: true });
 
 	const querySchema = z.object({
 		skip: z.number({ coerce: true }).int().min(0).optional().default(0),
@@ -19,7 +19,8 @@ export async function load({ url, locals }) {
 		email: z.string().optional(),
 		label: z.string().optional(),
 		npub: z.string().optional(),
-		employeeAlias: z.string().optional()
+		employeeAlias: z.string().optional(),
+		posSubtype: z.string().optional()
 	});
 
 	const searchParams = Object.fromEntries(url.searchParams.entries());
@@ -33,7 +34,8 @@ export async function load({ url, locals }) {
 		email,
 		npub,
 		label,
-		employeeAlias
+		employeeAlias,
+		posSubtype
 	} = result;
 
 	const query: Filter<Order> = {};
@@ -46,6 +48,9 @@ export async function load({ url, locals }) {
 	}
 	if (paymentMethod) {
 		query['payments.method'] = paymentMethod;
+	}
+	if (posSubtype) {
+		query['payments.posSubtype'] = posSubtype;
 	}
 	if (country) {
 		query['shippingAddress.country'] = country;
@@ -72,6 +77,10 @@ export async function load({ url, locals }) {
 		.sort({ createdAt: -1 })
 		.toArray();
 	const labels = await collections.labels.find({}).toArray();
+	const posSubtypes = await collections.posPaymentSubtypes
+		.find({})
+		.sort({ sortOrder: 1 })
+		.toArray();
 	const nonCustomers = await collections.users
 		.find({ roleId: { $ne: CUSTOMER_ROLE_ID } })
 		.sort({ _id: 1 })
@@ -100,6 +109,8 @@ export async function load({ url, locals }) {
 		employees: nonCustomers.map((user) => ({
 			_id: user._id.toString(),
 			alias: user.alias
-		}))
+		})),
+		posSubtype,
+		posSubtypes: posSubtypes.map((s) => ({ slug: s.slug, name: s.name }))
 	};
 }

--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.svelte
@@ -6,6 +6,7 @@
 
 	export let data;
 	let next = 0;
+	let selectedPaymentMethod = $page.url.searchParams.get('paymentMethod') ?? '';
 
 	const { t, countryName, sortedCountryCodes } = useI18n();
 </script>
@@ -34,18 +35,36 @@
 		</label>
 		<label class="form-label w-[15em]">
 			Payment Mean
-			<select name="paymentMethod" class="form-input" disabled={data.paymentMethods.length === 0}>
-				<option></option>
+			<select
+				name="paymentMethod"
+				class="form-input"
+				disabled={data.paymentMethods.length === 0}
+				bind:value={selectedPaymentMethod}
+			>
+				<option value=""></option>
 				{#each data.paymentMethods as paymentMethod}
-					<option
-						value={paymentMethod}
-						selected={$page.url.searchParams.get('paymentMethod') === paymentMethod}
-					>
+					<option value={paymentMethod}>
 						{t('checkout.paymentMethod.' + paymentMethod)}
 					</option>
 				{/each}
 			</select>
 		</label>
+		{#if selectedPaymentMethod === 'point-of-sale' && data.posSubtypes?.length}
+			<label class="form-label w-[15em]">
+				PoS Subtype
+				<select name="posSubtype" class="form-input">
+					<option value="">All subtypes</option>
+					{#each data.posSubtypes as subtype}
+						<option
+							value={subtype.slug}
+							selected={$page.url.searchParams.get('posSubtype') === subtype.slug}
+						>
+							{subtype.name}
+						</option>
+					{/each}
+				</select>
+			</label>
+		{/if}
 		<label class="form-label w-[15em]">
 			Country
 			<select name="country" class="form-input">

--- a/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.server.ts
@@ -15,14 +15,15 @@ export async function load({ url }) {
 		endsAt: z.date({ coerce: true }).default(new Date()),
 		paymentMethod: z.enum(['' as const, ...methods]).optional(),
 		employeesAlias: z.string().array(),
-		tagId: z.string().optional()
+		tagId: z.string().optional(),
+		posSubtype: z.string().optional()
 	});
 	const queryParams = Object.fromEntries(url.searchParams.entries());
 	const result = querySchema.parse({
 		...queryParams,
 		employeesAlias: url.searchParams.getAll('employeesAlias')
 	});
-	const { beginsAt, endsAt, paymentMethod, employeesAlias, tagId } = result;
+	const { beginsAt, endsAt, paymentMethod, employeesAlias, tagId, posSubtype } = result;
 	const aliasFilter = [];
 	if (employeesAlias.includes('System')) {
 		aliasFilter.push({ 'user.userAlias': { $exists: false } });
@@ -43,6 +44,7 @@ export async function load({ url }) {
 				$lt: addDays(endsAt, 1)
 			},
 			...(paymentMethod && { 'payments.method': paymentMethod }),
+			...(posSubtype && { 'payments.posSubtype': posSubtype }),
 			...(aliasFilter.length > 0 && { $or: aliasFilter }),
 			...tagFilter
 		})
@@ -97,6 +99,7 @@ export async function load({ url }) {
 		endsAt,
 		paymentMethods: methods,
 		paymentMethod,
+		posSubtype,
 		employees: nonCustomers.map((user) => ({
 			_id: user._id.toString(),
 			alias: user.alias

--- a/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.svelte
@@ -25,6 +25,7 @@
 	let includeCanceled = false;
 	let includePartiallyPaid = false;
 	let filterByTag = !!data.tagId;
+	let selectedPaymentMethod = data.paymentMethod ?? '';
 	let html = '';
 	let loadedHtml = false;
 	let htmlStatus = '';
@@ -50,6 +51,18 @@
 		(order) => order.createdAt >= beginsAt && order.createdAt <= endsAt
 	);
 	$: paidOrders = orders.filter((order) => order.status === 'paid');
+	$: paymentMatchesFilter = (payment: { method: string; posSubtype?: string }) => {
+		if (!data.paymentMethod) {
+			return true;
+		}
+		if (payment.method !== data.paymentMethod) {
+			return false;
+		}
+		if (data.posSubtype && payment.posSubtype !== data.posSubtype) {
+			return false;
+		}
+		return true;
+	};
 	$: orderFiltered = orders.filter(
 		(order) =>
 			order.status === 'paid' ||
@@ -158,27 +171,23 @@
 		return productQuantities;
 	}
 	function quantityOfPaymentMean(orders: typeof paidOrders) {
-		const paymentMeanQuantities: Record<string, { quantity: number; total: number }> = {};
-		const paymentMeanDetails: Record<string, Price[]> = {};
-
-		for (const order of orders) {
-			for (const payment of order.payments) {
+		const grouped = orders
+			.flatMap((order) => order.payments.filter(paymentMatchesFilter))
+			.reduce<Record<string, Price[]>>((acc, payment) => {
 				const key =
 					payment.method === 'point-of-sale' && payment.posSubtype
 						? `${payment.method}:${payment.posSubtype}`
 						: payment.method;
-				paymentMeanDetails[key] ??= [];
-				paymentMeanDetails[key].push(payment.currencySnapshot.main.price);
-				paymentMeanQuantities[key] ??= { quantity: 0, total: 0 };
-				paymentMeanQuantities[key].quantity += 1;
-			}
-		}
+				(acc[key] ??= []).push(payment.currencySnapshot.main.price);
+				return acc;
+			}, {});
 
-		for (const [method, details] of Object.entries(paymentMeanDetails)) {
-			paymentMeanQuantities[method].total = sumCurrency(data.currencies.main, details);
-		}
-
-		return paymentMeanQuantities;
+		return Object.fromEntries(
+			Object.entries(grouped).map(([method, prices]) => [
+				method,
+				{ quantity: prices.length, total: sumCurrency(data.currencies.main, prices) }
+			])
+		);
 	}
 	function fetchProductById(productId: string) {
 		for (const order of paidOrders) {
@@ -294,16 +303,36 @@
 	<div class="col-span-2">
 		<label class="form-label">
 			Payment Mean
-			<select name="paymentMethod" class="form-input" disabled={data.paymentMethods.length === 0}>
-				<option></option>
+			<select
+				name="paymentMethod"
+				class="form-input"
+				disabled={data.paymentMethods.length === 0}
+				bind:value={selectedPaymentMethod}
+			>
+				<option value=""></option>
 				{#each data.paymentMethods as paymentMethod}
-					<option value={paymentMethod} selected={data.paymentMethod === paymentMethod}>
+					<option value={paymentMethod}>
 						{t('checkout.paymentMethod.' + paymentMethod)}
 					</option>
 				{/each}
 			</select>
 		</label>
 	</div>
+	{#if selectedPaymentMethod === 'point-of-sale' && data.posSubtypes?.length}
+		<div class="col-span-2">
+			<label class="form-label">
+				PoS Subtype
+				<select name="posSubtype" class="form-input">
+					<option value="">All subtypes</option>
+					{#each data.posSubtypes as subtype}
+						<option value={subtype.slug} selected={data.posSubtype === subtype.slug}>
+							{subtype.name}
+						</option>
+					{/each}
+				</select>
+			</label>
+		</div>
+	{/if}
 	<div class="col-span-3">
 		<label class="form-label">
 			Employee alias
@@ -570,7 +599,7 @@
 				<tbody>
 					<!-- Order rows -->
 					{#each orders.filter((order) => order.status === 'paid' || (includePartiallyPaid && order.payments.some((payment) => payment.status === 'paid')) || (includeExpired && order.payments.some((payment) => payment.status === 'expired'))) as order}
-						{#each order.payments as payment}
+						{#each order.payments.filter(paymentMatchesFilter) as payment}
 							<tr class="hover:bg-gray-100 whitespace-nowrap">
 								<td class="border border-gray-300 px-4 py-2">{order.number}</td>
 								<td class="border border-gray-300 px-4 py-2"


### PR DESCRIPTION
Admins can now filter by individual PoS payment subtypes (cash, check, external-tpe, etc.) on the reporting page. A secondary dropdown appears when "Point of sale" is selected as payment method.

Closes #2413