### PR TITLE
🐛🤖 Fix product price preview in /pos/touch to use custom VAT rate

### DIFF
--- a/src/routes/(app)/pos/+layout.server.ts
+++ b/src/routes/(app)/pos/+layout.server.ts
@@ -7,21 +7,35 @@ async function getProductsToDisplay(params: {
 	query: Record<string, unknown>;
 	language?: string;
 }): Promise<
-	Pick<Product, '_id' | 'price' | 'name' | 'preorder' | 'availableDate' | 'tagIds' | 'stock'>[]
+	Pick<
+		Product,
+		'_id' | 'price' | 'name' | 'preorder' | 'availableDate' | 'tagIds' | 'stock' | 'vatProfileId'
+	>[]
 > {
 	return collections.products
 		.find({
 			...params.query
 		})
 		.project<
-			Pick<Product, '_id' | 'price' | 'name' | 'preorder' | 'availableDate' | 'tagIds' | 'stock'>
+			Pick<
+				Product,
+				| '_id'
+				| 'price'
+				| 'name'
+				| 'preorder'
+				| 'availableDate'
+				| 'tagIds'
+				| 'stock'
+				| 'vatProfileId'
+			>
 		>({
 			price: 1,
 			preorder: 1,
 			name: params.language ? { $ifNull: [`$translations.${params.language}.name`, '$name'] } : 1,
 			availableDate: 1,
 			tagIds: 1,
-			stock: 1
+			stock: 1,
+			vatProfileId: 1
 		})
 		.sort({ createdAt: 1 })
 		.toArray();
@@ -45,7 +59,7 @@ export const load = async ({ locals }) => {
 	return {
 		layoutReset: true,
 		pictures,
-		products,
+		products: products.map((p) => ({ ...p, vatProfileId: p.vatProfileId?.toString() })),
 		tags,
 		posUseSelectForTags: runtimeConfig.posUseSelectForTags
 	};

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -17,6 +17,7 @@
 	import { computePriceInfo } from '$lib/cart.js';
 	import { UNDERLYING_CURRENCY, type Currency } from '$lib/types/Currency.js';
 	import { applyVat, computeVatRate } from '$lib/utils/vat';
+	import { toCurrency } from '$lib/utils/toCurrency';
 	import { sluggifyTab } from '$lib/types/PosTabGroup.js';
 	import PrintTicketModal from '$lib/components/PrintTicketModal.svelte';
 	import type { PrintTicketOptions } from '$lib/types/PrintTicketOptions';
@@ -95,14 +96,6 @@
 		},
 		{} as Record<string, number>
 	);
-
-	$: catalogVatRate = computeVatRate({
-		productVatProfileId: undefined,
-		vatProfiles: data.vatProfiles,
-		bebopCountry: data.vatCountry,
-		userCountry: data.countryCode,
-		vatSingleCountry: data.vatSingleCountry
-	});
 
 	$: totalItemsCount = items.reduce((sum, item) => sum + item.quantity, 0);
 
@@ -717,8 +710,21 @@
 											{tabSlug}
 											{isMobile}
 											pictures={picturesByProduct[product._id] ?? []}
-											priceWithVat={applyVat(product.price.amount, catalogVatRate)}
-											currency={product.price.currency}
+											priceWithVat={applyVat(
+												toCurrency(
+													data.currencies.main,
+													product.price.amount,
+													product.price.currency
+												),
+												computeVatRate({
+													productVatProfileId: product.vatProfileId,
+													vatProfiles: data.vatProfiles,
+													bebopCountry: data.vatCountry,
+													userCountry: data.countryCode,
+													vatSingleCountry: data.vatSingleCountry
+												})
+											)}
+											currency={data.currencies.main}
 											quantityInCart={quantityByProductId[product._id] ?? 0}
 										/>
 									{/if}


### PR DESCRIPTION
- Fixed product price preview on /pos/touch tiles always using the default VAT rate instead of the product's custom VAT rate
- Tile prices now correctly reflect each product's assigned VAT profile, matching the actual order total
- Only the preview was affected — pool order totals were already correct

Fixes #2454 