### PR TITLE
🐛 Fix S3 operations failing when configured via admin panel

### DIFF
--- a/src/lib/server/locks/cleanup-lock.ts
+++ b/src/lib/server/locks/cleanup-lock.ts
@@ -4,7 +4,7 @@ import { collections } from '../database';
 import { processClosed } from '../process';
 import { setTimeout } from 'node:timers/promises';
 import { getS3Client } from '../s3';
-import { S3_BUCKET } from '$lib/server/env-config';
+import { runtimeConfig } from '$lib/server/runtime-config';
 import { ObjectId } from 'mongodb';
 
 const lock = new Lock('cleanup');
@@ -29,7 +29,7 @@ async function cleanup() {
 			for (const file of expiredFiles) {
 				await getS3Client()
 					.deleteObject({
-						Bucket: S3_BUCKET,
+						Bucket: runtimeConfig.s3.bucket,
 						Key: file.storage.key
 					})
 					.catch();
@@ -55,7 +55,7 @@ async function cleanup() {
 			for (const picture of expiredPictures) {
 				await getS3Client()
 					.deleteObject({
-						Bucket: S3_BUCKET,
+						Bucket: runtimeConfig.s3.bucket,
 						Key: picture.storage.original.key
 					})
 					.catch();
@@ -63,7 +63,7 @@ async function cleanup() {
 				for (const format of picture.storage.formats) {
 					await getS3Client()
 						.deleteObject({
-							Bucket: S3_BUCKET,
+							Bucket: runtimeConfig.s3.bucket,
 							Key: format.key
 						})
 						.catch();

--- a/src/lib/server/picture.ts
+++ b/src/lib/server/picture.ts
@@ -10,7 +10,7 @@ import {
 	getS3Client
 } from './s3';
 import { PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { S3_BUCKET } from '$lib/server/env-config';
+import { runtimeConfig } from '$lib/server/runtime-config';
 import * as mimeTypes from 'mime-types';
 import type { ImageData, Picture, TagType } from '../types/Picture';
 import type { SetRequired } from 'type-fest';
@@ -58,7 +58,7 @@ export async function generatePicture(
 	await getS3Client()
 		.deleteObject({
 			Key: pendingPicture.storage.original.key,
-			Bucket: S3_BUCKET
+			Bucket: runtimeConfig.s3.bucket
 		})
 		.catch();
 
@@ -106,7 +106,7 @@ export async function generatePicture(
 
 	await getS3Client().send(
 		new PutObjectCommand({
-			Bucket: S3_BUCKET,
+			Bucket: runtimeConfig.s3.bucket,
 			Key: path,
 			Body: buffer,
 			ContentType: mime
@@ -129,7 +129,7 @@ export async function generatePicture(
 			const buffer = await image.toFormat('webp').toBuffer();
 			await getS3Client().send(
 				new PutObjectCommand({
-					Bucket: S3_BUCKET,
+					Bucket: runtimeConfig.s3.bucket,
 					Key: key,
 					Body: buffer,
 					ContentType: 'image/webp'
@@ -163,7 +163,7 @@ export async function generatePicture(
 				const key = `${pathPrefix}${_id}-${newWidth}x${newHeight}.webp`;
 				await getS3Client().send(
 					new PutObjectCommand({
-						Bucket: S3_BUCKET,
+						Bucket: runtimeConfig.s3.bucket,
 						Key: key,
 						Body: buffer,
 						ContentType: 'image/webp'
@@ -216,7 +216,7 @@ export async function generatePicture(
 		// Remove uploaded files
 		for (const key of uploadedKeys) {
 			getS3Client()
-				.send(new DeleteObjectCommand({ Bucket: S3_BUCKET, Key: key }))
+				.send(new DeleteObjectCommand({ Bucket: runtimeConfig.s3.bucket, Key: key }))
 				.catch();
 		}
 		throw err;
@@ -232,12 +232,17 @@ export async function deletePicture(pictureId: Picture['_id']) {
 
 	for (const format of res.value.storage.formats) {
 		await getS3Client()
-			.send(new DeleteObjectCommand({ Bucket: S3_BUCKET, Key: format.key }))
+			.send(new DeleteObjectCommand({ Bucket: runtimeConfig.s3.bucket, Key: format.key }))
 			.catch(console.error);
 	}
 
 	await getS3Client()
-		.send(new DeleteObjectCommand({ Bucket: S3_BUCKET, Key: res.value.storage.original.key }))
+		.send(
+			new DeleteObjectCommand({
+				Bucket: runtimeConfig.s3.bucket,
+				Key: res.value.storage.original.key
+			})
+		)
 		.catch(console.error);
 }
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/backup/import/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/backup/import/+page.server.ts
@@ -1,8 +1,9 @@
 import { fail } from '@sveltejs/kit';
 import * as devalue from 'devalue';
 import type { Challenge } from '$lib/types/Challenge.js';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import { S3_REGION, S3_KEY_ID, S3_KEY_SECRET, S3_BUCKET, SMTP_USER } from '$lib/server/env-config';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { SMTP_USER } from '$lib/server/env-config';
+import { getS3Client } from '$lib/server/s3';
 import type { Picture } from '$lib/types/Picture';
 import type { DigitalFile } from '$lib/types/DigitalFile';
 import { sendEmail } from '$lib/server/email.js';
@@ -188,14 +189,6 @@ async function handleDigitalFileImport(
 }
 
 async function uploadFileToS3(imageUrl: URL | RequestInfo | undefined, s3Key: string) {
-	const s3Client = new S3Client({
-		region: S3_REGION,
-		credentials: {
-			accessKeyId: S3_KEY_ID,
-			secretAccessKey: S3_KEY_SECRET
-		}
-	});
-
 	try {
 		const response = await fetch(imageUrl ? imageUrl : '');
 		const contentType = response.headers.get('content-type') || undefined;
@@ -209,13 +202,13 @@ async function uploadFileToS3(imageUrl: URL | RequestInfo | undefined, s3Key: st
 		const uint8ArrayBuffer = new Uint8Array(arrayBuffer);
 
 		const params = {
-			Bucket: S3_BUCKET,
+			Bucket: runtimeConfig.s3.bucket,
 			Key: s3Key,
 			Body: uint8ArrayBuffer,
 			ContentType: contentType
 		};
 
-		await s3Client.send(new PutObjectCommand(params));
+		await getS3Client().send(new PutObjectCommand(params));
 
 		return true;
 	} catch (error) {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/digital-file/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/digital-file/[id]/+page.server.ts
@@ -1,4 +1,4 @@
-import { S3_BUCKET } from '$lib/server/env-config';
+import { runtimeConfig } from '$lib/server/runtime-config';
 import { adminPrefix } from '$lib/server/admin.js';
 import { collections } from '$lib/server/database';
 import { getPublicS3DownloadLink, getS3Client } from '$lib/server/s3';
@@ -33,7 +33,9 @@ export const actions = {
 		await collections.digitalFiles.deleteOne({ _id: params.id });
 
 		await getS3Client()
-			.send(new DeleteObjectCommand({ Bucket: S3_BUCKET, Key: digitalFile.storage.key }))
+			.send(
+				new DeleteObjectCommand({ Bucket: runtimeConfig.s3.bucket, Key: digitalFile.storage.key })
+			)
 			.catch(console.error);
 		if (digitalFile.productId) {
 			throw redirect(303, `${adminPrefix()}/product/${digitalFile.productId}`);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/digital-file/finalize/+server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/digital-file/finalize/+server.ts
@@ -1,4 +1,4 @@
-import { S3_BUCKET } from '$lib/server/env-config';
+import { runtimeConfig } from '$lib/server/runtime-config';
 import { collections, withTransaction } from '$lib/server/database';
 import { getS3Client } from '$lib/server/s3';
 import { error } from '@sveltejs/kit';
@@ -20,7 +20,7 @@ export async function POST({ request }) {
 	}
 
 	const info = await getS3Client().headObject({
-		Bucket: S3_BUCKET,
+		Bucket: runtimeConfig.s3.bucket,
 		Key: pendingFile.storage.key
 	});
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/digital-file/prepare/+server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/digital-file/prepare/+server.ts
@@ -1,4 +1,4 @@
-import { S3_BUCKET } from '$lib/server/env-config';
+import { runtimeConfig } from '$lib/server/runtime-config';
 import { collections } from '$lib/server/database';
 import { getPublicS3Client, secureLink } from '$lib/server/s3';
 import { generateId } from '$lib/utils/generateId';
@@ -43,7 +43,7 @@ export async function POST({ request }) {
 		await getSignedUrl(
 			getPublicS3Client(),
 			new PutObjectCommand({
-				Bucket: S3_BUCKET,
+				Bucket: runtimeConfig.s3.bucket,
 				Key: key,
 				...(contentType ? { ContentType: contentType } : {}),
 				ContentLength: body.fileSize

--- a/src/routes/(app)/admin[[hash=admin_hash]]/picture/prepare/+server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/picture/prepare/+server.ts
@@ -1,4 +1,4 @@
-import { S3_BUCKET } from '$lib/server/env-config';
+import { runtimeConfig } from '$lib/server/runtime-config';
 import { collections } from '$lib/server/database';
 import { getPublicS3Client, secureLink } from '$lib/server/s3';
 import { generateId } from '$lib/utils/generateId';
@@ -26,7 +26,7 @@ export async function POST({ request }) {
 		await getSignedUrl(
 			getPublicS3Client(),
 			new PutObjectCommand({
-				Bucket: S3_BUCKET,
+				Bucket: runtimeConfig.s3.bucket,
 				Key: key,
 				...(contentType ? { ContentType: contentType } : {}),
 				ContentLength: body.fileSize

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -9,7 +9,7 @@ import type { Actions } from './$types';
 import { error, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import { ObjectId } from 'mongodb';
-import { ORIGIN, S3_BUCKET } from '$lib/server/env-config';
+import { ORIGIN } from '$lib/server/env-config';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import type { Product } from '$lib/types/Product';
 import { Kind } from 'nostr-tools';
@@ -493,8 +493,8 @@ export const actions: Actions = {
 				insertedS3Keys.push(pictureToInsert.storage.original.key);
 				await getS3Client().send(
 					new CopyObjectCommand({
-						Bucket: S3_BUCKET,
-						CopySource: `/${S3_BUCKET}/${picture.storage.original.key}`,
+						Bucket: runtimeConfig.s3.bucket,
+						CopySource: `/${runtimeConfig.s3.bucket}/${picture.storage.original.key}`,
 						Key: pictureToInsert.storage.original.key
 					})
 				);
@@ -504,8 +504,8 @@ export const actions: Actions = {
 					insertedS3Keys.push(format.key);
 					await getS3Client().send(
 						new CopyObjectCommand({
-							Bucket: S3_BUCKET,
-							CopySource: `/${S3_BUCKET}/${format.key}`,
+							Bucket: runtimeConfig.s3.bucket,
+							CopySource: `/${runtimeConfig.s3.bucket}/${format.key}`,
 							Key: pictureToInsert.storage.formats[formatIndex++].key
 						})
 					);
@@ -530,8 +530,8 @@ export const actions: Actions = {
 				insertedS3Keys.push(digitalFileToInsert.storage.key);
 				await getS3Client().send(
 					new CopyObjectCommand({
-						Bucket: S3_BUCKET,
-						CopySource: `/${S3_BUCKET}/${file.storage.key}`,
+						Bucket: runtimeConfig.s3.bucket,
+						CopySource: `/${runtimeConfig.s3.bucket}/${file.storage.key}`,
 						Key: digitalFileToInsert.storage.key
 					})
 				);
@@ -542,7 +542,7 @@ export const actions: Actions = {
 			getS3Client()
 				.send(
 					new DeleteObjectsCommand({
-						Bucket: S3_BUCKET,
+						Bucket: runtimeConfig.s3.bucket,
 						Delete: {
 							Objects: insertedS3Keys.map((key) => ({ Key: key }))
 						}


### PR DESCRIPTION
S3 storage configured through the admin panel (`/admin/s3`) was not working for file uploads, digital files, backup imports, and product duplication — all failed with 500 error. Only environment variable configuration worked.

Now both configuration methods work correctly. Backup import also switched to the shared S3 client for consistent behavior across all S3 operations.

Closes #2483