### PR TITLE
🦋 Add GNU Taler as a payment method

### DIFF
--- a/src/lib/components/Order/PaymentQRCodes.svelte
+++ b/src/lib/components/Order/PaymentQRCodes.svelte
@@ -10,10 +10,24 @@
 	export let hideCreditCardQrCode: boolean | undefined = undefined;
 </script>
 
+<!-- Taler wallet browser extension auto-detects payments via this meta tag -->
+<svelte:head>
+	{#if payment.status === 'pending' && payment.method === 'taler' && payment.address}
+		<meta name="taler-support" content={payment.address} />
+	{/if}
+</svelte:head>
+
 {#if payment.status === 'pending'}
 	<!-- Lightning QR -->
 	{#if payment.method === 'lightning'}
 		<a href={lightningPaymentQrCodeString(payment.address ?? '')}>
+			<img src="{$page.url.pathname}/payment/{payment.id}/qrcode" class="w-96 h-96" alt="QR code" />
+		</a>
+	{/if}
+
+	<!-- Taler QR -->
+	{#if payment.method === 'taler'}
+		<a href={payment.address ?? ''}>
 			<img src="{$page.url.pathname}/payment/{payment.id}/qrcode" class="w-96 h-96" alt="QR code" />
 		</a>
 	{/if}

--- a/src/lib/server/locks/order-lock.ts
+++ b/src/lib/server/locks/order-lock.ts
@@ -83,6 +83,7 @@ async function handleTapToPayCheck(
 			case 'lnd':
 			case 'swiss-bitcoin-pay':
 			case 'bitcoin-nodeless':
+			case 'taler':
 				throw new Error(
 					`Tap-to-pay payment ${payment._id} requests processor ` +
 						`${payment.processor}, but Tap-to-pay using this processor is ` +

--- a/src/lib/server/locks/order-notifications.ts
+++ b/src/lib/server/locks/order-notifications.ts
@@ -209,6 +209,9 @@ async function handleOrderNotification(order: Order): Promise<void> {
 							case 'paypal':
 								templateKey = 'order.payment.pending.paypal';
 								break;
+							case 'taler':
+								templateKey = 'order.payment.pending.taler';
+								break;
 							case 'point-of-sale':
 							case 'free':
 								// no email

--- a/src/lib/server/payment-methods.ts
+++ b/src/lib/server/payment-methods.ts
@@ -9,7 +9,8 @@ export const ALL_PAYMENT_METHODS = [
 	'lightning',
 	'point-of-sale',
 	'free',
-	'paypal'
+	'paypal',
+	'taler'
 ] as const;
 export type PaymentMethod = (typeof ALL_PAYMENT_METHODS)[number];
 
@@ -22,7 +23,8 @@ export const ALL_PAYMENT_PROCESSORS = [
 	'phoenixd',
 	'stripe',
 	'sumup',
-	'swiss-bitcoin-pay'
+	'swiss-bitcoin-pay',
+	'taler'
 ] as const;
 export type PaymentProcessor = (typeof ALL_PAYMENT_PROCESSORS)[number];
 
@@ -47,6 +49,7 @@ export const paymentMethods = (opts?: {
 						case 'paypal':
 						case 'bitcoin':
 						case 'lightning':
+						case 'taler':
 							return getProcessorsForMethod(method).some((pp) => pp.isEnabled());
 						case 'bank-transfer':
 							return runtimeConfig.sellerIdentity?.bank;

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -226,6 +226,11 @@ const baseConfig = {
 	swissBitcoinPay: {
 		apiKey: ''
 	},
+	taler: {
+		backendUrl: '',
+		backendApiKey: '',
+		currency: 'CHF' as Currency
+	},
 	bity: {
 		clientId: ''
 	},
@@ -364,6 +369,12 @@ Amount: {{amount}} {{currency}}</p>`,
 			default: true as boolean
 		},
 		'order.payment.pending.paypal': {
+			subject: 'Order #{{orderNumber}}',
+			html: `<p>Payment for order #{{orderNumber}} is pending, see <a href="{{orderLink}}">{{orderLink}}</a></p>
+<p>Please pay using this link: <a href="{{paymentLink}}">{{paymentLink}}</a></p>`,
+			default: true as boolean
+		},
+		'order.payment.pending.taler': {
 			subject: 'Order #{{orderNumber}}',
 			html: `<p>Payment for order #{{orderNumber}} is pending, see <a href="{{orderLink}}">{{orderLink}}</a></p>
 <p>Please pay using this link: <a href="{{paymentLink}}">{{paymentLink}}</a></p>`,

--- a/src/lib/server/sdk/contrib/PPTaler.ts
+++ b/src/lib/server/sdk/contrib/PPTaler.ts
@@ -1,0 +1,174 @@
+import { runtimeConfig } from '$lib/server/runtime-config';
+import { toCurrency } from '$lib/utils/toCurrency';
+import { FRACTION_DIGITS_PER_CURRENCY, CURRENCIES } from '$lib/types/Currency';
+import { typedInclude } from '$lib/utils/typedIncludes';
+import { ORIGIN } from '$lib/server/env-config';
+import { z } from 'zod';
+import type {
+	PaymentProcessorDefinition,
+	CreatePaymentParams,
+	CreatePaymentResult,
+	CheckPaymentResult
+} from '../pp';
+import type { Order } from '$lib/types/Order';
+
+// --- Taler API helpers (private to this module) ---
+
+function isTalerEnabled(): boolean {
+	return !!runtimeConfig.taler.backendUrl && !!runtimeConfig.taler.backendApiKey;
+}
+
+// Demo backend (backend.demo.taler.net) uses test currency KUDOS instead of real currencies
+function isDemoMerchantBackend(): boolean {
+	return runtimeConfig.taler.backendUrl.startsWith('https://backend.demo.taler.net');
+}
+
+/** Resolve KUDOS test currency to configured currency, pass through real currencies */
+function resolveTalerCurrency(currencyStr: string): string {
+	return currencyStr === 'KUDOS' ? runtimeConfig.taler.currency : currencyStr;
+}
+
+const talerOrderSchema = z.object({
+	taler_pay_uri: z.string().optional(),
+	order_status: z.enum(['unpaid', 'paid', 'claimed']),
+	contract_terms: z.object({ amount: z.string() }).optional()
+});
+
+type TalerOrder = z.infer<typeof talerOrderSchema>;
+
+function buildTalerHeaders(): Record<string, string> {
+	return {
+		Authorization: `Bearer ${runtimeConfig.taler.backendApiKey}`,
+		'Content-Type': 'application/json'
+	};
+}
+
+async function getTalerOrder(orderId: string): Promise<TalerOrder | 'not_found'> {
+	const resp = await fetch(`${runtimeConfig.taler.backendUrl}/private/orders/${orderId}`, {
+		headers: buildTalerHeaders()
+	});
+	if (resp.status === 404) {
+		return 'not_found';
+	}
+	if (!resp.ok) {
+		const errText = await resp.text();
+		throw new Error(
+			`Failed to get Taler order ${orderId}: ${resp.status} ${resp.statusText} — ${errText}`
+		);
+	}
+	return talerOrderSchema.parse(await resp.json());
+}
+
+// --- SDK Payment Processor ---
+
+export default {
+	meta: { processor: 'taler', method: 'taler', emoji: '🪙' },
+
+	isEnabled: () => isTalerEnabled(),
+
+	paymentPrice(price) {
+		const currency = runtimeConfig.taler.currency;
+		return {
+			amount: toCurrency(currency, price.amount, price.currency),
+			currency
+		};
+	},
+
+	async createPayment(params: CreatePaymentParams): Promise<CreatePaymentResult> {
+		const currency = runtimeConfig.taler.currency;
+		const amount = toCurrency(currency, params.toPay.amount, params.toPay.currency);
+		const talerCurrency = isDemoMerchantBackend() ? 'KUDOS' : currency;
+		const talerAmount = `${talerCurrency}:${amount.toFixed(
+			FRACTION_DIGITS_PER_CURRENCY[currency]
+		)}`;
+
+		// Step 1: Create order in Taler merchant backend
+		const createResp = await fetch(`${runtimeConfig.taler.backendUrl}/private/orders`, {
+			method: 'POST',
+			headers: buildTalerHeaders(),
+			body: JSON.stringify({
+				order: {
+					amount: talerAmount,
+					summary: `Order #${params.orderNumber}`,
+					fulfillment_url: `${ORIGIN}/order/${params.orderId}`,
+					...(params.expiresAt && {
+						pay_deadline: { t_s: Math.floor(params.expiresAt.getTime() / 1000) }
+					})
+				}
+			})
+		});
+		if (!createResp.ok) {
+			const errText = await createResp.text();
+			throw new Error(`Taler order creation failed (${createResp.status}): ${errText}`);
+		}
+		const { order_id } = z.object({ order_id: z.string() }).parse(await createResp.json());
+
+		// Step 2: Fetch order details to get taler_pay_uri for QR code
+		const orderData = await getTalerOrder(order_id);
+		if (orderData === 'not_found') {
+			throw new Error(`Taler order ${order_id} not found after creation`);
+		}
+		if (!orderData.taler_pay_uri) {
+			throw new Error(`Taler order ${order_id} missing taler_pay_uri`);
+		}
+
+		return {
+			checkoutId: order_id,
+			address: orderData.taler_pay_uri,
+			processor: 'taler'
+		};
+	},
+
+	async checkPayment(
+		payment: Order['payments'][number],
+		order: Order // eslint-disable-line @typescript-eslint/no-unused-vars
+	): Promise<CheckPaymentResult> {
+		if (!payment.checkoutId) {
+			return { status: 'pending' };
+		}
+
+		const orderData = await getTalerOrder(payment.checkoutId);
+		if (orderData === 'not_found') {
+			return { status: 'failed' };
+		}
+
+		if (orderData.order_status === 'paid') {
+			const amountStr = orderData.contract_terms?.amount;
+			if (!amountStr) {
+				throw new Error(`Taler order ${payment.checkoutId} paid but missing contract_terms.amount`);
+			}
+
+			const colonIdx = amountStr.indexOf(':');
+			if (colonIdx === -1) {
+				throw new Error(`Taler order ${payment.checkoutId}: malformed amount "${amountStr}"`);
+			}
+			const currencyStr = amountStr.slice(0, colonIdx);
+			const amountValue = amountStr.slice(colonIdx + 1);
+			const parsedAmount = Number(amountValue);
+			if (isNaN(parsedAmount)) {
+				throw new Error(`Taler order ${payment.checkoutId}: non-numeric amount "${amountValue}"`);
+			}
+
+			const resolvedCurrency = resolveTalerCurrency(currencyStr);
+
+			if (!typedInclude(CURRENCIES, resolvedCurrency)) {
+				throw new Error(`Taler returned unknown currency: ${resolvedCurrency}`);
+			}
+
+			return {
+				status: 'paid',
+				received: {
+					amount: parsedAmount,
+					currency: resolvedCurrency
+				}
+			};
+		}
+
+		if (payment.expiresAt && payment.expiresAt < new Date()) {
+			return { status: 'expired' };
+		}
+
+		// 'claimed' (wallet grabbed order) and 'unpaid' → pending
+		return { status: 'pending' };
+	}
+} satisfies PaymentProcessorDefinition;

--- a/src/lib/server/sdk/pp-registry.ts
+++ b/src/lib/server/sdk/pp-registry.ts
@@ -8,6 +8,7 @@ import PPLnd from './contrib/PPLnd';
 import PPBitcoinNodeless from './contrib/PPBitcoinNodeless';
 import PPBitcoind from './contrib/PPBitcoind';
 import PPPaypal from './contrib/PPPaypal';
+import PPTaler from './contrib/PPTaler';
 
 // Registration order = default priority per method (when no user preference set)
 
@@ -27,3 +28,6 @@ registerProcessor(PPBitcoind);
 
 // paypal: single provider
 registerProcessor(PPPaypal);
+
+// taler: single provider
+registerProcessor(PPTaler);

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -123,6 +123,7 @@
 			"lightning": "Lightning",
 			"paypal": "Paypal",
 			"point-of-sale": "Point of Sale",
+			"taler": "Taler",
 			"unavailable": "Keine Zahlungsmethoden verfügbar."
 		},
 		"paymentStatus": "Zahlungsstatus",
@@ -516,7 +517,8 @@
 			"free": "Nichts bezahlt",
 			"lightning": "Bezahlt mit: Lightning-Transaktion (1 {paymentCurrency} = {exchangeRate} {mainCurrency} zum Zeitpunkt der Bestellung)",
 			"paypal": "Bezahlt mit: Paypal",
-			"point-of-sale": "Im Geschäft bezahlt"
+			"point-of-sale": "Im Geschäft bezahlt",
+			"taler": "Bezahlt mit: Taler"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Bezahlt mit: verifizierter Banküberweisung",
@@ -524,7 +526,8 @@
 			"card": "Bezahlt mit: Bankkarte",
 			"free": "Nichts bezahlt",
 			"lightning": "Bezahlt mit: Lightning-Transaktion",
-			"point-of-sale": "Im Geschäft bezahlt"
+			"point-of-sale": "Im Geschäft bezahlt",
+			"taler": "Bezahlt mit: Taler"
 		},
 		"payToComplete": "Bezahlen Sie, um die Bestellung abzuschließen.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -123,6 +123,7 @@
 			"lightning": "Lightning",
 			"paypal": "Paypal",
 			"point-of-sale": "Point of sale",
+			"taler": "Taler",
 			"unavailable": "No payment methods available."
 		},
 		"paymentStatus": "Payment status",
