### PR TITLE
🦋 Customer data cleaning for GDPR/law compliance

### DIFF
--- a/src/lib/server/locks/cleanup-lock.ts
+++ b/src/lib/server/locks/cleanup-lock.ts
@@ -6,6 +6,7 @@ import { setTimeout } from 'node:timers/promises';
 import { getS3Client } from '../s3';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { ObjectId } from 'mongodb';
+import { anonymizeOrderData } from '../orders';
 
 const lock = new Lock('cleanup');
 
@@ -109,6 +110,47 @@ async function cleanup() {
 			}
 		} catch (err) {
 			console.error('Error during cleanup schedules', err);
+		}
+
+		try {
+			const { dataCleanup } = runtimeConfig;
+			if (dataCleanup.scheduled.enabled && dataCleanup.scheduled.delaySeconds > 0) {
+				const cutoffDate = new Date(Date.now() - dataCleanup.scheduled.delaySeconds * 1000);
+
+				const { orderStatuses } = dataCleanup.scheduled;
+
+				if (orderStatuses.length) {
+					const ordersToClean = await collections.orders
+						.find({
+							status: { $in: orderStatuses },
+							dataAnonymized: { $ne: true },
+							createdAt: { $lt: cutoffDate }
+						})
+						.project({ _id: 1 })
+						.limit(50)
+						.toArray();
+
+					for (const order of ordersToClean) {
+						await anonymizeOrderData(order._id);
+					}
+
+					if (ordersToClean.length) {
+						console.log(`Data cleanup: anonymized ${ordersToClean.length} orders`);
+					}
+				}
+
+				const deleteResult = await collections.personalInfo.deleteMany({
+					$or: [
+						{ updatedAt: { $lt: cutoffDate } },
+						{ updatedAt: { $exists: false }, createdAt: { $lt: cutoffDate } }
+					]
+				});
+				if (deleteResult.deletedCount) {
+					console.log(`Data cleanup: deleted ${deleteResult.deletedCount} personalInfo records`);
+				}
+			}
+		} catch (err) {
+			console.error('Error during data cleanup:', err);
 		}
 
 		await setTimeout(5_000);

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -466,6 +466,17 @@ export async function onOrderPaymentFailed(
 			}
 		);
 	}
+	if (
+		runtimeConfig.dataCleanup.onOrderExpireOrCancel &&
+		order.status !== ret.value.status &&
+		(ret.value.status === 'canceled' || ret.value.status === 'expired')
+	) {
+		try {
+			await anonymizeOrderData(order._id);
+		} catch (err) {
+			console.error('Failed to anonymize order data:', order._id, err);
+		}
+	}
 	order = ret.value;
 
 	return order;
