### PR TITLE
🐛🤖 Fix burnt ticket date/time display and i18n on /order/id/tickets

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -922,7 +922,7 @@
 		"boughtAt": "Bought {date} at {time}",
 		"burn": "Mark ticket as used",
 		"print": "Print",
-		"scanned": "🔥 This ticket has been scanned le {date} à {time} and is not valid anymore",
+		"scanned": "🔥 This ticket has been scanned on {date} at {time} and is not valid anymore",
 		"unburn": "Mark ticket as unused"
 	},
 	"widget": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -915,7 +915,7 @@
 		"boughtAt": "Gekocht op {date} om {time}",
 		"burn": "Markeer het ticket als gebruikt",
 		"print": "Afdrukken",
-		"scanned": "🔥 Dit ticket is gescand le {date} à {time} en is niet meer geldig",
+		"scanned": "🔥 Dit ticket is gescand op {date} om {time} en is niet meer geldig",
 		"unburn": "Markeer het ticket als ongebruikt"
 	},
 	"widget": {

--- a/src/routes/(app)/order/[id]/tickets/+page.svelte
+++ b/src/routes/(app)/order/[id]/tickets/+page.svelte
@@ -46,7 +46,13 @@
 			<img src="/ticket/{ticket.ticketId}/qrcode" alt="QR code" class="h-96 w-96" />
 
 			{#if ticket.scanned}
-				<p>{t('ticket.scanned')}</p>
+				{@const scannedDate = new Date(ticket.scanned.at)}
+				<p>
+					{t('ticket.scanned', {
+						date: scannedDate.toLocaleDateString(),
+						time: scannedDate.toLocaleTimeString()
+					})}
+				</p>
 			{/if}
 		</article>
 	{/each}


### PR DESCRIPTION
Remove {date} and {time} from burnt tickets and put good values instead, and remove "le" "à" (french translation artifacts) from EN and NL languages.

Fixes #2451