@@ -516,7 +517,8 @@
 			"free": "Paid Nothing",
 			"lightning": "Paid with: Lightning transaction (1 {paymentCurrency} = {exchangeRate} {mainCurrency} at the time of the order)",
 			"paypal": "Paid with: paypal",
-			"point-of-sale": "Paid in store"
+			"point-of-sale": "Paid in store",
+			"taler": "Paid with: Taler"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Paid with: verified bank transfer",
@@ -524,7 +526,8 @@
 			"card": "Paid with: bank card",
 			"free": "Paid Nothing",
 			"lightning": "Paid with: Lightning transaction",
-			"point-of-sale": "Paid in store"
+			"point-of-sale": "Paid in store",
+			"taler": "Paid with: Taler"
 		},
 		"payToComplete": "Pay to complete the order.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -123,6 +123,7 @@
 			"lightning": "Lightning",
 			"paypal": "Paypal",
 			"point-of-sale": "Punto de venta",
+			"taler": "Taler",
 			"unavailable": "No hay métodos de pago disponibles."
 		},
 		"paymentStatus": "Estado del pago",
@@ -516,7 +517,8 @@
 			"free": "No se pagó nada",
 			"lightning": "Pagado con: transacción Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento del pedido)",
 			"paypal": "Pagado con: paypal",
