### PR TITLE
🧪🤖 Embed Stripe payment form in order page (optional setting)

### DIFF
--- a/src/lib/components/Order/CardPayment.svelte
+++ b/src/lib/components/Order/CardPayment.svelte
@@ -1,6 +1,37 @@
+<script context="module" lang="ts">
+	declare global {
+		interface Window {
+			Stripe(publicKey: string): {
+				elements: (options: {
+					locale?: string;
+					appearance: {
+						theme: 'stripe' | 'night' | 'flat';
+						variables?: Record<string, string>;
+					};
+					clientSecret: string;
+				}) => {
+					create: (
+						type: 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'payment',
+						options: {
+							layout: { type: 'accordion' | 'tabs' } | 'accordion' | 'tabs';
+						}
+					) => {
+						mount: (element: string | HTMLElement) => void;
+					};
+				};
+				confirmPayment: (options: {
+					elements: unknown;
+					confirmParams: { return_url: string };
+				}) => Promise<{ error: { type: string; message: string } }>;
+			};
+		}
+	}
+</script>
+
 <script lang="ts">
 	import type { SerializedOrderPayment } from '$lib/types/Order';
 	import { useI18n } from '$lib/i18n';
+	import { onMount } from 'svelte';
 	import IconSumupWide from '$lib/components/icons/IconSumupWide.svelte';
 	import IconStripe from '$lib/components/icons/IconStripe.svelte';
 
@@ -9,27 +40,103 @@
 	export let payment: SerializedOrderPayment;
 	export let orderId: string;
 	export let returnTo: string | undefined = undefined;
+	export let stripePublicKey: string | null = null;
 
 	$: payUrl = returnTo
 		? `/order/${orderId}/payment/${payment.id}/pay?returnTo=${encodeURIComponent(returnTo)}`
 		: `/order/${orderId}/payment/${payment.id}/pay`;
