### PR TITLE
🐛🤖 Add i18n for empty orders list on /orders (#2233)

### DIFF
--- a/src/lib/components/OrdersList.svelte
+++ b/src/lib/components/OrdersList.svelte
@@ -128,6 +128,6 @@
 			{/if}
 		</li>
 	{:else}
-		<li>No orders yet</li>
+		<li>{t('order.noOrdersYet')}</li>
 	{/each}
 </ul>

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -610,6 +610,7 @@
 		"shippingAddress": {
 			"title": "Lieferadresse"
 		},
+		"noOrdersYet": "Noch keine Bestellungen",
 		"singleTitle": "Bestellung #{number}",
 		"summary": {
 			"fullyPaid": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -610,6 +610,7 @@
 		"shippingAddress": {
 			"title": "Shipping address"
 		},
+		"noOrdersYet": "No orders yet",
 		"singleTitle": "Order #{number}",
 		"summary": {
 			"fullyPaid": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -610,6 +610,7 @@
 		"shippingAddress": {
 			"title": "Dirección de envío"
 		},
+		"noOrdersYet": "Aún no hay pedidos",
 		"singleTitle": "Pedido #{number}",
 		"summary": {
 			"fullyPaid": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -610,6 +610,7 @@
 		"shippingAddress": {
 			"title": "Adresse de livraison"
 		},
+		"noOrdersYet": "Aucune commande pour le moment",
 		"singleTitle": "Commande #{number}",
 		"summary": {
 			"fullyPaid": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -610,6 +610,7 @@
 		"shippingAddress": {
 			"title": "Indirizzo di spedizione"
 		},
+		"noOrdersYet": "Nessun ordine per il momento",
 		"singleTitle": "Ordine #{number}",
 		"summary": {
 			"fullyPaid": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -610,6 +610,7 @@
 		"shippingAddress": {
 			"title": "Afleveradres"
 		},
+		"noOrdersYet": "Nog geen bestellingen",
 		"singleTitle": "Volgorde #{number}",
 		"summary": {
 			"fullyPaid": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -610,6 +610,7 @@
 		"shippingAddress": {
 			"title": "Morada de envio"
 		},
+		"noOrdersYet": "Ainda não há encomendas",
 		"singleTitle": "Encomenda #{number}",
 		"summary": {
 			"fullyPaid": {


### PR DESCRIPTION
Remove "No orders yet" on /orders on every non-EN language and replace it by a proper translation key.

Fixes #2233 