### PR TITLE
🦋🤖 Allow users to see active and past subscriptions on /subscription …

### DIFF
--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -898,8 +898,14 @@
 		},
 		"initiallyCreated": "Ursprünglich erstellt: ",
 		"paidUntil": "Bezahlt bis: ",
+		"expiresOn": "Läuft ab am",
+		"lastOrder": "Letzte Bestellung anzeigen",
+		"lastPayment": "Letzte Zahlung",
+		"listTitle": "Ihre Abonnements",
+		"noSubscriptions": "Sie haben noch keine Abonnements.",
 		"singleTitle": "Abonnement #{number}",
 		"status": {
+			"active": "aktiv",
 			"expired": "abgelaufen"
 		}
 	},

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -898,8 +898,14 @@
 		},
 		"initiallyCreated": "Initially created: <0></0>",
 		"paidUntil": "Paid until: <0></0>",
+		"expiresOn": "Expires on",
+		"lastOrder": "View last order",
+		"lastPayment": "Last payment",
+		"listTitle": "Your subscriptions",
+		"noSubscriptions": "You have no subscriptions yet.",
 		"singleTitle": "Subscription #{number}",
 		"status": {
+			"active": "active",
 			"expired": "expired"
 		}
 	},

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -898,8 +898,14 @@
 		},
 		"initiallyCreated": "Creada inicialmente: <0></0>",
 		"paidUntil": "Pagada hasta: <0></0>",
+		"expiresOn": "Expira el",
+		"lastOrder": "Ver último pedido",
+		"lastPayment": "Último pago",
+		"listTitle": "Sus suscripciones",
+		"noSubscriptions": "Aún no tiene suscripciones.",
 		"singleTitle": "Suscripción #{number}",
 		"status": {
+			"active": "activa",
 			"expired": "expirada"
 		}
 	},

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -898,8 +898,14 @@
 		},
 		"initiallyCreated": "Créé initialement : <0></0>",
 		"paidUntil": "Payé jusqu'au : <0></0>",
+		"expiresOn": "Expire le",
+		"lastOrder": "Voir dernière commande",
+		"lastPayment": "Dernier paiement",
+		"listTitle": "Vos abonnements",
+		"noSubscriptions": "Vous n'avez pas encore d'abonnements.",
 		"singleTitle": "Abonnement #{number}",
 		"status": {
+			"active": "actif",
 			"expired": "expiré"
 		}
 	},

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -898,8 +898,14 @@
 		},
 		"initiallyCreated": "Inizialmente creato: <0></0>",
 		"paidUntil": "Pagato fino al <0></0>",
+		"expiresOn": "Scade il",
+		"lastOrder": "Visualizza ultimo ordine",
+		"lastPayment": "Ultimo pagamento",
+		"listTitle": "I tuoi abbonamenti",
+		"noSubscriptions": "Non hai ancora abbonamenti.",
 		"singleTitle": "Abbonamento #{number}",
 		"status": {
+			"active": "attivo",
 			"expired": "scaduto"
 		}
 	},

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -898,8 +898,14 @@
 		},
 		"initiallyCreated": "Oorspronkelijk gemaakt: <0></0>",
 		"paidUntil": "Betaald tot: <0></0>",
+		"expiresOn": "Verloopt op",
+		"lastOrder": "Laatste bestelling bekijken",
+		"lastPayment": "Laatste betaling",
+		"listTitle": "Uw abonnementen",
+		"noSubscriptions": "U heeft nog geen abonnementen.",
 		"singleTitle": "Abonnement #{number}",
 		"status": {
+			"active": "actief",
 			"expired": "verlopen"
 		}
 	},

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -898,8 +898,14 @@
 		},
 		"initiallyCreated": "Criado inicialmente: ",
 		"paidUntil": "Pago até: ",
+		"expiresOn": "Expira em",
+		"lastOrder": "Ver última encomenda",
+		"lastPayment": "Último pagamento",
+		"listTitle": "As suas subscrições",
+		"noSubscriptions": "Ainda não tem subscrições.",
 		"singleTitle": "Subscrição #{number}",
 		"status": {
+			"active": "ativo",
 			"expired": "expirado"
 		}
 	},

