### PR TITLE
⚗ Per-product payment credentials for marketplace (Phase 1)

### DIFF
--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -91,6 +91,7 @@
 
 	let paymentMethods = product.paymentMethods || [...availablePaymentMethods];
 	let restrictPaymentMethods = !!product.paymentMethods;
+	let hasMerchantCredentials = !!product.merchantCredentials;
 	let vatProfileId = product.vatProfileId || '';
 	let formElement: HTMLFormElement;
 	let priceAmountElement: HTMLInputElement;
@@ -816,6 +817,58 @@
 						{/each}
 					</div>
 				{/if}
+
+				<label class="checkbox-label">
+					<input
+						class="form-checkbox"
+						type="checkbox"
+						bind:checked={hasMerchantCredentials}
+						name="hasMerchantCredentials"
+					/>
+					Merchant payment credentials (marketplace)
+				</label>
+
+				<fieldset disabled={!hasMerchantCredentials} hidden={!hasMerchantCredentials}>
+					<div class="bg-blue-50 p-4 rounded-lg space-y-3">
+						<p class="text-sm font-medium text-gray-700">Swiss Bitcoin Pay:</p>
+						<input
+							type="password"
+							name="merchantSwissBitcoinPayApiKey"
+							value={product.merchantCredentials?.swissBitcoinPayApiKey ?? ''}
+							placeholder="API Key"
+							class="form-input w-full"
+						/>
+						<p class="text-sm font-medium text-gray-700 mt-3">Bank Transfer:</p>
+						<input
+							type="text"
+							name="merchantBankIban"
+							value={product.merchantCredentials?.bank?.iban ?? ''}
+							placeholder="IBAN"
+							class="form-input w-full"
+						/>
+						<input
+							type="text"
+							name="merchantBankBic"
+							value={product.merchantCredentials?.bank?.bic ?? ''}
+							placeholder="BIC/SWIFT"
+							class="form-input w-full"
+						/>
+						<input
+							type="text"
+							name="merchantBankAccountHolder"
+							value={product.merchantCredentials?.bank?.accountHolder ?? ''}
+							placeholder="Account Holder"
+							class="form-input w-full"
+						/>
+						<input
+							type="text"
+							name="merchantBankAccountHolderAddress"
+							value={product.merchantCredentials?.bank?.accountHolderAddress ?? ''}
+							placeholder="Account Holder Address"
+							class="form-input w-full"
+						/>
+					</div>
+				</fieldset>
 
 				<label class="checkbox-label">
 					<input

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -105,13 +105,14 @@ export async function queueEmail(
 ): Promise<void> {
 	console.log(`📧 Queueing email: ${templateKey} → ${to}`);
 
+	// Defaults first, then ...vars so callers can override iban/bic with per-order values
 	const lowerVars = mapKeys(
 		{
-			...vars,
+			iban: runtimeConfig.sellerIdentity?.bank?.iban,
+			bic: runtimeConfig.sellerIdentity?.bank?.bic,
 			websiteLink: ORIGIN,
 			brandName: runtimeConfig.brandName,
-			iban: runtimeConfig.sellerIdentity?.bank?.iban,
-			bic: runtimeConfig.sellerIdentity?.bank?.bic
+			...vars
 		},
 		(key) => key.toLowerCase()
 	);

--- a/src/lib/server/locks/order-notifications.ts
+++ b/src/lib/server/locks/order-notifications.ts
@@ -236,7 +236,9 @@ async function handleOrderNotification(order: Order): Promise<void> {
 							maximumFractionDigits: FRACTION_DIGITS_PER_CURRENCY[payment.price.currency],
 							minimumFractionDigits: FRACTION_DIGITS_PER_CURRENCY[payment.price.currency]
 						}),