@@ -493,6 +504,54 @@ export async function cancelPayment(
 
 	await onOrderPaymentFailed(order, payment, 'canceled');
 	throw redirect(303, redirectUrl);
+}
+
+export async function anonymizeOrderData(orderId: string): Promise<boolean> {
+	const order = await collections.orders.findOne(
+		{ _id: orderId, dataAnonymized: { $ne: true } },
+		{ projection: { shippingAddress: 1, billingAddress: 1 } }
+	);
+	if (!order) {
+		return false;
+	}
+
+	const $set: Record<string, unknown> = {
+		dataAnonymized: true,
+		updatedAt: new Date()
+	};
+	if (order.shippingAddress) {
+		$set.shippingAddress = {
+			country: order.shippingAddress.country,
+			zip: order.shippingAddress.zip
+		};
+	}
+	if (order.billingAddress) {
+		$set.billingAddress = { country: order.billingAddress.country, zip: order.billingAddress.zip };
+	}
+
+	const result = await collections.orders.updateOne(
+		{ _id: orderId, dataAnonymized: { $ne: true } },
+		{
+			$set,
+			$unset: {
+				clientIp: 1,
+				notes: 1,
+				'user.userId': 1,
+				'user.email': 1,
+				'user.npub': 1,
+				'user.secondaryEmails': 1,
+				'user.ssoIds': 1,
+				'user.sessionId': 1,
+				'user.userLogin': 1,
+				'user.userAlias': 1,
+				'user.userRoleId': 1,
+				'user.userHasPosOptions': 1,
+				'notifications.paymentStatus.npub': 1,
+				'notifications.paymentStatus.email': 1
+			}
+		}
+	);
+	return result.modifiedCount > 0;
 }
 
 export async function lastInvoiceNumber(): Promise<number | undefined> {

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -44,6 +44,7 @@ import {
 } from '$lib/translations';
 import { typedInclude } from '$lib/utils/typedIncludes';
 import type { CountryAlpha2 } from '$lib/types/Country';
+import type { OrderPaymentStatus } from '$lib/types/Order';
 import type { PaymentMethod, PaymentProcessor } from './payment-methods';
 import { merge } from '$lib/utils/merge';
 import { typedEntries } from '$lib/utils/typedEntries';
@@ -268,6 +269,15 @@ const baseConfig = {
 	displayCompanyInfo: false,
 	displayMainShopInfo: false,
 	disableNostrBotIntro: false,
+	dataCleanup: {
+		onOrderExpireOrCancel: false,
+		allowUserManualCleanup: false,
+		scheduled: {
+			enabled: false,
+			delaySeconds: 0,
+			orderStatuses: [] as OrderPaymentStatus[]
+		}
+	},
 	hideFromSearchEngines: false,
 	telemetry: null as null | {
 		enabled: boolean;

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -557,6 +557,9 @@
 			"pending": "ausstehend"
 		},
 		"paymentStatusNpub": "Öffentlicher Nostr-Schlüssel für den Zahlungsstatus",
+		"cleanPersonalData": "Meine persönlichen Daten löschen",
+		"cleanPersonalDataConfirm": "WARNUNG: Dadurch werden Ihre persönlichen Daten aus dieser Bestellung unwiderruflich entfernt, einschließlich Liefer- und Rechnungsadressen.\n\nTun Sie dies erst, NACHDEM Ihre Bestellung geliefert wurde und Sie Ihre Artikel erhalten haben.\n\nDiese Aktion kann nicht rückgängig gemacht werden. Fortfahren?",
+		"cleanPersonalDataSuccess": "Ihre persönlichen Daten wurden erfolgreich aus dieser Bestellung entfernt.",
 		"receipt": {
 			"accountHolder": "Kontoinhaber",
 			"accountHolderAddress": "Adresse",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -557,6 +557,9 @@
 			"pending": "pending"
 		},
 		"paymentStatusNpub": "Nostr public key for payment status",
+		"cleanPersonalData": "Clean my personal data",
+		"cleanPersonalDataConfirm": "WARNING: This will permanently remove your personal data from this order, including shipping and billing addresses.\n\nOnly do this AFTER your order has been delivered and you have received your items.\n\nThis action cannot be undone. Continue?",
+		"cleanPersonalDataSuccess": "Your personal data has been successfully removed from this order.",
 		"receipt": {
 			"accountHolder": "Account holder",
 			"accountHolderAddress": "Address",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -557,6 +557,9 @@
 			"pending": "pendiente"
 		},
 		"paymentStatusNpub": "Clave pública de Nostr para el estado del pago",
+		"cleanPersonalData": "Eliminar mis datos personales",
+		"cleanPersonalDataConfirm": "ADVERTENCIA: Esta acción eliminará permanentemente sus datos personales de este pedido, incluyendo las direcciones de envío y facturación.\n\nHaga esto solo DESPUÉS de que su pedido haya sido entregado y haya recibido sus artículos.\n\nEsta acción no se puede deshacer. ¿Continuar?",
+		"cleanPersonalDataSuccess": "Sus datos personales han sido eliminados de este pedido exitosamente.",
 		"receipt": {
 			"accountHolder": "Titular de la cuenta",
 			"accountHolderAddress": "Dirección",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -557,6 +557,9 @@
 			"pending": "en attente"
 		},
 		"paymentStatusNpub": "Clé publique Nostr pour le statut de paiement",
+		"cleanPersonalData": "Supprimer mes données personnelles",
+		"cleanPersonalDataConfirm": "ATTENTION : Cette action supprimera définitivement vos données personnelles de cette commande, y compris les adresses de livraison et de facturation.\n\nNe faites cela qu'APRÈS la livraison de votre commande et la réception de vos articles.\n\nCette action est irréversible. Continuer ?",
+		"cleanPersonalDataSuccess": "Vos données personnelles ont été supprimées de cette commande avec succès.",
 		"receipt": {
 			"accountHolder": "Titulaire",
 			"accountHolderAddress": "Adresse",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -557,6 +557,9 @@
 			"pending": "In sospeso"
 		},
 		"paymentStatusNpub": "Indirizzo pubblico Nostr per lo stato del pagamento",
+		"cleanPersonalData": "Cancella i miei dati personali",
+		"cleanPersonalDataConfirm": "ATTENZIONE: Questa azione rimuoverà permanentemente i tuoi dati personali da questo ordine, inclusi gli indirizzi di spedizione e fatturazione.\n\nEsegui questa operazione solo DOPO che il tuo ordine è stato consegnato e hai ricevuto i tuoi articoli.\n\nQuesta azione non può essere annullata. Continuare?",
+		"cleanPersonalDataSuccess": "I tuoi dati personali sono stati rimossi con successo da questo ordine.",
 		"receipt": {
 			"accountHolder": "Intestatario dell'account",
 			"accountHolderAddress": "Indirizzo",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -557,6 +557,9 @@
 			"pending": "in behandeling"
 		},
 		"paymentStatusNpub": "Nostr openbaar adres voor betalingsstatus",
+		"cleanPersonalData": "Mijn persoonlijke gegevens verwijderen",
+		"cleanPersonalDataConfirm": "WAARSCHUWING: Dit verwijdert permanent uw persoonlijke gegevens uit deze bestelling, inclusief verzend- en factuuradressen.\n\nDoe dit alleen NADAT uw bestelling is bezorgd en u uw artikelen heeft ontvangen.\n\nDeze actie kan niet ongedaan worden gemaakt. Doorgaan?",
+		"cleanPersonalDataSuccess": "Uw persoonlijke gegevens zijn succesvol uit deze bestelling verwijderd.",
 		"receipt": {
 			"accountHolder": "Rekeninghouder",
 			"accountHolderAddress": "Adres",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -557,6 +557,9 @@
 			"pending": "pendente"
 		},
 		"paymentStatusNpub": "Chave pública Nostr para estado do pagamento",
+		"cleanPersonalData": "Limpar os meus dados pessoais",
+		"cleanPersonalDataConfirm": "AVISO: Esta ação removerá permanentemente os seus dados pessoais deste pedido, incluindo endereços de envio e faturação.\n\nFaça isto apenas APÓS o seu pedido ter sido entregue e ter recebido os seus artigos.\n\nEsta ação não pode ser desfeita. Continuar?",
+		"cleanPersonalDataSuccess": "Os seus dados pessoais foram removidos deste pedido com sucesso.",
 		"receipt": {
 			"accountHolder": "Titular da conta",
 			"accountHolderAddress": "Morada",

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -16,7 +16,8 @@ import { toBitcoins } from '$lib/utils/toBitcoins';
 import type { ScheduleEventBooked } from './Schedule';
 import type { PickDeep } from 'type-fest';
 
-export type OrderPaymentStatus = 'pending' | 'paid' | 'expired' | 'canceled' | 'failed';
+export const ORDER_PAYMENT_STATUSES = ['pending', 'paid', 'expired', 'canceled', 'failed'] as const;
+export type OrderPaymentStatus = (typeof ORDER_PAYMENT_STATUSES)[number];
 
 export type DiscountType = 'fiat' | 'percentage';
 
@@ -337,6 +338,7 @@ export interface Order extends Timestamps {
 		acceptedExportationAndVATObligation?: boolean;
 	};
 	orderLabelIds?: OrderLabel['_id'][];
+	dataAnonymized?: boolean;
 }
 interface SimplifiedOrderPayment {
 	id: string;

--- a/src/lib/utils/delayMultipliers.ts
+++ b/src/lib/utils/delayMultipliers.ts
@@ -1,0 +1,7 @@
+export const DELAY_MULTIPLIERS: Record<string, number> = {
+	hours: 3600,
+	days: 86400,
+	weeks: 604800,
+	months: 2592000,
+	years: 31536000
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
@@ -1,3 +1,5 @@
+import { ORDER_PAYMENT_STATUSES, type OrderPaymentStatus } from '$lib/types/Order';
+import { DELAY_MULTIPLIERS } from '$lib/utils/delayMultipliers';
 import { ORIGIN } from '$lib/server/env-config';
 import { collections } from '$lib/server/database';
 import { runtimeConfig } from '$lib/server/runtime-config';
@@ -7,8 +9,9 @@ import { toCurrency } from '$lib/utils/toCurrency';
 import { typedKeys } from '$lib/utils/typedKeys.js';
 import { fetchAndSaveExchangeRates } from '$lib/server/locks/currency-lock';
 import { adminPrefix } from '$lib/server/admin';
+import { persistConfigElement } from '$lib/server/utils/persistConfig';
 import { z } from 'zod';
-import { redirect } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import {
 	paymentMethods,
 	type PaymentMethod,
@@ -71,7 +74,8 @@ export async function load(event) {
 		lndConfigured: isLndConfigured(),
 		phoenixdConfigured: isPhoenixdConfigured(),
 		swissBitcoinPayConfigured: isSwissBitcoinPayConfigured(),
-		btcpayServerConfigured: isBtcpayServerConfigured()
+		btcpayServerConfigured: isBtcpayServerConfigured(),
+		dataCleanup: runtimeConfig.dataCleanup
 	};
 }
 
@@ -231,6 +235,36 @@ export const actions = {
 				},
 				{ upsert: true }
 			);
+		}
+
+		const cleanupDelayValue = Math.max(
+			0,
+			Number(formData.get('dataCleanup.scheduled.delayValue')) || 0
+		);
+		const cleanupDelayUnit = String(formData.get('dataCleanup.scheduled.delayUnit') || 'days');
+		if (!(cleanupDelayUnit in DELAY_MULTIPLIERS)) {
+			throw error(400, 'Invalid delay unit');
+		}
+		const cleanupDelaySeconds = cleanupDelayValue * DELAY_MULTIPLIERS[cleanupDelayUnit];
+
+		const dataCleanup = {
+			onOrderExpireOrCancel: formData.get('dataCleanup.onOrderExpireOrCancel') === 'on',
+			allowUserManualCleanup: formData.get('dataCleanup.allowUserManualCleanup') === 'on',
+			scheduled: {
+				enabled: formData.get('dataCleanup.scheduled.enabled') === 'on',
+				delaySeconds: cleanupDelaySeconds,
+				orderStatuses: formData
+					.getAll('dataCleanup.scheduled.orderStatuses')
+					.map(String)
+					.filter((s): s is OrderPaymentStatus =>
+						(ORDER_PAYMENT_STATUSES as readonly string[]).includes(s)
+					)
+			}
+		};
+
+		if (JSON.stringify(runtimeConfig.dataCleanup) !== JSON.stringify(dataCleanup)) {
+			runtimeConfig.dataCleanup = dataCleanup;
+			await persistConfigElement('dataCleanup', dataCleanup);
 		}
 
 		if (oldAdminHash !== result.adminHash) {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
@@ -6,6 +6,9 @@
 
 	import { sortCurrencies, currenciesToSelectOptions } from '$lib/types/Currency';
 	import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
+	import { ORDER_PAYMENT_STATUSES } from '$lib/types/Order';
+	import { DELAY_MULTIPLIERS } from '$lib/utils/delayMultipliers';
+	import { typedInclude } from '$lib/utils/typedIncludes';
 	import { formatDistance } from 'date-fns';
 	import { exchangeRate } from '$lib/stores/exchangeRate';
 	import { useI18n } from '$lib/i18n.js';
@@ -22,6 +25,19 @@
 	let priceReferenceCurrency = data.currencies.priceReference;
 	let hasCartLimitProductLine = !!data.cartMaxSeparateItems;
 	let hasPhysicalCartMinAmount = !!data.physicalCartMinAmount;
+
+	let dataCleanupOnExpire = data.dataCleanup.onOrderExpireOrCancel;
+	let dataCleanupManual = data.dataCleanup.allowUserManualCleanup;
+	let dataCleanupScheduled = data.dataCleanup.scheduled.enabled;
+	const storedSeconds = data.dataCleanup.scheduled.delaySeconds;
+	const defaultUnit =
+		Object.entries(DELAY_MULTIPLIERS)
+			.reverse()
+			.find(([, mult]) => storedSeconds > 0 && storedSeconds % mult === 0)?.[0] ?? 'days';
+	let cleanupDelayUnit = storedSeconds > 0 ? defaultUnit : 'years';
+	let cleanupDelayValue =
+		storedSeconds > 0 ? storedSeconds / (DELAY_MULTIPLIERS[defaultUnit] ?? 86400) : 2;
+	let cleanupStatuses = data.dataCleanup.scheduled.orderStatuses;
 
 	// Currency options for Select components (sorted: BTC/SAT → fiat A-Z)
 	// Exclude SAT for main/secondary/accounting
@@ -48,6 +64,26 @@
 	async function onOverwrite(event: Event) {
 		if (!confirm('Do you want to overwrite current product currencies with this one?')) {
 			event.preventDefault();
+		}
+	}
+
+	function confirmUpdate(e: Event) {
+		if (dataCleanupScheduled && cleanupDelayValue > 0) {
+			const formData = new FormData(e.target as HTMLFormElement);
+			const statuses = formData.getAll('dataCleanup.scheduled.orderStatuses').map(String);
+			if (statuses.length > 0) {
+				const multiplier = DELAY_MULTIPLIERS[cleanupDelayUnit] ?? 86400;
+				const cutoffDate = new Date(Date.now() - cleanupDelayValue * multiplier * 1000);
+				if (
+					!confirm(
+						`Are you sure? It will delete personal data for every order with status [${statuses.join(
+							', '
+						)}] older than ${cutoffDate.toLocaleDateString($locale)}. This cannot be undone.`
+					)
+				) {
+					e.preventDefault();
+				}
+			}
 		}
 	}
 
@@ -102,7 +138,7 @@
 	<input type="hidden" value={priceReferenceCurrency} name="priceReferenceCurrency" />
 </form>
 
-<form method="post" action="?/update" class="flex flex-col gap-6">
+<form method="post" action="?/update" class="flex flex-col gap-6" on:submit={confirmUpdate}>
 	<h2 class="text-2xl">Currencies</h2>
 	<label class="form-label">
 		<CurrencyLabel label="Main currency" />
@@ -714,6 +750,81 @@
 			value={data.analyticsScriptSnippet}
 		/>
 	</label>
+	<h2 class="text-2xl font-semibold mt-8">Customer Data Cleaning</h2>
+	<p class="text-sm text-gray-500 mb-2">
+		Configure how customer personal data is cleaned for law compliance (GDPR, etc.). You are
+		responsible for checking your local regulations.
+	</p>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			name="dataCleanup.onOrderExpireOrCancel"
+			class="form-checkbox"
+			bind:checked={dataCleanupOnExpire}
+		/>
+		Auto-clean personal data when order expires or is cancelled
+	</label>
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			name="dataCleanup.allowUserManualCleanup"
+			class="form-checkbox"
+			bind:checked={dataCleanupManual}
+		/>
+		Allow customers to request cleanup of their personal data
+	</label>
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			name="dataCleanup.scheduled.enabled"
+			class="form-checkbox"
+			bind:checked={dataCleanupScheduled}
+		/>
+		Enable scheduled auto-cleanup of personal data
+	</label>
+	{#if dataCleanupScheduled}
+		<label class="form-label">
+			Cleanup delay
+			<div class="flex gap-2 items-center">
+				<input
+					type="number"
+					min="1"
+					step="1"
+					name="dataCleanup.scheduled.delayValue"
+					bind:value={cleanupDelayValue}
+					class="form-input w-24"
+				/>
+				<select
+					name="dataCleanup.scheduled.delayUnit"
+					bind:value={cleanupDelayUnit}
+					class="form-input"
+				>
+					<option value="hours">Hours</option>
+					<option value="days">Days</option>
+					<option value="weeks">Weeks</option>
+					<option value="months">Months</option>
+					<option value="years">Years</option>
+				</select>
+			</div>
+		</label>
+		<fieldset class="mt-2">
+			<legend class="form-label">Order statuses to clean</legend>
+			{#each ORDER_PAYMENT_STATUSES as status}
+				<label class="inline-flex items-center mr-4">
+					<input
+						type="checkbox"
+						name="dataCleanup.scheduled.orderStatuses"
+						value={status}
+						checked={typedInclude(cleanupStatuses, status)}
+						class="form-checkbox"
+					/>
+					<span class="ml-1">{status}</span>
+				</label>
+			{/each}
+		</fieldset>
+	{/if}
+
 	<input type="submit" value="Update" class="btn body-mainCTA self-start" />
 </form>
 

--- a/src/routes/(app)/order/[id]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/+page.server.ts
@@ -1,11 +1,12 @@
 import { collections } from '$lib/server/database';
 import { UrlDependency } from '$lib/types/UrlDependency';
-import { redirect } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import { fetchOrderForUser } from './fetchOrderForUser.js';
 import { getPublicS3DownloadLink } from '$lib/server/s3.js';
 import { uniqBy } from '$lib/utils/uniqBy.js';
 import { cmsFromContent } from '$lib/server/cms.js';
-import { conflictingTapToPayOrder } from '$lib/server/orders';
+import { anonymizeOrderData, conflictingTapToPayOrder } from '$lib/server/orders';
+import { userIdentifier, userQuery } from '$lib/server/user';
 import { CUSTOMER_ROLE_ID } from '$lib/types/User.js';
 import { runtimeConfig } from '$lib/server/runtime-config.js';
 import { paymentMethods } from '$lib/server/payment-methods.js';
@@ -138,7 +139,10 @@ export async function load({ params, depends, locals, url }) {
 		overwriteCreditCardSvgColor: runtimeConfig.overwriteCreditCardSvgColor,
 		hideCreditCardQrCode: runtimeConfig.hideCreditCardQrCode,
 		labels,
-		returnTo: returnTo ?? undefined
+		returnTo: returnTo ?? undefined,
+		allowManualCleanup: runtimeConfig.dataCleanup.allowUserManualCleanup,
+		canCleanPersonalData:
+			runtimeConfig.dataCleanup.allowUserManualCleanup && !!(locals.email || locals.npub)
 	};
 }
 
@@ -157,5 +161,22 @@ export const actions = {
 		);
 
 		throw redirect(303, request.headers.get('referer') || '/');
+	},
+	cleanPersonalData: async function ({ params, locals }) {
+		if (!runtimeConfig.dataCleanup.allowUserManualCleanup) {
+			throw error(403, 'Data cleanup is not enabled');
+		}
+
+		const order = await collections.orders.findOne({
+			_id: params.id,
+			...userQuery(userIdentifier(locals)),
+			dataAnonymized: { $ne: true }
+		});
+		if (!order) {
+			throw error(404, 'Order not found or already cleaned');
+		}
+
+		const cleaned = await anonymizeOrderData(order._id);
+		return { success: cleaned };
 	}
 };

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { invalidate } from '$app/navigation';
+	import { enhance } from '$app/forms';
 	import { navigating, page } from '$app/stores';
 	import { onMount } from 'svelte';
 	import OrderSummary from '$lib/components/OrderSummary.svelte';
@@ -20,6 +21,7 @@
 	import { CUSTOMER_ROLE_ID } from '$lib/types/User.js';
 
 	export let data;
+	export let form;
 
 	let count = 0;
 
@@ -557,6 +559,25 @@
 						</section>
 					</form>
 				{/if}
+			{/if}
+
+			{#if data.canCleanPersonalData && !data.order.dataAnonymized}
+				<form
+					method="POST"
+					action="?/cleanPersonalData"
+					use:enhance={({ cancel }) => {
+						if (!confirm(t('order.cleanPersonalDataConfirm'))) {
+							cancel();
+							return;
+						}
+					}}
+				>
+					<button type="submit" class="btn btn-red w-full mt-4">
+						{t('order.cleanPersonalData')}
+					</button>
+				</form>
+			{:else if form?.success}
+				<p class="text-green-500 mt-4">{t('order.cleanPersonalDataSuccess')}</p>
 			{/if}
 		</div>
 		<!-- END: LEFT COLUMN -->

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -239,6 +239,7 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 			userAlias: order.user.userAlias
 		},
 		onLocation: order.onLocation,
+		dataAnonymized: order.dataAnonymized,
 		...(params?.userRoleId !== CUSTOMER_ROLE_ID && { orderLabelIds: order.orderLabelIds })
 	};
 }


### PR DESCRIPTION
🦋 Customer data cleaning for GDPR/law compliance

Shop owners can now configure automatic and manual cleaning of customer personal data (email, addresses, phone, IP) from orders to comply with local data protection regulations like GDPR.

Three independently toggleable options in admin Config:
- Auto-clean when orders expire or are cancelled
- Allow customers to clean their own data via a button on the order page
- Scheduled auto-cleanup after a configurable delay (hours to years) with selectable order statuses

Shipping country and ZIP code are preserved for FR/BE tax reporting. All options are disabled by default — the shop owner enables what their jurisdiction requires, same approach as VAT configuration.

Closes #1922