### PR TITLE
🐛 Fix inability to deactivate POS session checkbox settings

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.server.ts
@@ -132,15 +132,15 @@ export const actions: Actions = {
 						enabled: z.boolean({ coerce: true }).default(false),
 						allowXTicketEditing: z.boolean({ coerce: true }).default(false),
 						cashDeltaJustificationMandatory: z.boolean({ coerce: true }).default(false),
-						lockItemsAfterMidTicket: z.boolean({ coerce: true }).default(true),
-						forbidTouchWhenSessionClosed: z.boolean({ coerce: true }).default(true)
+						lockItemsAfterMidTicket: z.boolean({ coerce: true }).default(false),
+						forbidTouchWhenSessionClosed: z.boolean({ coerce: true }).default(false)
 					})
 					.default({
 						enabled: false,
 						allowXTicketEditing: false,
 						cashDeltaJustificationMandatory: false,
-						lockItemsAfterMidTicket: true,
-						forbidTouchWhenSessionClosed: true
+						lockItemsAfterMidTicket: false,
+						forbidTouchWhenSessionClosed: false
 					})
 			})
 			.parse({

--- a/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/pos/+page.svelte
@@ -220,7 +220,7 @@
 			type="checkbox"
 			name="posSession.lockItemsAfterMidTicket"
 			class="form-checkbox"
-			checked={data.posSession.lockItemsAfterMidTicket}
+			bind:checked={posSession.lockItemsAfterMidTicket}
 		/>
 		Forbid item deletion / qty reduction, after mid-ticket print
 	</label>


### PR DESCRIPTION
Unchecking "Forbid item deletion / qty reduction after mid-ticket print" or "Forbid use of /pos/touch when PoS Session is not opened" had no effect — values stayed `true` in the database. Fixed for both cases. 

Closes #2382