-						currency: payment.price.currency
+						currency: payment.price.currency,
+						iban: order.sellerIdentity?.bank?.iban,
+						bic: order.sellerIdentity?.bank?.bic
 					};
 					if (email) {
 						await queueEmail(email, templateKey, vars, {

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -57,6 +57,7 @@ import { CUSTOMER_ROLE_ID } from '$lib/types/User';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import type { PaymentMethod, PaymentProcessor } from './payment-methods';
 import type { CountryAlpha2 } from '$lib/types/Country';
+import type { SellerIdentity } from '$lib/types/SellerIdentity';
 import type { LanguageKey } from '$lib/translations';
 import { filterNullish } from '$lib/utils/fillterNullish';
 import { toUrlEncoded } from '$lib/utils/toUrlEncoded';
@@ -1322,7 +1323,7 @@ export async function createOrder(
 				createdAt: new Date(),
 				updatedAt: new Date(),
 				status: 'pending',
-				sellerIdentity: runtimeConfig.sellerIdentity,
+				sellerIdentity: buildOrderSellerIdentity(items, runtimeConfig.sellerIdentity),
 				items: items.map((item, i) => ({
 					_id: item._id,
 					quantity: item.quantity,
@@ -1712,6 +1713,77 @@ export async function createOrder(
 	return orderId;
 }
 
+/**
+ * Determines per-product merchant payment credential overrides.
+ * Returns overrides only when the order contains a single unique product
+ * that has merchantCredentials set. In Phase 2, this will be extended
+ * to group items by merchant for split payments.
+ */
+function getMerchantPaymentOverrides(items: Array<{ product: Product }>):
+	| {
+			swissBitcoinPayApiKey?: string;
+			bankIban?: string;
+	  }
+	| undefined {
+	const uniqueProductIds = [...new Set(items.map((i) => i.product._id))];
+	if (uniqueProductIds.length !== 1) {
+		return undefined;
+	}
+
+	const creds = items[0].product.merchantCredentials;
+	if (!creds) {
+		return undefined;
+	}
+
+	return {
+		...(creds.swissBitcoinPayApiKey && {
+			swissBitcoinPayApiKey: creds.swissBitcoinPayApiKey
+		}),
+		...(creds.bank && {
+			bankIban: creds.bank.iban
+		})
+	};
+}
+
+/**
+ * Builds order-level sellerIdentity, merging per-product merchant bank details
+ * when a single-product order has merchantCredentials.bank set.
+ * Falls back to global sellerIdentity when no product override exists.
+ */
+function buildOrderSellerIdentity(
+	items: Array<{ product: Product }>,
+	globalIdentity: SellerIdentity | undefined | null
+): SellerIdentity | null {
+	const uniqueProductIds = [...new Set(items.map((i) => i.product._id))];
+	const merchantBankOverride =
+		uniqueProductIds.length === 1 ? items[0].product.merchantCredentials?.bank : undefined;
+
+	if (!merchantBankOverride) {
+		return globalIdentity ?? null;
+	}
+
+	const bic = merchantBankOverride.bic ?? globalIdentity?.bank?.bic ?? '';
+	if (!bic) {
+		console.warn(
+			`Order for product "${items[0].product._id}" has merchantCredentials.bank without BIC, and no global BIC fallback`
+		);
+	}
+
+	return {
+		...(globalIdentity ?? ({} as SellerIdentity)),
+		bank: {
+			iban: merchantBankOverride.iban,
+			bic,
+			...(merchantBankOverride.accountHolder && {
+				accountHolder: merchantBankOverride.accountHolder
+			}),
+			...(merchantBankOverride.accountHolderAddress && {
+				accountHolderAddress: merchantBankOverride.accountHolderAddress
+			})
+		}
+	};
+}
+
 async function generatePaymentInfo(params: {
 	method: PaymentMethod;
 	orderId: string;
@@ -1719,6 +1791,14 @@ async function generatePaymentInfo(params: {
 	toPay: Price;
 	paymentId: ObjectId;
 	expiresAt?: Date;
+	/**
+	 * Per-product merchant payment credential overrides (Phase 1: single-product only).
+	 * In Phase 2, this will support per-group overrides for mixed-merchant carts.
+	 */
+	overrides?: {
+		swissBitcoinPayApiKey?: string;
+		bankIban?: string;
+	};
 }): Promise<{
 	address?: string;
 	wallet?: string;
@@ -1797,6 +1877,30 @@ async function generatePaymentInfo(params: {
 				}
 			})();
 			const satoshis = toSatoshis(params.toPay.amount, params.toPay.currency);
+
+			// If product has custom SBP key, force SBP as processor
+			if (params.overrides?.swissBitcoinPayApiKey) {
+				try {
+					const invoice = await swissBitcoinPayCreateInvoice({
+						label,
+						orderId: `${params.orderNumber}`,
+						expiresAt: params.expiresAt,
+						toPay: { amount: satoshis, currency: 'SAT' },
+						apiKey: params.overrides.swissBitcoinPayApiKey
+					});
+					return {
+						address: invoice.payment_address,
+						invoiceId: invoice.invoiceId,
+						processor: 'swiss-bitcoin-pay' satisfies PaymentProcessor
+					};
+				} catch (err) {
+					throw error(
+						402,
+						`Failed to create Swiss Bitcoin Pay invoice with per-product API key: ${err}`
+					);
+				}
+			}
+
 			const preference = runtimeConfig.paymentProcessorPreferences?.lightning;
 			const hardcodedPriority: PaymentProcessor[] = [
 				'swiss-bitcoin-pay',
@@ -1899,7 +2003,7 @@ async function generatePaymentInfo(params: {
 			return {};
 		}
 		case 'bank-transfer': {
-			return { address: runtimeConfig.sellerIdentity?.bank?.iban };
+			return { address: params.overrides?.bankIban ?? runtimeConfig.sellerIdentity?.bank?.iban };
 		}
 		case 'card':
 			return await generateCardPaymentInfo(params);
@@ -2245,6 +2349,8 @@ export async function addOrderPayment(
 	const isFreePayment = paymentMethod === 'free';
 	const paidAt = isFreePayment ? new Date() : undefined;
 
+	const paymentCredentialOverrides = getMerchantPaymentOverrides(order.items);
+
 	const payment: OrderPayment = {
 		_id: paymentId,
 		status: isFreePayment ? 'paid' : 'pending',
@@ -2289,7 +2395,8 @@ export async function addOrderPayment(
 			orderNumber: order.number,
 			toPay: priceToPay,
 			paymentId,
-			expiresAt: expiresAt ?? undefined
+			expiresAt: expiresAt ?? undefined,
+			overrides: paymentCredentialOverrides
 		})),
 		createdAt: new Date()
 	};
@@ -2713,6 +2820,7 @@ async function swissBitcoinPayCreateInvoice(params: {
 	orderId: string;
 	toPay: Price;
 	expiresAt?: Date;
+	apiKey?: string;
 }): Promise<{
 	payment_address: string;
 	invoiceId: string;
@@ -2720,18 +2828,21 @@ async function swissBitcoinPayCreateInvoice(params: {
 	const accountingNote = `Order #${params.orderId}`;
 	const device = runtimeConfig.brandName;
 	try {
-		const checkout = await sbpCreateCheckout({
-			title: params.label,
-			description: accountingNote,
-			amount: params.toPay.amount,
-			unit: params.toPay.currency === 'SAT' ? 'sat' : params.toPay.currency,
-			extra: {
-				customDevice: device
+		const checkout = await sbpCreateCheckout(
+			{
+				title: params.label,
+				description: accountingNote,
+				amount: params.toPay.amount,
+				unit: params.toPay.currency === 'SAT' ? 'sat' : params.toPay.currency,
+				extra: {
+					customDevice: device
+				},
+				...(params.expiresAt === undefined
+					? {}
+					: { delay: differenceInMinutes(params.expiresAt, new Date()) })
 			},
-			...(params.expiresAt === undefined
-				? {}
-				: { delay: differenceInMinutes(params.expiresAt, new Date()) })
-		});
+			params.apiKey ? { apiKey: params.apiKey } : undefined
+		);
 		const payment_address = checkout.pr;
 		const invoiceId = checkout.id;
 		return { payment_address, invoiceId };

--- a/src/lib/server/swiss-bitcoin-pay.ts
+++ b/src/lib/server/swiss-bitcoin-pay.ts
@@ -54,8 +54,12 @@ export interface CheckoutStatus {
 	redirectAfterPaid?: string;
 }
 
-export async function sbpCreateCheckout(request: CheckoutRequest): Promise<CheckoutResponse> {
-	if (!isSwissBitcoinPayConfigured()) {
+export async function sbpCreateCheckout(
+	request: CheckoutRequest,
+	opts?: { apiKey?: string }
+): Promise<CheckoutResponse> {
+	const apiKey = opts?.apiKey ?? runtimeConfig.swissBitcoinPay.apiKey;
+	if (!apiKey) {
 		throw new Error('Swiss Bitcoin Pay is not enabled');
 	}
 
@@ -63,10 +67,11 @@ export async function sbpCreateCheckout(request: CheckoutRequest): Promise<Check
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
-			'api-key': runtimeConfig.swissBitcoinPay.apiKey,
+			'api-key': apiKey,
 			'user-agent': `be-BOP`
 		},
-		body: JSON.stringify(request)
+		body: JSON.stringify(request),
+		signal: AbortSignal.timeout(15_000)
 	});
 
 	if (!response.ok) {
@@ -77,7 +82,8 @@ export async function sbpCreateCheckout(request: CheckoutRequest): Promise<Check
 
 export async function sbpGetCheckoutStatus(id: string): Promise<CheckoutStatus> {
 	const response = await fetch(`${apiUrl()}/checkout/${id}`, {
-		method: 'GET'
+		method: 'GET',
+		signal: AbortSignal.timeout(15_000)
 	});
 
 	if (!response.ok) {

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -37,6 +37,13 @@ export interface ProductTranslatableFields {
 	};
 }
 
+export interface MerchantBankDetails {
+	iban: string;
+	bic?: string;
+	accountHolder?: string;
+	accountHolderAddress?: string;
+}
+
 export interface Product extends Timestamps, ProductTranslatableFields {
 	_id: string;
 	alias: string[];
@@ -128,6 +135,14 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 	 * The product can only be bought with the specified payment methods
 	 */
 	paymentMethods?: PaymentMethod[];
+	/**
+	 * Per-product payment credentials for marketplace scenarios (Phase 1).
+	 * If set and cart contains only this product, these credentials override global ones.
+	 */
+	merchantCredentials?: {
+		swissBitcoinPayApiKey?: string;
+		bank?: MerchantBankDetails;
+	};
 	mobile?: {
 		hideContentBefore: boolean;
 		hideContentAfter: boolean;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -222,6 +222,25 @@ export const actions: Actions = {
 						...(parsed.restrictPaymentMethods && {
 							paymentMethods: parsed.paymentMethods ?? []
 						}),
+						...(parsed.hasMerchantCredentials && {
+							merchantCredentials: {
+								...(parsed.merchantSwissBitcoinPayApiKey && {
+									swissBitcoinPayApiKey: parsed.merchantSwissBitcoinPayApiKey
+								}),
+								...(parsed.merchantBankIban && {
+									bank: {
+										iban: parsed.merchantBankIban,
+										...(parsed.merchantBankBic && { bic: parsed.merchantBankBic }),
+										...(parsed.merchantBankAccountHolder && {
+											accountHolder: parsed.merchantBankAccountHolder
+										}),
+										...(parsed.merchantBankAccountHolderAddress && {
+											accountHolderAddress: parsed.merchantBankAccountHolderAddress
+										})
+									}
+								})
+							}
+						}),
 						hasVariations,
 						...(hasVariations && {
 							variations: variationsParsedPrice.filter(
@@ -255,6 +274,7 @@ export const actions: Actions = {
 						...(!parsed.depositPercentage && { deposit: '' }),
 						...(!parsed.vatProfileId && { vatProfileId: '' }),
 						...(!parsed.restrictPaymentMethods && { paymentMethods: '' }),
+						...(!parsed.hasMerchantCredentials && { merchantCredentials: '' }),
 						...(!hasVariations && { variations: '', variationLabels: '' }),
 						...(!parsed.hasSellDisclaimer && { sellDisclaimer: '' }),
 						...(!parsed.payWhatYouWant && { recommendedPWYWAmount: '' }),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -209,5 +209,11 @@ export const productBaseSchema = () => ({
 	sellDisclaimerTitle: z.string().trim().max(60).optional(),
 	sellDisclaimerReason: z.string().trim().max(10_000).optional(),
 	hideFromSEO: z.boolean({ coerce: true }).default(false),
-	hideDiscountExpiration: z.boolean({ coerce: true }).default(false)
+	hideDiscountExpiration: z.boolean({ coerce: true }).default(false),
+	hasMerchantCredentials: z.boolean({ coerce: true }).default(false),
+	merchantSwissBitcoinPayApiKey: z.string().trim().min(1).optional(),
+	merchantBankIban: z.string().trim().min(1).optional(),
+	merchantBankBic: z.string().trim().min(1).optional(),
+	merchantBankAccountHolder: z.string().trim().min(1).optional(),
+	merchantBankAccountHolderAddress: z.string().trim().min(1).optional()
 });

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -214,7 +214,7 @@
 						orderId={data.order._id}
 						posMode={data.posMode}
 						hideCreditCardQrCode={data.hideCreditCardQrCode}
-						sellerIdentity={data.sellerIdentity}
+						sellerIdentity={data.order.sellerIdentity ?? data.sellerIdentity}
 						posSubtypes={data.posSubtypes}
 						returnTo={data.returnTo}
 					>


### PR DESCRIPTION
Products can now have their own Swiss Bitcoin Pay API key and bank transfer details (IBAN, BIC, account holder). When a customer checks out with a single product that has merchant credentials configured, payments go directly to the merchant's account — both for Lightning and bank transfers. Orders with multiple products or without custom credentials work exactly as before.

Admin panel: new "Merchant payment credentials" section in product settings.

Closes #2493