### PR TITLE
🐛 Fix false positive S3 connection test

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/s3/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/s3/+page.server.ts
@@ -51,16 +51,20 @@ async function parseForm(request: Request) {
 
 async function simpleListTest(s3: typeof runtimeConfig.s3) {
 	try {
-		const { S3Client, ListBucketsCommand } = await import('@aws-sdk/client-s3');
+		const { S3Client, ListBucketsCommand, HeadBucketCommand } = await import('@aws-sdk/client-s3');
 		const client = new S3Client({
 			region: s3.region || 'us-east-1' /* “Harmless” region for providers who don't care */,
 			endpoint: s3.endpointUrl,
 			credentials: {
 				accessKeyId: s3.keyId,
 				secretAccessKey: s3.keySecret
-			}
+			},
+			forcePathStyle: true
 		});
 		await client.send(new ListBucketsCommand({}));
+		if (s3.bucket) {
+			await client.send(new HeadBucketCommand({ Bucket: s3.bucket }));
+		}
 		return { testResult: { success: true, message: 'S3 connection successful!' } };
 	} catch (error) {
 		return {


### PR DESCRIPTION
S3 connection test now correctly reports failures instead of showing "S3 connection successful!" when the connection doesn't actually work.

Closes #2472