-			"point-of-sale": "Pagado en tienda"
+			"point-of-sale": "Pagado en tienda",
+			"taler": "Pagado con: Taler"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Pagado con: transferencia bancaria verificada",
@@ -524,7 +526,8 @@
 			"card": "Pagado con: tarjeta bancaria",
 			"free": "No se pagó nada",
 			"lightning": "Pagado con: transacción Lightning",
-			"point-of-sale": "Pagado en tienda"
+			"point-of-sale": "Pagado en tienda",
+			"taler": "Pagado con: Taler"
 		},
 		"payToComplete": "Pagar para completar el pedido.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -123,6 +123,7 @@
 			"lightning": "Lightning",
 			"paypal": "Paypal",
 			"point-of-sale": "Point of sale",
+			"taler": "Taler",
 			"unavailable": "Aucun mode de paiement disponible."
 		},
 		"paymentStatus": "Statut de paiement",
@@ -516,7 +517,8 @@
 			"free": "N'a rien payé",
 			"lightning": "Payé avec : Transaction Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} au moment de la commande)",
 			"paypal": "Payé avec: paypal",
-			"point-of-sale": "Payé en magasin"
+			"point-of-sale": "Payé en magasin",
+			"taler": "Payé avec : Taler"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Payé avec : virement bancaire vérifié",
@@ -524,7 +526,8 @@
 			"card": "Payé avec : carte bancaire",
 			"free": "N'a rien payé",
 			"lightning": "Payé avec : Transaction Lightning",
