### PR TITLE
🐛🤖 Remove receiptReady gating on invoice download buttons

### DIFF
--- a/src/lib/components/Order/PaymentActions.svelte
+++ b/src/lib/components/Order/PaymentActions.svelte
@@ -20,8 +20,6 @@
 	export let tapToPayInUseByOtherOrder = false;
 	export let printReceipt: () => void;
 	export let printTicket: () => void;
-	export let receiptReady = false;
-	export let ticketReady = false;
 
 	let openPaymentMethodChange = false;
 	let openCashbackSection = false;
@@ -54,50 +52,25 @@
 <!-- Receipt buttons -->
 <div class="receipt-buttons flex flex-col gap-1">
 	{#if showProforma && roleIsStaff}
-		<button
-			class="body-hyperlink self-start"
-			type="button"
-			disabled={!receiptReady}
-			on:click={printReceipt}
-		>
+		<button class="body-hyperlink self-start" type="button" on:click={printReceipt}>
 			{posMode ? t('pos.receipt.invoice') : 'Print receipt (A4)'}
 		</button>
-		<button
-			class="body-hyperlink self-start"
-			type="button"
-			disabled={!ticketReady}
-			on:click={printTicket}
-		>
+		<button class="body-hyperlink self-start" type="button" on:click={printTicket}>
 			{posMode ? t('pos.receipt.ticket') : 'Print receipt (ticket)'}
 		</button>
 	{/if}
 
 	{#if showProforma && !roleIsStaff}
-		<button
-			class="body-hyperlink self-start"
-			type="button"
-			disabled={!receiptReady}
-			on:click={printReceipt}
-		>
+		<button class="body-hyperlink self-start" type="button" on:click={printReceipt}>
 			{t('order.receipt.createProforma')}
 		</button>
 	{/if}
 
 	{#if showInvoice && roleIsStaff}
-		<button
-			class="btn btn-black self-start"
-			type="button"
-			disabled={!receiptReady}
-			on:click={printReceipt}
-		>
+		<button class="btn btn-black self-start" type="button" on:click={printReceipt}>
 			{posMode ? t('pos.receipt.invoice') : 'Print receipt (A4)'}
 		</button>
-		<button
-			class="btn btn-black self-start"
-			type="button"
-			disabled={!ticketReady}
-			on:click={printTicket}
-		>
+		<button class="btn btn-black self-start" type="button" on:click={printTicket}>
 			{posMode ? t('pos.receipt.ticket') : 'Print receipt (ticket)'}
 		</button>
 	{/if}
@@ -110,12 +83,7 @@
 	{/if}
 
 	{#if showInvoice && !roleIsStaff}
-		<button
-			class="btn btn-black self-start"
-			type="button"
-			disabled={!receiptReady}
-			on:click={printReceipt}
-		>
+		<button class="btn btn-black self-start" type="button" on:click={printReceipt}>
 			{t('order.receipt.create')}
 		</button>
 	{/if}

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -230,8 +230,6 @@
 							tapToPayInUseByOtherOrder={data.tapToPay.inUseByOtherOrder}
 							printReceipt={() => receiptIFrame[payment.id]?.contentWindow?.print()}
 							printTicket={() => ticketIFrame[payment.id]?.contentWindow?.print()}
-							receiptReady={receiptReady[payment.id]}
-							ticketReady={ticketReady[payment.id]}
 						/>
 					</PaymentItem>
 


### PR DESCRIPTION
Accessing to an order from a link, after payment, doesn't allow to download receipt (button is displayed but disable).

Now, if payment exists, button will be always available.

Fixes #2461