### PR TITLE
🐛🤖 Fix VAT breakdown display on /pos/touch and its split view

### DIFF
--- a/src/lib/components/MoveItemsModal.svelte
+++ b/src/lib/components/MoveItemsModal.svelte
@@ -337,7 +337,6 @@
 								totalExcl={leftTabPriceInfo.partialPrice}
 								totalIncl={leftTabPriceInfo.partialPriceWithVat}
 								currency={leftTabPriceInfo.currency}
-								vatRates={leftTabPriceInfo.vat.map((vat) => vat.rate)}
 							/>
 						</div>
 					{/if}
@@ -374,7 +373,6 @@
 								totalExcl={rightTabPriceInfo.partialPrice}
 								totalIncl={rightTabPriceInfo.partialPriceWithVat}
 								currency={rightTabPriceInfo.currency}
-								vatRates={rightTabPriceInfo.vat.map((vat) => vat.rate)}
 							/>
 						</div>
 					{/if}

--- a/src/lib/components/PosSplitTotalSection.svelte
+++ b/src/lib/components/PosSplitTotalSection.svelte
@@ -6,7 +6,6 @@
 	export let totalExcl: number;
 	export let totalIncl: number;
 	export let currency: Currency;
-	export let vatRates: number[];
 	export let totalInclBeforeDiscount: number | undefined = undefined;
 	export let discountPercentage: number | undefined = undefined;
 
@@ -20,9 +19,7 @@
 		<PriceTag amount={totalExcl} {currency} main class="text-2xl" />
 		{#if totalInclBeforeDiscount && discountPercentage}
 			<div class="text-2xl">
-				{t('pos.split.inclVat', {
-					rates: vatRates.map((rate) => `${rate}%`).join(', ')
-				})}
+				{t('pos.split.inclVatShort')}
 			</div>
 			<PriceTag
 				amount={totalInclBeforeDiscount}
@@ -47,9 +44,7 @@
 			</div>
 		{:else}
 			<div class="text-2xl">
-				{t('pos.split.inclVat', {
-					rates: vatRates.map((rate) => `${rate}%`).join(', ')
-				})}
+				{t('pos.split.inclVatShort')}
 			</div>
 			<PriceTag amount={totalIncl} {currency} main class="text-2xl" />
 		{/if}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -590,7 +590,7 @@
 									main
 									class="text-base sm:text-lg md:text-xl lg:text-2xl text-right"
 								/>
-								{#each priceInfo.vat as vat}
+								{#each priceInfo.vat.filter((v) => v.partialPrice.amount > 0) as vat}
 									<span class="whitespace-nowrap">{t('pos.touch.vatBreakdown')} {vat.rate}%</span>
 									<PriceTag
 										amount={vat.partialPrice.amount}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
@@ -165,7 +165,6 @@
 			: null;
 
 	$: poolCurrency = tab.items[0]?.product.price.currency ?? UNDERLYING_CURRENCY;
-	$: poolVatRates = [...new Set(originalQuantitiesPriceInfo.vatRates)];
 
 	const modeParam = $page.url.searchParams.get('mode');
 	let rightPannel: 'menu' | 'split-items' | 'split-shares' =
@@ -364,7 +363,6 @@
 								totalExcl={poolTotals.excl}
 								totalIncl={poolTotals.incl}
 								currency={poolCurrency}
-								vatRates={poolVatRates}
 								totalInclBeforeDiscount={tab.discount && tab.discount.percentage > 0
 									? poolTotals.inclBeforeDiscount
 									: undefined}
@@ -398,7 +396,6 @@
 								totalExcl={tabItemsPriceInfo.partialPrice}
 								totalIncl={tabItemsPriceInfo.partialPriceWithVat}
 								currency={tabItemsPriceInfo.currency}
-								vatRates={tabItemsPriceInfo.vat.map((vat) => vat.rate)}
 								totalInclBeforeDiscount={tab.discount && tab.discount.percentage > 0
 									? tabTotalInclBeforeDiscount
 									: undefined}
@@ -502,7 +499,6 @@
 								totalExcl={splitTabPriceInfo.partialPrice}
 								totalIncl={splitTabPriceInfo.partialPriceWithVat}
 								currency={splitTabPriceInfo.currency}
-								vatRates={splitTabPriceInfo.vat.map((vat) => vat.rate)}
 							/>
 
 							<!-- Payment method selector (hidden when pool is fully paid) -->


### PR DESCRIPTION
- On /pos/touch/tab/{id}: only show "Incl. VAT X%" rows when a product with that rate is actually in the pool (filter zero-amount entries from the VAT breakdown).
- On /pos/touch/tab/{id}/split: replace the confusing "incl. VAT 2.6%, 8.1% CHF Y" subtotal line with just "incl. VAT CHF Y" since the VAT rate detail is already shown in the upper-left breakdown.

That'll lead to a less confusing and more compliant UI for /pos/touch.

Fixes #2517