### PR TITLE
🐛 Fix wrong VAT-included price on POS touch product tiles

### DIFF
--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -98,15 +98,17 @@
 	);
 
 	function productPriceWithVat(product: (typeof data.products)[number]): number {
-		return applyVat(
-			toCurrency(data.currencies.main, product.price.amount, product.price.currency),
-			computeVatRate({
-				productVatProfileId: product.vatProfileId,
-				vatProfiles: data.vatProfiles,
-				bebopCountry: data.vatCountry,
-				userCountry: data.countryCode,
-				vatSingleCountry: data.vatSingleCountry
-			})
+		const rate = computeVatRate({
+			productVatProfileId: product.vatProfileId,
+			vatProfiles: data.vatProfiles,
+			bebopCountry: data.vatCountry,
+			userCountry: data.countryCode,
+			vatSingleCountry: data.vatSingleCountry
+		});
+		return toCurrency(
+			data.currencies.main,
+			applyVat(product.price.amount, rate),
+			product.price.currency
 		);
 	}
 


### PR DESCRIPTION
Tile price could be one cent higher than the cart price for the same
product (e.g. 5.01 vs 5.00 CHF). Now they match.

Closes #2520