-			"point-of-sale": "Payé en magasin"
+			"point-of-sale": "Payé en magasin",
+			"taler": "Payé avec : Taler"
 		},
 		"payToComplete": "Payez pour finaliser la commande.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -123,6 +123,7 @@
 			"lightning": "Lightning",
 			"paypal": "PayPal",
 			"point-of-sale": "Punto di vendita",
+			"taler": "Taler",
 			"unavailable": "Nessun metodo di pagamento valido."
 		},
 		"paymentStatus": "Status del pagamento",
@@ -516,7 +517,8 @@
 			"free": "Nessun pagamento",
 			"lightning": "Pagato con: transazione Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento dell'ordine)",
 			"paypal": "Pagato con:  paypal",
-			"point-of-sale": "Pagato in magazzino"
+			"point-of-sale": "Pagato in magazzino",
+			"taler": "Pagato con: Taler"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Pagato con: bonifico bancario verificato",
@@ -524,7 +526,8 @@
 			"card": "Pagato con: carta bancaria",
 			"free": "Nessun pagamento",
 			"lightning": "Pagato con: transazione Lightning",
-			"point-of-sale": "Pagato in magazzino"
+			"point-of-sale": "Pagato in magazzino",
+			"taler": "Pagato con: Taler"
 		},
 		"payToComplete": "Paga per completare l'ordine.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -123,6 +123,7 @@
 			"lightning": "Bliksem",
 			"paypal": "Paypal",
 			"point-of-sale": "Verkooppunt",