+
+	$: orderPath = returnTo
+		? `/order/${orderId}?returnTo=${encodeURIComponent(returnTo)}`
+		: `/order/${orderId}`;
+
+	$: embedStripe = !!stripePublicKey && payment.processor === 'stripe';
+
+	let paymentLoading = false;
+	let stripeLoading = true;
+	let handleSubmit = () => {};
+
+	function mountStripeCard() {
+		stripeLoading = true;
+		if (payment.clientSecret && stripePublicKey) {
+			const stripe = window.Stripe(stripePublicKey);
+			const elements = stripe.elements({
+				appearance: { theme: 'stripe' },
+				clientSecret: payment.clientSecret
+			});
+			elements.create('payment', { layout: 'tabs' }).mount(`#stripe-embedded-${payment.id}`);
+			setTimeout(() => {
+				stripeLoading = false;
+			}, 3000);
+
+			handleSubmit = async () => {
+				try {
+					paymentLoading = true;
+					const { error } = await stripe.confirmPayment({
+						elements,
+						confirmParams: {
+							return_url: window.location.origin + orderPath
+						}
+					});
+					if (error.type === 'card_error' || error.type === 'validation_error') {
+						alert(error.message);
+					} else {
+						alert('An unexpected error occurred.');
+					}
+				} finally {
+					paymentLoading = false;
+				}
+			};
+		}
+	}
+
+	onMount(() => {
+		if (!embedStripe) {
+			return;
+		}
+		if ('Stripe' in window) {
+			mountStripeCard();
+		} else {
+			document.head.append(
+				Object.assign(document.createElement('script'), {
+					src: 'https://js.stripe.com/v3/',
+					async: false,
+					defer: false,
+					onload: () => mountStripeCard()
+				})
+			);
+		}
+	});
 </script>
 
 {#if payment.status === 'pending'}
-	<a href={payUrl} class="body-hyperlink">
-		<span>{t('order.paymentLink')}</span>
-		{#if payment.processor === 'sumup'}
-			<IconSumupWide class="h-12 order-creditCard-svg" />
-		{:else if payment.processor === 'stripe'}
-			<IconStripe class="h-12 order-creditCard-svg" />
-		{:else if payment.processor === 'paypal'}
-			<img
-				src="https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-200px.png"
-				alt="PayPal"
-				class="h-12"
-			/>
-		{:else if payment.processor}
-			<span class="text-sm text-gray-500">{payment.processor}</span>
-		{/if}
-	</a>
+	{#if embedStripe}
+		<form class="payment-form flex flex-col gap-4" on:submit|preventDefault={handleSubmit}>
+			<div id="stripe-embedded-{payment.id}" class="stripe"></div>
+			<button
+				class="btn btn-black self-start"
+				type="submit"
+				disabled={stripeLoading || paymentLoading}
+			>
+				{t('checkout.cta.submit')}
+			</button>
+		</form>
+	{:else}
+		<a href={payUrl} class="body-hyperlink">
+			<span>{t('order.paymentLink')}</span>
+			{#if payment.processor === 'sumup'}
+				<IconSumupWide class="h-12 order-creditCard-svg" />
+			{:else if payment.processor === 'stripe'}
+				<IconStripe class="h-12 order-creditCard-svg" />
+			{:else if payment.processor === 'paypal'}
+				<img
+					src="https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-200px.png"
+					alt="PayPal"
+					class="h-12"
+				/>
+			{:else if payment.processor}
+				<span class="text-sm text-gray-500">{payment.processor}</span>
+			{/if}
+		</a>
+	{/if}
 {/if}

--- a/src/lib/components/Order/PaymentItem.svelte
+++ b/src/lib/components/Order/PaymentItem.svelte
@@ -21,6 +21,7 @@
 	export let sellerIdentity: SellerIdentity | null | undefined = undefined;
 	export let posSubtypes: Array<{ slug: string; name: string }> | undefined = undefined;
 	export let returnTo: string | undefined = undefined;
+	export let stripePublicKey: string | null = null;
 
 	// Registry of dynamic components
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -69,6 +70,7 @@
 				{sellerIdentity}
 				{posMode}
 				{returnTo}
+				{stripePublicKey}
 			/>
 		{:else if payment.method === 'point-of-sale'}
 			<PointOfSalePayment />

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -209,7 +209,8 @@ const baseConfig = {
 		publicKey: '',
 		/** sk_... */
 		secretKey: '',
-		currency: 'EUR' as Currency
+		currency: 'EUR' as Currency,
+		embedPaymentForm: false
 	},
 	btcpayServer: {
 		apiKey: '',

--- a/src/routes/(app)/admin[[hash=admin_hash]]/stripe/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/stripe/+page.server.ts
@@ -17,7 +17,8 @@ export const actions = {
 				secretKey: z.string().startsWith('sk_'),
 				currency: z.enum(
 					CURRENCIES.filter((c) => c !== 'BTC' && c !== 'SAT') as [Currency, ...Currency[]]
-				)
+				),
+				embedPaymentForm: z.boolean({ coerce: true }).default(false)
 			})
 			.parse(Object.fromEntries(await request.formData()));
 
@@ -46,7 +47,8 @@ export const actions = {
 		runtimeConfig.stripe = {
 			secretKey: '',
 			publicKey: '',
-			currency: 'EUR'
+			currency: 'EUR',
+			embedPaymentForm: false
 		};
 	}
 };

--- a/src/routes/(app)/admin[[hash=admin_hash]]/stripe/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/stripe/+page.svelte
@@ -40,6 +40,16 @@
 		</select>
 	</label>
 
+	<label class="checkbox-label">
+		<input
+			class="form-checkbox"
+			type="checkbox"
+			name="embedPaymentForm"
+			bind:checked={data.stripe.embedPaymentForm}
+		/>
+		Include payment form in order page
+	</label>
+
 	<div class="flex justify-between">
 		<button class="btn btn-black" type="submit">Save</button>
 		<button class="btn btn-red" type="submit" form="delete-form">Reset</button>

--- a/src/routes/(app)/order/[id]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/+page.server.ts
@@ -9,6 +9,7 @@ import { conflictingTapToPayOrder } from '$lib/server/orders';
 import { CUSTOMER_ROLE_ID } from '$lib/types/User.js';
 import { runtimeConfig } from '$lib/server/runtime-config.js';
 import { paymentMethods } from '$lib/server/payment-methods.js';
+import { isStripeEnabled } from '$lib/server/stripe.js';
 import type { OrderLabel } from '$lib/types/OrderLabel.js';
 
 export async function load({ params, depends, locals, url }) {
@@ -138,7 +139,11 @@ export async function load({ params, depends, locals, url }) {
 		overwriteCreditCardSvgColor: runtimeConfig.overwriteCreditCardSvgColor,
 		hideCreditCardQrCode: runtimeConfig.hideCreditCardQrCode,
 		labels,
-		returnTo: returnTo ?? undefined
+		returnTo: returnTo ?? undefined,
+		stripePublicKey:
+			isStripeEnabled() && runtimeConfig.stripe.embedPaymentForm
+				? runtimeConfig.stripe.publicKey
+				: null
 	};
 }
 

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -217,6 +217,7 @@
 						sellerIdentity={data.sellerIdentity}
 						posSubtypes={data.posSubtypes}
 						returnTo={data.returnTo}
+						stripePublicKey={data.stripePublicKey}
 					>
 						<PaymentActions
 							{payment}


### PR DESCRIPTION
Add "Include payment form in order page" checkbox on /admin/stripe. When enabled, the Stripe payment form is rendered inline on /order/[id] instead of linking to a separate /pay page.

Refs #1867