--- a/src/routes/(app)/subscription/+page.server.ts
+++ b/src/routes/(app)/subscription/+page.server.ts
@@ -1,0 +1,87 @@
+import { collections } from '$lib/server/database';
+import { userIdentifier, userQuery } from '$lib/server/user';
+
+export async function load({ locals }) {
+	const userQ = userQuery(userIdentifier(locals));
+	const now = new Date();
+
+	const subscriptions = await collections.paidSubscriptions
+		.find(userQ)
+		.sort({ paidUntil: -1 })
+		.limit(100)
+		.toArray();
+
+	if (!subscriptions.length) {
+		return { subscriptions: [] };
+	}
+
+	const productIds = [...new Set(subscriptions.map((s) => s.productId))];
+
+	const [products, lastOrdersByProduct] = await Promise.all([
+		collections.products
+			.find(
+				{ _id: { $in: productIds } },
+				{
+					projection: {
+						_id: 1,
+						name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] }
+					}
+				}
+			)
+			.toArray(),
+		collections.orders
+			.aggregate<{ _id: string; lastCreatedAt: Date; lastOrderId: string }>([
+				{
+					$match: {
+						'payments.status': 'paid',
+						...userQ
+					}
+				},
+				{ $unwind: '$items' },
+				{
+					$match: {
+						'items.product._id': { $in: productIds }
+					}
+				},
+				{ $sort: { createdAt: -1 } },
+				{
+					$group: {
+						_id: '$items.product._id',
+						lastCreatedAt: { $first: '$createdAt' },
+						lastOrderId: { $first: '$_id' }
+					}
+				}
+			])
+			.toArray()
+	]);
+
+	const productNameMap = new Map(products.map((p) => [p._id, p.name]));
+	const lastOrderMap = new Map(lastOrdersByProduct.map((o) => [o._id, o]));
+
+	// Sort: active first, then by paidUntil descending
+	const sorted = subscriptions
+		.map((sub) => {
+			const isActive = sub.paidUntil > now;
+			const lastOrder = lastOrderMap.get(sub.productId);
+			return { sub, isActive, lastOrder };
+		})
+		.sort((a, b) => {
+			if (a.isActive !== b.isActive) {
+				return a.isActive ? -1 : 1;
+			}
+			return b.sub.paidUntil.getTime() - a.sub.paidUntil.getTime();
+		});
+
+	return {
+		subscriptions: sorted.map(({ sub, isActive, lastOrder }) => ({
+			_id: sub._id,
+			number: sub.number,
+			productId: sub.productId,
+			productName: productNameMap.get(sub.productId) ?? sub.productId,
+			paidUntil: sub.paidUntil,
+			isActive,
+			lastPaymentDate: lastOrder?.lastCreatedAt ?? null,
+			lastOrderId: lastOrder?.lastOrderId ?? null
+		}))
+	};
+}

--- a/src/routes/(app)/subscription/+page.svelte
+++ b/src/routes/(app)/subscription/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { useI18n } from '$lib/i18n';
+
+	const { t, locale } = useI18n();
+
+	export let data;
+</script>
+
+<main class="mx-auto max-w-7xl p-6 body-mainPlan flex flex-col gap-6">
+	<h1 class="text-3xl">{t('subscription.listTitle')}</h1>
+
+	{#if data.subscriptions.length}
+		<ul class="flex flex-col gap-4">
+			{#each data.subscriptions as sub}
+				<li class="border rounded-lg p-4 flex flex-col gap-2">
+					<div class="flex items-center justify-between flex-wrap gap-2">
+						<a href="/product/{sub.productId}" class="text-lg font-semibold underline">
+							{sub.productName}
+						</a>
+						{#if sub.isActive}
+							<span class="text-green-600 font-medium">{t('subscription.status.active')}</span>
+						{:else}
+							<span class="text-red-500 font-medium">{t('subscription.status.expired')}</span>
+						{/if}
+					</div>
+
+					<div class="flex flex-col gap-1 text-sm">
+						<p class:text-red-500={!sub.isActive} class:text-green-600={sub.isActive}>
+							{t('subscription.expiresOn')}:
+							{new Date(sub.paidUntil).toLocaleDateString($locale)}
+						</p>
+						{#if sub.lastPaymentDate}
+							<p>
+								{t('subscription.lastPayment')}:
+								{new Date(sub.lastPaymentDate).toLocaleDateString($locale)}
+							</p>
+						{/if}
+					</div>
+
+					<div class="flex gap-4 text-sm">
+						<a href="/subscription/{sub._id}" class="underline">
+							{t('subscription.singleTitle', { number: sub.number })}
+						</a>
+						{#if sub.lastOrderId}
+							<a href="/order/{sub.lastOrderId}" class="underline">
+								{t('subscription.lastOrder')}
+							</a>
+						{/if}
+					</div>
+				</li>
+			{/each}
+		</ul>
+	{:else}
+		<p class="text-gray-500">{t('subscription.noSubscriptions')}</p>
+	{/if}
+</main>


### PR DESCRIPTION
Add a /subscription list page showing all customer subscriptions sorted by status (active first) then by expiry date. Each entry displays the product name, expiry date with color-coded status, last payment date, and links to the subscription detail and last order.

Fixes #2438