+			"taler": "Taler",
 			"unavailable": "Geen betaalmethoden beschikbaar."
 		},
 		"paymentStatus": "Betalingsstatus",
@@ -516,7 +517,8 @@
 			"free": "Niets betaald",
 			"lightning": "Betaald met: Lightning-transactie (1 {paymentCurrency} = {exchangeRate} {mainCurrency} op het moment van de bestelling)",
 			"paypal": "Betaald met: paypal",
-			"point-of-sale": "Betaald in de winkel"
+			"point-of-sale": "Betaald in de winkel",
+			"taler": "Betaald met: Taler"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Betaald met: geverifieerde bankoverschrijving",
@@ -524,7 +526,8 @@
 			"card": "Betaald met: bankkaart",
 			"free": "Niets betaald",
 			"lightning": "Betaald met: Lightning-transactie",
-			"point-of-sale": "Betaald in de winkel"
+			"point-of-sale": "Betaald in de winkel",
+			"taler": "Betaald met: Taler"
 		},
 		"payToComplete": "Betaal om de bestelling af te ronden.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -123,6 +123,7 @@
 			"lightning": "Lightning",
 			"paypal": "Paypal",
 			"point-of-sale": "Ponto de venda",
+			"taler": "Taler",
 			"unavailable": "Nenhum método de pagamento disponível."
 		},
 		"paymentStatus": "Estado do pagamento",
@@ -516,7 +517,8 @@
 			"free": "Pago nada",
 			"lightning": "Pago com: transação Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} no momento da encomenda)",
 			"paypal": "Pago com: paypal",
-			"point-of-sale": "Pago na loja"
+			"point-of-sale": "Pago na loja",
+			"taler": "Pago com: Taler"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Pago com: transferência bancária verificada",
@@ -524,7 +526,8 @@
 			"card": "Pago com: cartão bancário",
 			"free": "Pago nada",
 			"lightning": "Pago com: transação Lightning",
