### PR TITLE
🐛🤖 Fix schedule event status staying pending for non-subscription bookings

### DIFF
--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -2440,12 +2440,15 @@ export async function updateAfterOrderPaid(order: Order, session: ClientSession)
 		await handleOrderTabAfterPayment({ order, session });
 	}
 
-	if (order.items.some((item) => item.product.type === 'subscription')) {
+	if (order.items.some((item) => item.booking)) {
 		await collections.scheduleEvents.updateMany(
 			{ orderId: order._id },
 			{ $set: { status: 'confirmed' } },
 			{ session }
 		);
+	}
+
+	if (order.items.some((item) => item.product.type === 'subscription')) {
 		await applyOrderSubscriptionsDiscounts(order, session);
 	}
 


### PR DESCRIPTION
Move scheduleEvents status update to 'confirmed' outside the subscription check so it runs for all paid orders, not just subscription products.

Transparent for end-user but required for #2463 

Fixes #2462