-			"point-of-sale": "Pago na loja"
+			"point-of-sale": "Pago na loja",
+			"taler": "Pago com: Taler"
 		},
 		"payToComplete": "Pague para completar a encomenda.",
 		"payToCompleteBitcoin": {

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -404,7 +404,8 @@ export const PAYMENT_METHOD_EMOJI: Record<PaymentMethod, string> = {
 	'point-of-sale': '🛒',
 	lightning: '⚡',
 	bitcoin: '₿',
-	free: '🆓'
+	free: '🆓',
+	taler: '🅣'
 };
 
 export const ORDER_PAGINATION_LIMIT = 50;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
@@ -147,6 +147,10 @@ export const adminLinks: AdminLinks = [
 				label: 'Lightning LND node'
 			},
 			{
+				href: '/admin/taler',
+				label: 'Taler'
+			},
+			{
 				href: '/admin/pos-payments',
 				label: 'PoS Payments'
 			}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.server.ts
@@ -1,0 +1,55 @@
+import { collections } from '$lib/server/database.js';
+import { runtimeConfig } from '$lib/server/runtime-config';
+import { CURRENCIES, type Currency } from '$lib/types/Currency.js';
+import { z } from 'zod';
+
+export async function load() {
+	return {
+		taler: runtimeConfig.taler
+	};
+}
+
+export const actions = {
+	save: async function ({ request }) {
+		const taler = z
+			.object({
+				backendUrl: z
+					.string()
+					.min(1)
+					.transform((v) => v.replace(/\/+$/, '')),
+				backendApiKey: z.string().min(1),
+				currency: z.enum(
+					CURRENCIES.filter((c) => c !== 'BTC' && c !== 'SAT') as [Currency, ...Currency[]]
+				)
+			})
+			.parse(Object.fromEntries(await request.formData()));
+
+		await collections.runtimeConfig.updateOne(
+			{
+				_id: 'taler'
+			},
+			{
+				$set: {
+					data: taler,
+					updatedAt: new Date()
+				}
+			},
+			{
+				upsert: true
+			}
+		);
+
+		runtimeConfig.taler = taler;
+	},
+	delete: async function () {
+		await collections.runtimeConfig.deleteOne({
+			_id: 'taler'
+		});
+
+		runtimeConfig.taler = {
+			backendUrl: '',
+			backendApiKey: '',
+			currency: 'CHF'
+		};
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/taler/+page.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { sortCurrencies, currenciesToSelectOptions } from '$lib/types/Currency';
+	import Select from 'svelte-select';
+	import CurrencyLabel from '$lib/components/CurrencyLabel.svelte';
+	import { currencies } from '$lib/stores/currencies';
+
+	export let data;
+
+	const sortedCurrencies = sortCurrencies($currencies.main, $currencies.secondary);
+	const currenciesWithoutCrypto = currenciesToSelectOptions(
+		sortedCurrencies.filter((c) => c !== 'BTC' && c !== 'SAT')
+	);
+	let selectedCurrency =
+		currenciesWithoutCrypto.find((c) => c.value === data.taler.currency) || null;
+	$: if (selectedCurrency) {
+		data.taler.currency = selectedCurrency.value;
+	}
+</script>
+
+<h1 class="text-3xl">Taler</h1>
+
+<form class="contents" method="post" action="?/save">
+	<label class="form-label">
+		Backend URL
+		<input
+			class="form-input"
+			type="text"
+			name="backendUrl"
+			value={data.taler.backendUrl}
+			required
+		/>
+	</label>
+
+	<label class="form-label">
+		Backend API Key
+		<input
+			class="form-input"
+			type="password"
+			name="backendApiKey"
+			value={data.taler.backendApiKey}
+			required
+		/>
+	</label>
+
+	<label class="form-label">
+		<CurrencyLabel label="Currency" />
+		<Select
+			items={currenciesWithoutCrypto}
+			searchable={true}
+			clearable={false}
+			bind:value={selectedCurrency}
+			class="form-input"
+		/>
+		<input type="hidden" name="currency" value={selectedCurrency?.value || ''} required />
+	</label>
+
+	<div class="flex justify-between">
+		<button class="btn btn-black" type="submit">Save</button>
+		<button class="btn btn-red" type="submit" form="delete-form">Reset</button>
+	</div>
+</form>
+<form class="contents" method="post" action="?/delete" id="delete-form"></form>

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/qrcode/+server.ts
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/qrcode/+server.ts
@@ -23,7 +23,8 @@ export async function GET({ params, url }) {
 		throw error(404, 'Payment not found');
 	}
 
-	if (payment.method !== 'bitcoin' && payment.method !== 'lightning' && payment.method !== 'card') {
+	const qrMethods = new Set(['bitcoin', 'lightning', 'card', 'taler']);
+	if (!qrMethods.has(payment.method)) {
 		throw error(400, 'Invalid payment method for QR Code generation');
 	}
 


### PR DESCRIPTION
GNU Taler is an electronic payment system that can now be configured as a payment method in be-BOP. Admins can set it up under Payment Settings → Taler by providing their merchant backend URL, API key, and preferred currency.

Once enabled, customers see Taler as a payment option at checkout, with a QR code they can scan using the Taler wallet app or browser extension. Payments are confirmed automatically.

- New payment method available in checkout alongside existing options
- Admin configuration page for Taler merchant backend credentials
- QR code and browser wallet integration on the payment page