### PR TITLE
🦋 New discount conditions and promo codes on cart

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -25,6 +25,7 @@ declare global {
 				role?: Role;
 				alias?: string;
 				hasPosOptions?: boolean;
+				recoveryEmail?: string;
 			};
 			email?: string;
 			npub?: string;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -224,7 +224,8 @@ const handleGlobal: Handle = async ({ event, resolve }) => {
 						login: user.login ? user.login : '',
 						roleId: user.roleId,
 						alias: user.alias,
-						hasPosOptions: user.hasPosOptions
+						hasPosOptions: user.hasPosOptions,
+						recoveryEmail: user.recovery?.email
 					};
 				}
 			}

--- a/src/lib/components/ProductCombinationRow.svelte
+++ b/src/lib/components/ProductCombinationRow.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { MultiSelect } from 'svelte-multiselect';
+	import { createEventDispatcher } from 'svelte';
+
+	export let product: { productId: string; quantity: number };
+	export let comboIdx: number;
+	export let prodIdx: number;
+	export let availableProductList: Array<{ _id: string; name: string }>;
+
+	const dispatch = createEventDispatcher<{ remove: null; change: null }>();
+
+	function hasStringValue(o: unknown): o is { value: string } {
+		return (
+			!!o &&
+			typeof o === 'object' &&
+			'value' in o &&
+			typeof (o as { value: unknown }).value === 'string'
+		);
+	}
+
+	function handleSelectChange(
+		e: CustomEvent<{ option?: unknown; type: 'add' | 'remove' | 'removeAll' }>
+	) {
+		const { type, option } = e.detail;
+		if (type === 'add' && hasStringValue(option)) {
+			product.productId = option.value;
+		} else if (type === 'remove' || type === 'removeAll') {
+			product.productId = '';
+		}
+		dispatch('change');
+	}
+</script>
+
+<div class="flex gap-2 items-center mb-1">
+	<div class="flex-[4] min-w-0">
+		<MultiSelect
+			--sms-options-bg="var(--body-mainPlan-backgroundColor)"
+			maxSelect={1}
+			options={availableProductList.map((p) => ({ label: p.name, value: p._id }))}
+			selected={product.productId
+				? [
+						{
+							value: product.productId,
+							label:
+								availableProductList.find((p) => p._id === product.productId)?.name ??
+								product.productId
+						}
+				  ]
+				: []}
+			on:change={handleSelectChange}
+		/>
+	</div>
+	<input
+		type="hidden"
+		name="combinations[{comboIdx}][{prodIdx}][productId]"
+		value={product.productId}
+	/>
+	<input
+		type="number"
+		min="1"
+		class="form-input flex-1 min-w-0 !h-[30px] !py-0"
+		name="combinations[{comboIdx}][{prodIdx}][quantity]"
+		bind:value={product.quantity}
+		placeholder="Required quantity"
+		title="Required quantity of this product to trigger the discount"
+	/>
+	<button type="button" class="shrink-0" on:click={() => dispatch('remove')}>🗑️</button>
+</div>

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -206,6 +206,11 @@ const indexes: Array<[Collection<any>, IndexSpecification, CreateIndexesOptions?
 		{ wholeCatalog: 1, beginsAt: 1 },
 		{ partialFilterExpression: { wholeCatalog: true } }
 	],
+	[
+		collections.discounts,
+		{ promoCode: 1, beginsAt: 1 },
+		{ partialFilterExpression: { promoCode: { $exists: true } } }
+	],
 	[collections.personalInfo, { 'user.userId': 1 }],
 	[collections.personalInfo, { 'user.sessionId': 1 }],
 	[collections.personalInfo, { 'user.npub': 1 }],

--- a/src/lib/server/discount.ts
+++ b/src/lib/server/discount.ts
@@ -1,0 +1,374 @@
+import { isAlpha2CountryCode, type CountryAlpha2 } from '$lib/types/Country';
+import type { Discount, DiscountChannel, ProductCombination } from '$lib/types/Discount';
+import type { Product } from '$lib/types/Product';
+import type { UserIdentifier } from '$lib/types/UserIdentifier';
+import { error } from '@sveltejs/kit';
+import { ALL_PAYMENT_METHODS, type PaymentMethod } from './payment-methods';
+import { collections } from './database';
+
+const ALL_DISCOUNT_CHANNELS: readonly DiscountChannel[] = [
+	'web',
+	'web-pos',
+	'pos-touch',
+	'nostr-bot'
+];
+
+export interface DiscountContext {
+	userSubscriptionIds: string[];
+	promoCode?: string;
+	channel?: DiscountChannel;
+	paymentMethod?: PaymentMethod;
+	deliveryCountry?: CountryAlpha2;
+	billingCountry?: CountryAlpha2;
+	userContactAddresses: string[];
+	cartItems: Array<{ productId: string; quantity: number; tagIds?: string[] }>;
+	isLoggedIn: boolean;
+}
+
+/**
+ * Fetch all currently active percentage discounts (filtered by date in Mongo).
+ * freeProducts discounts stay subscription-only (Q4) and are NOT included.
+ */
+export async function getActivePercentageDiscounts(): Promise<Discount[]> {
+	const now = new Date();
+	return collections.discounts
+		.find({
+			beginsAt: { $lte: now },
+			mode: 'percentage',
+			$or: [{ endsAt: { $gt: now } }, { endsAt: null }]
+		})
+		.toArray();
+}
+
+/**
+ * Evaluate whether a discount's AND-conditions match the given context.
+ * Each non-empty condition must pass. Empty/undefined = "true" (no filter).
+ */
+export function evaluateDiscountConditions(discount: Discount, ctx: DiscountContext): boolean {
+	if (
+		discount.subscriptionIds?.length &&
+		!discount.subscriptionIds.some((id) => ctx.userSubscriptionIds.includes(id))
+	) {
+		return false;
+	}
+
+	if (discount.promoCode && discount.promoCode.toLowerCase() !== ctx.promoCode?.toLowerCase()) {
+		return false;
+	}
+
+	if (discount.channels?.length && ctx.channel && !discount.channels.includes(ctx.channel)) {
+		return false;
+	}
+
+	if (discount.paymentMethods?.length) {
+		if (!ctx.paymentMethod || !discount.paymentMethods.includes(ctx.paymentMethod)) {
+			return false;
+		}
+	}
+
+	// Delivery and billing country are independent AND-conditions
+	if (discount.deliveryCountry && discount.deliveryCountry !== ctx.deliveryCountry) {
+		return false;
+	}
+	if (discount.billingCountry && discount.billingCountry !== ctx.billingCountry) {
+		return false;
+	}
+
+	if (discount.contactAddresses?.length) {
+		if (!ctx.isLoggedIn) {
+			return false;
+		}
+		const normalizedRequired = discount.contactAddresses.map((a) => a.toLowerCase());
+		const normalizedUser = ctx.userContactAddresses.map((a) => a.toLowerCase());
+		const matchesAddress = normalizedRequired.some((addr) => {
+			// Wildcard `npub*` matches any Nostr-authenticated user.
+			// Reject lookalikes such as `npubcool@gmail.com` (no `npub1` prefix)
+			// or `npub1xyz@example.com` (contains `@`).
+			if (addr === 'npub*') {
+				return normalizedUser.some((u) => u.startsWith('npub1') && !u.includes('@'));
+			}
+			return normalizedUser.includes(addr);
+		});
+		if (!matchesAddress) {
+			return false;
+		}
+	}
+
+	if (discount.productCombinations?.length) {
+		const hasMatchingCombo = discount.productCombinations.some((combo) =>
+			combo.products.every((req) => {
+				const cartItem = ctx.cartItems.find((i) => i.productId === req.productId);
+				return cartItem && cartItem.quantity >= req.quantity;
+			})
+		);
+		if (!hasMatchingCombo) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+interface SelectBestItem {
+	product: Pick<Product, '_id' | 'price' | 'tagIds'>;
+	quantity: number;
+	customPrice?: { amount: number };
+}
+
+type PercentageDiscount = Discount & { mode: 'percentage' };
+
+interface DiscountSavings {
+	discount: PercentageDiscount;
+	discountByProduct: Map<string, number>;
+	totalSaved: number;
+}
+
+/**
+ * True if the discount targets a given product — either via wholeCatalog,
+ * an explicit productIds entry, or any of the requiredTagIds matching the
+ * product's tags. Single source of truth for application-side eligibility
+ * (the equivalent Mongo $or in fetchApplicableDiscount must stay in sync).
+ */
+export function discountTargetsProduct(
+	discount: Pick<Discount, 'wholeCatalog' | 'productIds' | 'requiredTagIds'>,
+	product: { _id: string; tagIds?: string[] }
+): boolean {
+	if (discount.wholeCatalog) {
+		return true;
+	}
+	if (discount.productIds.includes(product._id)) {
+		return true;
+	}
+	return discount.requiredTagIds?.some((t) => product.tagIds?.includes(t)) ?? false;
+}
+
+/** Compute savings for one discount applied to all eligible items in the cart */
+function computeDiscountSavings(
+	discount: PercentageDiscount,
+	items: SelectBestItem[]
+): DiscountSavings {
+	const eligibleItems = items.filter((item) =>
+		discountTargetsProduct(discount, { _id: item.product._id, tagIds: item.product.tagIds })
+	);
+
+	const discountByProduct = new Map(
+		eligibleItems.map((item) => [item.product._id, discount.percentage])
+	);
+
+	const totalSaved = eligibleItems.reduce((sum, item) => {
+		const basePrice = (item.customPrice?.amount ?? item.product.price.amount) * item.quantity;
+		return sum + basePrice * (discount.percentage / 100);
+	}, 0);
+
+	return { discount, discountByProduct, totalSaved };
+}
+
+/**
+ * Among all applicable discounts, pick the one with highest total savings across
+ * the entire order. Returns null if no discount applies. (one discount per order, no stacking)
+ */
+export function selectBestDiscount(
+	discounts: Discount[],
+	items: SelectBestItem[],
+	context: DiscountContext
+): { discount: Discount; discountByProduct: Map<string, number> } | null {
+	const best = discounts
+		.filter(
+			(d): d is PercentageDiscount =>
+				d.mode === 'percentage' && evaluateDiscountConditions(d, context)
+		)
+		.map((d) => computeDiscountSavings(d, items))
+		.filter((result) => result.totalSaved > 0)
+		.reduce<DiscountSavings | null>(
+			(currentBest, result) =>
+				!currentBest || result.totalSaved > currentBest.totalSaved ? result : currentBest,
+			null
+		);
+
+	return best ? { discount: best.discount, discountByProduct: best.discountByProduct } : null;
+}
+
+/**
+ * Determine the web sales channel for a user (web vs web-pos).
+ * /pos/touch and nostr-bot routes pass their channel literal directly.
+ */
+export function webChannelForUser(hasPosOptions?: boolean): DiscountChannel {
+	return hasPosOptions ? 'web-pos' : 'web';
+}
+
+/** Check if a string looks like an email (for treating login-as-email) */
+function looksLikeEmail(s?: string): boolean {
+	return !!s && /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s);
+}
+
+/** Mongo filter for active percentage discounts within their date window */
+function activePercentageDiscountFilter(now: Date) {
+	return {
+		beginsAt: { $lte: now },
+		mode: 'percentage' as const,
+		$or: [{ endsAt: { $gt: now } }, { endsAt: null }]
+	};
+}
+
+/**
+ * Find an active percentage discount matching the given promo code (case-insensitive).
+ * Returns null if no match.
+ */
+export async function findActivePromoDiscount(promoCode: string): Promise<Discount | null> {
+	return collections.discounts.findOne(
+		{
+			...activePercentageDiscountFilter(new Date()),
+			promoCode
+		},
+		{ collation: { locale: 'en', strength: 2 } }
+	);
+}
+
+/** True if there is at least one active percentage discount with a non-empty promo code */
+export async function hasAnyActivePromoDiscount(): Promise<boolean> {
+	const count = await collections.discounts.countDocuments(
+		{
+			...activePercentageDiscountFilter(new Date()),
+			promoCode: { $exists: true, $ne: '' }
+		},
+		{ limit: 1 }
+	);
+	return count > 0;
+}
+
+export interface DiscountConditionFields {
+	promoCode?: string;
+	channels?: DiscountChannel[];
+	paymentMethods?: PaymentMethod[];
+	deliveryCountry?: CountryAlpha2;
+	billingCountry?: CountryAlpha2;
+	contactAddresses?: string[];
+	requiredTagIds?: string[];
+	productCombinations?: ProductCombination[];
+	showBadge: boolean;
+	showExpirationBanner: boolean;
+}
+
+/** Parse product combinations from formData ("combinations[i][j][productId|quantity]") */
+export function parseProductCombinations(formData: FormData): ProductCombination[] {
+	// Parsing sparse nested form fields is naturally imperative
+	const raw: ProductCombination[] = [];
+	for (const [key, value] of formData.entries()) {
+		const match = key.match(/^combinations\[(\d+)]\[(\d+)]\[(productId|quantity)]$/);
+		if (!match) {
+			continue;
+		}
+		const comboIndex = Number(match[1]);
+		const productIndex = Number(match[2]);
+		const field = match[3];
+		if (!raw[comboIndex]) {
+			raw[comboIndex] = { products: [] };
+		}
+		if (!raw[comboIndex].products[productIndex]) {
+			raw[comboIndex].products[productIndex] = { productId: '', quantity: 1 };
+		}
+		if (field === 'productId') {
+			raw[comboIndex].products[productIndex].productId = String(value);
+		} else {
+			raw[comboIndex].products[productIndex].quantity = Number(value);
+		}
+	}
+	return raw
+		.filter((c) => c?.products?.length)
+		.map((c) => ({ products: c.products.filter((p) => p?.productId) }))
+		.filter((c) => c.products.length);
+}
+
+/**
+ * Parse all discount condition fields from a discount admin form.
+ * Throws 400 on invalid country/channel/paymentMethod values.
+ */
+export function parseDiscountConditionFields(formData: FormData): DiscountConditionFields {
+	const promoCode = String(formData.get('promoCode') ?? '').trim() || undefined;
+
+	const channelsRaw = formData.getAll('channels').map(String).filter(Boolean);
+	const invalidChannel = channelsRaw.find(
+		(c) => !ALL_DISCOUNT_CHANNELS.includes(c as DiscountChannel)
+	);
+	if (invalidChannel) {
+		throw error(400, `Invalid discount channel: ${invalidChannel}`);
+	}
+	const channels = channelsRaw.length ? (channelsRaw as DiscountChannel[]) : undefined;
+
+	const paymentMethodsRaw = formData.getAll('paymentMethods').map(String).filter(Boolean);
+	const invalidPaymentMethod = paymentMethodsRaw.find(
+		(pm) => !ALL_PAYMENT_METHODS.includes(pm as PaymentMethod)
+	);
+	if (invalidPaymentMethod) {
+		throw error(400, `Invalid payment method: ${invalidPaymentMethod}`);
+	}
+	const paymentMethods = paymentMethodsRaw.length
+		? (paymentMethodsRaw as PaymentMethod[])
+		: undefined;
+
+	const parseOptionalCountry = (field: string, label: string): CountryAlpha2 | undefined => {
+		const raw = String(formData.get(field) ?? '');
+		if (!raw || raw === 'none') {
+			return undefined;
+		}
+		if (!isAlpha2CountryCode(raw)) {
+			throw error(400, `Invalid ${label} country: ${raw}`);
+		}
+		return raw;
+	};
+	const deliveryCountry = parseOptionalCountry('deliveryCountry', 'delivery');
+	const billingCountry = parseOptionalCountry('billingCountry', 'billing');
+
+	const contactAddressesRaw = String(formData.get('contactAddresses') ?? '')
+		.split('\n')
+		.map((s) => s.trim())
+		.filter(Boolean);
+	const contactAddresses = contactAddressesRaw.length ? contactAddressesRaw : undefined;
+
+	const requiredTagIdsRaw = JSON.parse(String(formData.get('requiredTagIds') ?? '[]')) as Array<{
+		value: string;
+	}>;
+	const requiredTagIds = requiredTagIdsRaw.map((x) => x.value);
+
+	const productCombinations = parseProductCombinations(formData);
+
+	return {
+		...(promoCode && { promoCode }),
+		...(channels && { channels }),
+		...(paymentMethods && { paymentMethods }),
+		...(deliveryCountry && { deliveryCountry }),
+		...(billingCountry && { billingCountry }),
+		...(contactAddresses && { contactAddresses }),
+		...(requiredTagIds.length && { requiredTagIds }),
+		...(productCombinations.length && { productCombinations }),
+		showBadge: formData.get('showBadge') === 'on',
+		showExpirationBanner: formData.get('showExpirationBanner') === 'on'
+	};
+}
+
+/**
+ * True if the user has any form of authenticated identity (not just a form field).
+ * Covers: admin/POS users (userId), magic-link email sessions, Nostr sessions, SSO.
+ */
+export function isAuthenticated(user?: UserIdentifier | null): boolean {
+	if (!user) {
+		return false;
+	}
+	return !!(user.userId || user.email || user.npub || user.ssoIds?.length);
+}
+
+/** Collect all contact addresses (email, npub, phone) for a user identifier */
+export function collectUserAddresses(user?: UserIdentifier | null): string[] {
+	if (!user) {
+		return [];
+	}
+	const loginAsEmail = looksLikeEmail(user.userLogin) ? user.userLogin : undefined;
+	return [
+		...(user.email ? [user.email] : []),
+		...(user.secondaryEmails ?? []),
+		...(user.npub ? [user.npub] : []),
+		// Login can be an email for POS users
+		...(loginAsEmail ? [loginAsEmail] : []),
+		...(user.userRecoveryEmail ? [user.userRecoveryEmail] : [])
+	];
+}

--- a/src/lib/server/locks/handle-messages.ts
+++ b/src/lib/server/locks/handle-messages.ts
@@ -646,9 +646,15 @@ const commands: Record<
 				},
 				userVatCountry: undefined,
 				shippingAddress: null,
+				channel: 'nostr-bot',
 				cart
 			}).catch(async (e) => {
-				console.error(e);
+				console.error('Nostr-bot createOrder failed', {
+					senderNpub,
+					paymentMethod,
+					itemCount: items.length,
+					error: e
+				});
 				await send(e.message);
 				return;
 			});

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -54,6 +54,12 @@ import type { LanguageKey } from '$lib/translations';
 import { filterNullish } from '$lib/utils/fillterNullish';
 import { isPhoenixdConfigured } from './phoenixd';
 import type { Discount } from '$lib/types/Discount';
+import {
+	collectUserAddresses,
+	getActivePercentageDiscounts,
+	isAuthenticated,
+	selectBestDiscount
+} from './discount';
 import { groupByNonPartial } from '$lib/utils/group-by';
 import {
 	dayList,
@@ -661,6 +667,8 @@ export async function createOrder(
 		posSubtype?: string;
 		peopleCountFromPosUi?: number;
 		session?: ClientSession;
+		promoCode?: string;
+		channel?: import('$lib/types/Discount').DiscountChannel;
 	}
 ): Promise<Order['_id']> {
 	const npubAddress = params.notifications?.paymentStatus?.npub;
@@ -778,93 +786,34 @@ export async function createOrder(
 			paidUntil: { $gt: new Date() }
 		})
 		.toArray();
-	const discounts = paidSubs.length
-		? await collections.discounts
-				.aggregate<{
-					_id: Product['_id'] | null;
-					discountPercent: number;
-					subscriptionIds: Discount['subscriptionIds'];
-				}>([
-					{
-						$match: {
-							$or: [
-								{ wholeCatalog: true },
-								{ productIds: { $in: items.map((p) => p.product._id) } }
-							],
-							subscriptionIds: { $in: paidSubs.map((sub) => sub.productId) },
-							beginsAt: {
-								$lt: new Date()
-							},
-							mode: 'percentage',
-							$and: [
-								{
-									$or: [
-										{
-											endsAt: { $gt: new Date() }
-										},
-										{
-											endsAt: null
-										}
-									]
-								}
-							]
-						}
-					},
-					{
-						$sort: {
-							percentage: -1
-						}
-					},
-					{
-						$project: {
-							productIds: 1,
-							percentage: 1,
-							subscriptionIds: 1,
-							_id: 0
-						}
-					},
-					{
-						$unwind: {
-							path: '$productIds',
-							preserveNullAndEmptyArrays: true
-						}
-					},
-					{
-						$unwind: {
-							path: '$subscriptionIds',
-							preserveNullAndEmptyArrays: false
-						}
-					},
-					{
-						$group: {
-							_id: { $ifNull: ['$productIds', null] },
-							discountPercent: { $first: '$percentage' },
-							subscriptionIds: { $addToSet: '$subscriptionIds' }
-						}
-					}
-				])
-				.toArray()
+	// Pick the best applicable auto discount based on the order's conditions
+	const activeDiscounts = await getActivePercentageDiscounts();
+	const bestAutoDiscount = selectBestDiscount(activeDiscounts, items, {
+		userSubscriptionIds: paidSubs.map((s) => s.productId),
+		promoCode: params.promoCode,
+		channel: params.channel,
+		paymentMethod: paymentMethod ?? undefined,
+		deliveryCountry: params.userVatCountry,
+		billingCountry: params.billingAddress?.country,
+		userContactAddresses: collectUserAddresses(params.user),
+		cartItems: items.map((i) => ({
+			productId: i.product._id,
+			quantity: i.quantity,
+			tagIds: i.product.tagIds
+		})),
+		isLoggedIn: isAuthenticated(params.user)
+	});
+
+	const bestDiscountSubIds = bestAutoDiscount?.discount.subscriptionIds;
+	const usedSubIds = bestDiscountSubIds?.length
+		? paidSubs
+				.filter((sub) => bestDiscountSubIds.includes(sub.productId))
+				.map((sub) => sub.productId)
 		: [];
 
-	const wholeDiscount = discounts.find((d) => d._id === null)?.discountPercent;
-	const discountByProductId = new Map(
-		discounts
-			.filter((d) => d._id !== null)
-			.map((d) => [
-				d._id,
-				wholeDiscount !== undefined && wholeDiscount > d.discountPercent
-					? wholeDiscount
-					: d.discountPercent
-			])
-	);
-
-	const discountSubIds = new Set(discounts.flatMap((d) => d.subscriptionIds));
-	const usedSubIds = paidSubs
-		.filter((sub) => discountSubIds.has(sub.productId))
-		.map((sub) => sub.productId);
-
 	for (const item of items) {
-		item.discountPercentage ??= discountByProductId.get(item.product._id) ?? wholeDiscount;
+		// POS per-item manual discount has highest priority — preserve it via ??=
+		item.discountPercentage ??= bestAutoDiscount?.discountByProduct.get(item.product._id);
 	}
 	const priceInfo = computePriceInfo(items, {
 		bebopCountry: runtimeConfig.vatCountry,

--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -67,7 +67,8 @@ export function userIdentifier(locals: App.Locals): UserIdentifier {
 		userLogin: locals.user?.login,
 		userRoleId: locals.user?.roleId,
 		userAlias: locals.user?.alias,
-		userHasPosOptions: locals.user?.hasPosOptions
+		userHasPosOptions: locals.user?.hasPosOptions,
+		userRecoveryEmail: locals.user?.recoveryEmail
 	};
 }
 

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -44,7 +44,7 @@
 	"cart": {
 		"cta": {
 			"checkout": "Zur Kasse",
-			"discardItem": "Verwerfen",
+			"discardItem": "Entfernen",
 			"view": "Warenkorb anzeigen"
 		},
 		"discount": {
@@ -59,6 +59,15 @@
 			"validate": "Bestätigen",
 			"customPercentPlaceholder": "z. B. 15",
 			"customAmountPlaceholder": "z. B. 5,00"
+		},
+		"promo": {
+			"question": "Haben Sie einen Gutscheincode?",
+			"placeholder": "Gutscheincode",
+			"apply": "Anwenden",
+			"applied": "Code {code} wurde auf Ihren Warenkorb angewendet",
+			"remove": "Meinen Gutscheincode entfernen?",
+			"invalid": "Gutscheincode nicht gefunden oder nicht auf Ihre Bestellung anwendbar.",
+			"rateLimited": "Zu viele fehlgeschlagene Versuche. Bitte versuchen Sie es später erneut."
 		},
 		"empty": "Der Warenkorb ist leer",
 		"fillProductAlias": "Produkt-Alias ausfüllen",
@@ -906,6 +915,7 @@
 		},
 		"variationPriceLabel": "Variationspreis",
 		"vatExcluded": "Ohne MwSt.",
+		"vatExcludedEstimate": "Geschätzter Preis ohne Steuer",
 		"vatIncluded": "Geschätzter Preis einschließlich Steuer"
 	},
 	"schedule": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -44,7 +44,7 @@
 	"cart": {
 		"cta": {
 			"checkout": "Checkout",
-			"discardItem": "Discard",
+			"discardItem": "Remove",
 			"view": "View cart"
 		},
 		"discount": {
@@ -59,6 +59,15 @@
 			"validate": "Validate",
 			"customPercentPlaceholder": "e.g. 15",
 			"customAmountPlaceholder": "e.g. 5.00"
+		},
+		"promo": {
+			"question": "Got a promo code?",
+			"placeholder": "Promo code",
+			"apply": "Apply",
+			"applied": "Code {code} applied to your cart",
+			"remove": "Remove my promo code?",
+			"invalid": "Promo code not found or not applicable to your order.",
+			"rateLimited": "Too many failed promo code attempts. Please try again later."
 		},
 		"empty": "Cart is empty",
 		"fillProductAlias": "Fill product alias",
@@ -913,6 +922,7 @@
 		},
 		"variationPriceLabel": "Variation Price",
 		"vatExcluded": "VAT excluded",
+		"vatExcludedEstimate": "Estimated price excluding tax",
 		"vatIncluded": "Estimated price including tax"
 	},
 	"schedule": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -44,7 +44,7 @@
 	"cart": {
 		"cta": {
 			"checkout": "Pagar",
-			"discardItem": "Descartar",
+			"discardItem": "Quitar",
 			"view": "Al carrito"
 		},
 		"discount": {
@@ -59,6 +59,15 @@
 			"validate": "Validar",
 			"customPercentPlaceholder": "p. ej. 15",
 			"customAmountPlaceholder": "p. ej. 5.00"
+		},
+		"promo": {
+			"question": "¿Tenés un código promocional?",
+			"placeholder": "Código promocional",
+			"apply": "Aplicar",
+			"applied": "Código {code} aplicado a tu carrito",
+			"remove": "¿Remover mi código promocional?",
+			"invalid": "Código promocional no encontrado o no aplicable a tu pedido.",
+			"rateLimited": "Demasiados intentos fallidos. Por favor intentá más tarde."
 		},
 		"empty": "La lista de compras está vacía",
 		"fillProductAlias": "Rellenar alias de producto",
@@ -906,6 +915,7 @@
 		},
 		"variationPriceLabel": "Precio de variación",
 		"vatExcluded": "No incluye IVA",
+		"vatExcludedEstimate": "Precio estimado sin impuestos",
 		"vatIncluded": "Precio estimado con IVA incluido"
 	},
 	"schedule": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -44,7 +44,7 @@
 	"cart": {
 		"cta": {
 			"checkout": "Commander",
-			"discardItem": "Supprimer",
+			"discardItem": "Retirer",
 			"view": "Voir le panier"
 		},
 		"discount": {
@@ -59,6 +59,15 @@
 			"validate": "Valider",
 			"customPercentPlaceholder": "par ex. 15",
 			"customAmountPlaceholder": "par ex. 5,00"
+		},
+		"promo": {
+			"question": "Un code promotionnel ?",
+			"placeholder": "Code promotionnel",
+			"apply": "Appliquer",
+			"applied": "Code {code} appliqué à votre panier",
+			"remove": "Supprimer mon code promotionnel ?",
+			"invalid": "Code promotionnel inexistant ou non-applicable à votre commande.",
+			"rateLimited": "Trop de tentatives échouées. Veuillez réessayer plus tard."
 		},
 		"empty": "Le panier est vide",
 		"fillProductAlias": "Remplir l'alias du produit",
@@ -906,6 +915,7 @@
 		},
 		"variationPriceLabel": "Variation de prix",
 		"vatExcluded": "Hors TVA",
+		"vatExcludedEstimate": "Prix estimé hors TVA",
 		"vatIncluded": "Prix TTC estimé"
 	},
 	"schedule": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -44,7 +44,7 @@
 	"cart": {
 		"cta": {
 			"checkout": "Pagamento",
-			"discardItem": "Togli",
+			"discardItem": "Rimuovi",
 			"view": "Guarda il carrello"
 		},
 		"discount": {
@@ -59,6 +59,15 @@
 			"validate": "Conferma",
 			"customPercentPlaceholder": "es. 15",
 			"customAmountPlaceholder": "es. 5,00"
+		},
+		"promo": {
+			"question": "Hai un codice promozionale?",
+			"placeholder": "Codice promozionale",
+			"apply": "Applica",
+			"applied": "Codice {code} applicato al tuo carrello",
+			"remove": "Rimuovere il mio codice promozionale?",
+			"invalid": "Codice promozionale non trovato o non applicabile al tuo ordine.",
+			"rateLimited": "Troppi tentativi falliti. Riprova più tardi."
 		},
 		"empty": "Il cartello è vuoto",
 		"fillProductAlias": "Compila l'alias del prodotto",
@@ -906,6 +915,7 @@
 		},
 		"variationPriceLabel": "Prezzo di variazione",
 		"vatExcluded": "IVA esclusa",
+		"vatExcludedEstimate": "Prezzo stimato IVA esclusa",
 		"vatIncluded": "Prezzo stimato inclusa l'imposta"
 	},
 	"schedule": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -44,7 +44,7 @@
 	"cart": {
 		"cta": {
 			"checkout": "Uitchecken",
-			"discardItem": "Weggooien",
+			"discardItem": "Verwijderen",
 			"view": "Bekijk winkelwagen"
 		},
 		"discount": {
@@ -59,6 +59,15 @@
 			"validate": "Bevestigen",
 			"customPercentPlaceholder": "bijv. 15",
 			"customAmountPlaceholder": "bijv. 5,00"
+		},
+		"promo": {
+			"question": "Heb je een promocode?",
+			"placeholder": "Promocode",
+			"apply": "Toepassen",
+			"applied": "Code {code} toegepast op je winkelwagen",
+			"remove": "Mijn promocode verwijderen?",
+			"invalid": "Promocode niet gevonden of niet toepasbaar op je bestelling.",
+			"rateLimited": "Te veel mislukte pogingen. Probeer het later opnieuw."
 		},
 		"empty": "Winkelwagen is leeg",
 		"fillProductAlias": "Productalias invullen",
@@ -906,6 +915,7 @@
 		},
 		"variationPriceLabel": "Variatie Prijs",
 		"vatExcluded": "Exclusief BTW",
+		"vatExcludedEstimate": "Geschatte prijs excl. btw",
 		"vatIncluded": "Geschatte prijs inclusief belasting"
 	},
 	"schedule": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -44,7 +44,7 @@
 	"cart": {
 		"cta": {
 			"checkout": "Finalizar compra",
-			"discardItem": "Descartar",
+			"discardItem": "Remover",
 			"view": "Ver carrinho"
 		},
 		"discount": {
@@ -59,6 +59,15 @@
 			"validate": "Confirmar",
 			"customPercentPlaceholder": "ex. 15",
 			"customAmountPlaceholder": "ex. 5,00"
+		},
+		"promo": {
+			"question": "Tem um código promocional?",
+			"placeholder": "Código promocional",
+			"apply": "Aplicar",
+			"applied": "Código {code} aplicado ao seu carrinho",
+			"remove": "Remover meu código promocional?",
+			"invalid": "Código promocional não encontrado ou não aplicável ao seu pedido.",
+			"rateLimited": "Muitas tentativas falhadas. Por favor, tente novamente mais tarde."
 		},
 		"empty": "O carrinho está vazio",
 		"fillProductAlias": "Preencher o alias do produto",
@@ -906,6 +915,7 @@
 		},
 		"variationPriceLabel": "Preço da Variação",
 		"vatExcluded": "IVA excluído",
+		"vatExcludedEstimate": "Preço estimado sem impostos",
 		"vatIncluded": "Preço estimado, incluindo imposto"
 	},
 	"schedule": {

--- a/src/lib/types/Cart.ts
+++ b/src/lib/types/Cart.ts
@@ -33,6 +33,7 @@ export interface Cart extends Timestamps {
 		internalNote?: { value: string; updatedAt: Date; updatedById?: User['_id'] };
 		chosenVariations?: Record<string, string>;
 	}>;
+	promoCode?: string;
 	orderTabSlug?: string;
 	orderTabId?: ObjectId;
 	splitMode?: 'items' | 'shares';

--- a/src/lib/types/Discount.ts
+++ b/src/lib/types/Discount.ts
@@ -1,11 +1,40 @@
+import type { PaymentMethod } from '$lib/server/payment-methods';
+import type { CountryAlpha2 } from './Country';
 import type { Product } from './Product';
 import type { Timestamps } from './Timestamps';
+
+export type DiscountChannel = 'web' | 'web-pos' | 'pos-touch' | 'nostr-bot';
+
+export interface ProductCombination {
+	products: Array<{ productId: string; quantity: number }>;
+}
 
 export type Discount = Timestamps & {
 	_id: string;
 	name: string;
-	subscriptionIds: string[];
-	/* If empty, works on all products */
+	/** If set, user must have at least one of these active subscriptions */
+	subscriptionIds?: string[];
+	/** Promo code (case-insensitive match). Percentage mode only */
+	promoCode?: string;
+	/** Sales channels where this discount applies */
+	channels?: DiscountChannel[];
+	/** Discount targets products carrying any of these tags (OR with productIds) */
+	requiredTagIds?: string[];
+	/** Payment methods required for discount */
+	paymentMethods?: PaymentMethod[];
+	/** Delivery country required */
+	deliveryCountry?: CountryAlpha2;
+	/** Billing country required (independent AND-condition) */
+	billingCountry?: CountryAlpha2;
+	/** Contact addresses (email, npub, phone) — logged-in users only */
+	contactAddresses?: string[];
+	/** Product combinations: OR between combos, AND within each */
+	productCombinations?: ProductCombination[];
+	/** Show the "-X%" badge on product page (default: true) */
+	showBadge?: boolean;
+	/** Show "X% off for Y hours" expiration reminder on product page */
+	showExpirationBanner?: boolean;
+	/** If empty, works on all products */
 	productIds: Product['_id'][];
 	wholeCatalog: boolean;
 	beginsAt: Date;

--- a/src/lib/types/UserIdentifier.ts
+++ b/src/lib/types/UserIdentifier.ts
@@ -15,4 +15,5 @@ export interface UserIdentifier {
 	userRoleId?: string;
 	userAlias?: string;
 	userHasPosOptions?: boolean;
+	userRecoveryEmail?: string;
 }

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -22,6 +22,13 @@ import type { Cart } from '$lib/types/Cart';
 import { computeDeliveryFees, computePriceInfo } from '$lib/cart';
 import { UNDERLYING_CURRENCY } from '$lib/types/Currency';
 import { isAlpha2CountryCode } from '$lib/types/Country';
+import {
+	collectUserAddresses,
+	getActivePercentageDiscounts,
+	isAuthenticated,
+	selectBestDiscount,
+	webChannelForUser
+} from '$lib/server/discount';
 
 async function getCartAndRemoveSomeItems(userIdentifier: UserIdentifier): Promise<Cart> {
 	const cartInDb = await getCartFromDb({ user: userIdentifier });
@@ -173,79 +180,41 @@ export async function load(params) {
 			: []
 	]);
 
-	const discounts = paidSubs.length
-		? await collections.discounts
-				.aggregate<{
-					_id: Product['_id'] | null;
-					discountPercent: number;
-				}>([
-					{
-						$match: {
-							$or: [
-								{ wholeCatalog: true },
-								{ productIds: { $in: cart.items.map((p) => p.productId) } }
-							],
-							subscriptionIds: { $in: paidSubs.map((sub) => sub.productId) },
-							beginsAt: {
-								$lt: new Date()
-							},
-							mode: 'percentage',
-							$and: [
-								{
-									$or: [
-										{
-											endsAt: { $gt: new Date() }
-										},
-										{
-											endsAt: null
-										}
-									]
-								}
-							]
-						}
-					},
-					{
-						$sort: {
-							percentage: -1
-						}
-					},
-					{
-						$project: {
-							productIds: 1,
-							percentage: 1,
-							_id: 0
-						}
-					},
-					{
-						$unwind: {
-							path: '$productIds',
-							preserveNullAndEmptyArrays: true
-						}
-					},
-					{
-						$group: {
-							_id: { $ifNull: ['$productIds', null] },
-							discountPercent: { $first: '$percentage' }
-						}
-					}
-				])
-				.toArray()
-		: [];
-
 	const productById = new Map(products.map((p) => [p._id, p]));
 	const productPicturesById = new Map(productPictures.map((p) => [p.productId, p]));
 	const digitalFilesByProductId = groupBy(digitalFiles, (df) => df.productId);
-	const wholeDiscount = discounts.find((d) => d._id === null)?.discountPercent;
-	const discountByProductId = new Map(
-		discounts
-			.filter((d) => d._id !== null)
-			.map((d) => [
-				d._id,
-				wholeDiscount !== undefined && wholeDiscount > d.discountPercent
-					? wholeDiscount
-					: d.discountPercent
-			])
-	);
+
+	// Pick the best applicable auto discount based on current cart conditions
+	const activeDiscounts = cart.items.length ? await getActivePercentageDiscounts() : [];
+	const bestAutoDiscount = activeDiscounts.length
+		? selectBestDiscount(
+				activeDiscounts,
+				cart.items
+					.map((item) => {
+						const p = productById.get(item.productId);
+						return p
+							? {
+									product: p,
+									quantity: item.quantity,
+									...(item.customPrice && { customPrice: item.customPrice })
+							  }
+							: undefined;
+					})
+					.filter((x) => x !== undefined),
+				{
+					userSubscriptionIds: paidSubs.map((s) => s.productId),
+					promoCode: cart.promoCode,
+					channel: webChannelForUser(params.locals.user?.hasPosOptions),
+					userContactAddresses: collectUserAddresses(user),
+					cartItems: cart.items.map((item) => ({
+						productId: item.productId,
+						quantity: item.quantity,
+						tagIds: productById.get(item.productId)?.tagIds
+					})),
+					isLoggedIn: isAuthenticated(user)
+				}
+		  )
+		: null;
 
 	const cartItems = cart.items
 		.map((item) => {
@@ -274,9 +243,9 @@ export async function load(params) {
 								updatedAt: item.internalNote?.updatedAt
 						  }
 						: undefined,
-				// Discount priority: POS per-item (0) > subscription (1) > whole catalog (2)
+				// Manual discount (set on cart by POS staff) overrides automatic discount
 				discountPercentage:
-					item.discountPercentage ?? discountByProductId.get(item.productId) ?? wholeDiscount,
+					item.discountPercentage ?? bestAutoDiscount?.discountByProduct.get(item.productId),
 				discountJustification:
 					item.discountJustification && params.locals.user?.hasPosOptions
 						? item.discountJustification
@@ -393,7 +362,8 @@ export async function load(params) {
 		cart: {
 			items: cartItems,
 			freeProductUnits: cartFreeProductUnits,
-			priceInfo: cartPriceInfo
+			priceInfo: cartPriceInfo,
+			promoCode: cart.promoCode
 		},
 		confirmationBlocksThresholds: runtimeConfig.confirmationBlocksThresholds,
 		cartMaxSeparateItems: runtimeConfig.cartMaxSeparateItems,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.server.ts
@@ -1,8 +1,13 @@
 import { adminPrefix } from '$lib/server/admin.js';
 import { collections } from '$lib/server/database.js';
 import { MAX_NAME_LIMIT, type Product } from '$lib/types/Product.js';
+import type { Tag } from '$lib/types/Tag';
+import { COUNTRY_ALPHA2S, type CountryAlpha2 } from '$lib/types/Country';
 import { error, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
+import { parseDiscountConditionFields } from '$lib/server/discount';
+import type { UpdateFilter } from 'mongodb';
+import type { Discount } from '$lib/types/Discount';
 
 export async function load({ params }) {
 	const discount = await collections.discounts.findOne({
@@ -13,26 +18,34 @@ export async function load({ params }) {
 		throw error(404, 'discount not found');
 	}
 
-	const beginsAt = discount.beginsAt?.toJSON().slice(0, 10);
-	const endsAt = discount.endsAt?.toJSON().slice(0, 10) ?? '';
-	const subscriptions = await collections.products
-		.find({ type: 'subscription' })
-		.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
-		.toArray();
-	const products = await collections.products
-		.find({
-			type: { $ne: 'subscription' },
-			payWhatYouWant: { $exists: true, $eq: false },
-			free: { $exists: true, $eq: false }
-		})
-		.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
-		.toArray();
+	const beginsAt = discount.beginsAt?.toJSON().slice(0, 16);
+	const endsAt = discount.endsAt?.toJSON().slice(0, 16) ?? '';
+	const [subscriptions, products, tags] = await Promise.all([
+		collections.products
+			.find({ type: 'subscription' })
+			.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
+			.toArray(),
+		collections.products
+			.find({
+				type: { $ne: 'subscription' },
+				payWhatYouWant: { $exists: true, $eq: false },
+				free: { $exists: true, $eq: false }
+			})
+			.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
+			.toArray(),
+		collections.tags
+			.find({ productTagging: true })
+			.project<Pick<Tag, '_id' | 'name'>>({ _id: 1, name: 1 })
+			.toArray()
+	]);
 	return {
 		discount,
 		beginsAt,
 		endsAt,
 		products,
-		subscriptions
+		subscriptions,
+		tags,
+		countries: [...COUNTRY_ALPHA2S] as CountryAlpha2[]
 	};
 }
 
@@ -47,17 +60,16 @@ export const actions = {
 		}
 		const formData = await request.formData();
 
-		const quantityPerProduct: Record<string, number> = {};
-		for (const [key, value] of formData.entries()) {
-			const match = key.match(/^quantityPerProduct\[(.+?)\]$/);
-			if (match) {
-				quantityPerProduct[match[1]] = Number(value);
-			}
-		}
+		const quantityPerProduct: Record<string, number> = Object.fromEntries(
+			[...formData.entries()].flatMap(([key, value]) => {
+				const match = key.match(/^quantityPerProduct\[(.+?)\]$/);
+				return match ? [[match[1], Number(value)]] : [];
+			})
+		);
 
 		const base = z.object({
 			name: z.string().min(1).max(MAX_NAME_LIMIT),
-			subscriptionIds: z.string().array().min(1),
+			subscriptionIds: z.string().array(), // was .min(1), now optional
 			productIds: z.string().array(),
 			wholeCatalog: z.boolean({ coerce: true }).default(false),
 			beginsAt: z.date({ coerce: true }),
@@ -77,7 +89,7 @@ export const actions = {
 
 		const baseData = base.parse({
 			name: formData.get('name'),
-			subscriptionIds: JSON.parse(String(formData.get('subscriptionIds'))).map(
+			subscriptionIds: JSON.parse(String(formData.get('subscriptionIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),
 			productIds: JSON.parse(String(formData.get('productIds') ?? '[]')).map(
@@ -88,6 +100,30 @@ export const actions = {
 			endsAt: formData.get('endsAt') || null
 		});
 
+		// Parse condition fields (validates payment methods, country, channels)
+		const conditionFields =
+			discount.mode === 'percentage' ? parseDiscountConditionFields(formData) : null;
+
+		// Build $unset for fields the admin cleared (so DB reflects current form state)
+		const OPTIONAL_CONDITION_KEYS = [
+			'promoCode',
+			'channels',
+			'paymentMethods',
+			'deliveryCountry',
+			'billingCountry',
+			'contactAddresses',
+			'requiredTagIds',
+			'productCombinations'
+		] as const;
+		const conditionFieldsToUnset: Partial<Record<(typeof OPTIONAL_CONDITION_KEYS)[number], ''>> =
+			conditionFields
+				? Object.fromEntries(
+						OPTIONAL_CONDITION_KEYS.filter((key) => conditionFields[key] === undefined).map(
+							(key) => [key, '']
+						)
+				  )
+				: {};
+
 		const timestamp = { createdAt: new Date(), updatedAt: new Date() };
 
 		if (discount.mode === 'percentage') {
@@ -97,19 +133,18 @@ export const actions = {
 				throw error(400, 'Invalid or missing percentage');
 			}
 
-			const percentageDiscount = {
-				...baseData,
-				...timestamp,
-				percentage: parsed.data.percentage
-			};
-			await collections.discounts.updateOne(
-				{
-					_id: discount._id
-				},
-				{
-					$set: percentageDiscount
+			const update: UpdateFilter<Discount> = {
+				$set: {
+					...baseData,
+					...conditionFields,
+					...timestamp,
+					percentage: parsed.data.percentage
 				}
-			);
+			};
+			if (Object.keys(conditionFieldsToUnset).length > 0) {
+				update.$unset = conditionFieldsToUnset;
+			}
+			await collections.discounts.updateOne({ _id: discount._id }, update);
 		}
 
 		if (discount.mode === 'freeProducts') {
@@ -157,31 +192,35 @@ export const actions = {
 				cancelledAt: { $exists: false }
 			})
 			.toArray();
-		for (const subscriptionId of discount.subscriptionIds) {
-			const toUpdate = subscriptionsToUpdate.find(
-				(subscription) => subscription.productId === subscriptionId
-			);
-			if (!toUpdate) {
-				continue;
-			}
-			const updatedFreeProductsById = structuredClone(toUpdate.freeProductsById ?? {});
-			for (const [productId, quantity] of Object.entries(discount.quantityPerProduct)) {
-				if (!updatedFreeProductsById[productId]) {
-					updatedFreeProductsById[productId] = { total: quantity, available: quantity, used: 0 };
-				}
-			}
-			await collections.paidSubscriptions.updateOne(
-				{ _id: toUpdate._id },
-				{
-					$set: {
-						updatedAt: new Date(),
-						...(Object.keys(updatedFreeProductsById).length !== 0 && {
-							freeProductsById: updatedFreeProductsById
-						})
-					}
-				}
-			);
-		}
+		const newFreeProducts = Object.entries(discount.quantityPerProduct).map(
+			([productId, quantity]) =>
+				[productId, { total: quantity, available: quantity, used: 0 }] as const
+		);
+		await Promise.all(
+			(discount.subscriptionIds ?? [])
+				.map((subscriptionId) =>
+					subscriptionsToUpdate.find((sub) => sub.productId === subscriptionId)
+				)
+				.filter((sub): sub is NonNullable<typeof sub> => sub !== undefined)
+				.map(async (toUpdate) => {
+					const existingFreeProducts = toUpdate.freeProductsById ?? {};
+					const merged = {
+						...existingFreeProducts,
+						...Object.fromEntries(
+							newFreeProducts.filter(([productId]) => !existingFreeProducts[productId])
+						)
+					};
+					await collections.paidSubscriptions.updateOne(
+						{ _id: toUpdate._id },
+						{
+							$set: {
+								updatedAt: new Date(),
+								...(Object.keys(merged).length !== 0 && { freeProductsById: merged })
+							}
+						}
+					);
+				})
+		);
 	},
 
 	delete: async function ({ params }) {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import { useI18n } from '$lib/i18n';
 	import { MAX_NAME_LIMIT } from '$lib/types/Product';
 	import { upperFirst } from '$lib/utils/upperFirst.js';
 	import { MultiSelect } from 'svelte-multiselect';
+	import ProductCombinationRow from '$lib/components/ProductCombinationRow.svelte';
 
 	export let data;
+	const { countryName } = useI18n();
+	$: sortedCountries = [...data.countries].sort((a, b) =>
+		countryName(a).localeCompare(countryName(b))
+	);
 
 	let beginsAt = data.beginsAt;
 	let endsAt = data.endsAt;
@@ -18,6 +24,7 @@
 		productFree = Object.keys(data.discount.quantityPerProduct ?? {});
 	}
 	let productFreeLine = productFree.length;
+	let combinations = data.discount.productCombinations ?? [];
 	function checkForm(event: SubmitEvent) {
 		if (endsAt && endsAt < beginsAt) {
 			endsAtElement.setCustomValidity('End date must be after beginning date');
@@ -92,11 +99,38 @@
 		</label>
 	{/if}
 
+	{#if mode === 'percentage'}
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				name="showBadge"
+				class="form-checkbox"
+				checked={data.discount.showBadge !== false}
+			/>
+			Show discount badge (-X%) on product page
+		</label>
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				name="showExpirationBanner"
+				class="form-checkbox"
+				checked={data.discount.showExpirationBanner}
+			/>
+			Show discount expiration reminder on product page
+		</label>
+	{/if}
+
 	<div class="flex flex-wrap gap-4">
 		<label class="form-label">
 			Beginning date
 
-			<input class="form-input" type="date" name="beginsAt" bind:value={beginsAt} required />
+			<input
+				class="form-input"
+				type="datetime-local"
+				name="beginsAt"
+				bind:value={beginsAt}
+				required
+			/>
 		</label>
 	</div>
 
@@ -106,7 +140,7 @@
 
 			<input
 				class="form-input"
-				type="date"
+				type="datetime-local"
 				name="endsAt"
 				bind:value={endsAt}
 				bind:this={endsAtElement}
@@ -115,19 +149,150 @@
 		</label>
 	</div>
 
+	{#if mode === 'percentage'}
+		<fieldset class="form-label">
+			<legend>Discount channel application</legend>
+			{#each [{ value: 'web', label: 'Web' }, { value: 'web-pos', label: 'Web with PoS privilege (/cart)' }, { value: 'pos-touch', label: 'Bar-restaurant PoS (/pos/touch)' }, { value: 'nostr-bot', label: 'Nostr-bot' }] as channel}
+				<label class="checkbox-label">
+					<input
+						type="checkbox"
+						name="channels"
+						value={channel.value}
+						class="form-checkbox"
+						checked={data.discount.channels?.some((c) => c === channel.value)}
+					/>
+					{channel.label}
+				</label>
+			{/each}
+		</fieldset>
+	{/if}
+
 	<!-- svelte-ignore a11y-label-has-associated-control -->
 	<label class="form-label"
-		>Required Subscription
+		>Required Subscription (optional)
 		<MultiSelect
 			--sms-options-bg="var(--body-mainPlan-backgroundColor)"
 			name="subscriptionIds"
 			options={subscriptions.map((p) => ({ label: p.name, value: p._id }))}
-			selected={data.discount.subscriptionIds.map((p) => ({
+			selected={(data.discount.subscriptionIds ?? []).map((p) => ({
 				value: p,
 				label: subscriptions.find((p2) => p2._id === p)?.name ?? p
 			}))}
 		/>
 	</label>
+
+	{#if mode === 'percentage'}
+		<label class="form-label">
+			Required code (optional)
+			<input
+				class="form-input"
+				type="text"
+				name="promoCode"
+				maxlength="50"
+				value={data.discount.promoCode ?? ''}
+				placeholder="Enter promocode chain"
+			/>
+			<span class="text-sm text-gray-500"
+				>Tip: use 8+ characters mixing letters, numbers and special characters (e.g. SPRING_2026X4!)
+				— short codes are easy to brute-force.</span
+			>
+		</label>
+
+		<label class="form-label">
+			Required delivery country (optional)
+			<select name="deliveryCountry" class="form-input">
+				<option value="none">None</option>
+				{#each sortedCountries as country}
+					<option value={country} selected={data.discount.deliveryCountry === country}
+						>{countryName(country)}</option
+					>
+				{/each}
+			</select>
+		</label>
+
+		<label class="form-label">
+			Required billing country (optional)
+			<select name="billingCountry" class="form-input">
+				<option value="none">None</option>
+				{#each sortedCountries as country}
+					<option value={country} selected={data.discount.billingCountry === country}
+						>{countryName(country)}</option
+					>
+				{/each}
+			</select>
+		</label>
+
+		<fieldset class="form-label">
+			<legend>Payment method</legend>
+			{#each ['lightning', 'bank-transfer', 'point-of-sale', 'card', 'bitcoin', 'paypal'] as pm}
+				<label class="checkbox-label">
+					<input
+						type="checkbox"
+						name="paymentMethods"
+						value={pm}
+						class="form-checkbox"
+						checked={data.discount.paymentMethods?.some((m) => m === pm)}
+					/>
+					{pm}{pm === 'point-of-sale' ? ' (only for users with POS role)' : ''}
+				</label>
+			{/each}
+		</fieldset>
+
+		<label class="form-label">
+			Required contact address (optional)
+			<textarea
+				class="form-input"
+				name="contactAddresses"
+				rows="4"
+				placeholder="One address per line (email, npub, phone...)"
+				>{(data.discount.contactAddresses ?? []).join('\n')}</textarea
+			>
+			<span class="text-sm text-gray-500"
+				>Tip: use <code>npub*</code> to grant the discount to all Nostr-authenticated users.</span
+			>
+		</label>
+
+		<fieldset class="form-label">
+			<legend>Required product combination (optional)</legend>
+			{#each combinations as combo, comboIdx}
+				<div class="border rounded p-2 mb-2">
+					<h4 class="font-semibold">Combination {comboIdx + 1} Product</h4>
+					{#each combo.products as product, prodIdx}
+						<ProductCombinationRow
+							{product}
+							{comboIdx}
+							{prodIdx}
+							{availableProductList}
+							on:change={() => (combinations = combinations)}
+							on:remove={() => {
+								combo.products = combo.products.filter((_, idx) => idx !== prodIdx);
+								combinations = combinations;
+							}}
+						/>
+					{/each}
+					<button
+						type="button"
+						class="text-sm underline"
+						on:click={() => {
+							combo.products = [...combo.products, { productId: '', quantity: 1 }];
+							combinations = combinations;
+						}}
+					>
+						+ Add product to combination
+					</button>
+				</div>
+			{/each}
+			<button
+				type="button"
+				class="btn body-mainCTA self-start"
+				on:click={() => {
+					combinations = [...combinations, { products: [{ productId: '', quantity: 1 }] }];
+				}}
+			>
+				Add combination
+			</button>
+		</fieldset>
+	{/if}
 	{#if mode === 'percentage'}
 		<label class="checkbox-label">
 			<input
@@ -152,6 +317,21 @@
 					}))}
 				/>
 			</label>
+			{#if data.tags.length}
+				<!-- svelte-ignore a11y-label-has-associated-control -->
+				<label class="form-label"
+					>Products with this tag (optional)
+					<MultiSelect
+						--sms-options-bg="var(--body-mainPlan-backgroundColor)"
+						name="requiredTagIds"
+						options={data.tags.map((t) => ({ label: t.name, value: t._id }))}
+						selected={(data.discount.requiredTagIds ?? []).map((id) => ({
+							value: id,
+							label: data.tags.find((t) => t._id === id)?.name ?? id
+						}))}
+					/>
+				</label>
+			{/if}
 		{/if}
 	{/if}
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.server.ts
@@ -6,25 +6,35 @@ import { MAX_NAME_LIMIT, type Product } from '$lib/types/Product';
 import { generateId } from '$lib/utils/generateId';
 import { adminPrefix } from '$lib/server/admin';
 import type { Discount } from '$lib/types/Discount';
+import type { Tag } from '$lib/types/Tag';
+import { COUNTRY_ALPHA2S, type CountryAlpha2 } from '$lib/types/Country';
+import { parseDiscountConditionFields } from '$lib/server/discount';
 
 export const load = async () => {
-	const subscriptions = await collections.products
-		.find({ type: 'subscription' })
-		.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
-		.toArray();
-
-	const products = await collections.products
-		.find({
-			type: { $ne: 'subscription' },
-			payWhatYouWant: { $ne: true },
-			free: { $ne: true }
-		})
-		.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
-		.toArray();
+	const [subscriptions, products, tags] = await Promise.all([
+		collections.products
+			.find({ type: 'subscription' })
+			.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
+			.toArray(),
+		collections.products
+			.find({
+				type: { $ne: 'subscription' },
+				payWhatYouWant: { $ne: true },
+				free: { $ne: true }
+			})
+			.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
+			.toArray(),
+		collections.tags
+			.find({ productTagging: true })
+			.project<Pick<Tag, '_id' | 'name'>>({ _id: 1, name: 1 })
+			.toArray()
+	]);
 
 	return {
 		products,
-		subscriptions
+		subscriptions,
+		tags,
+		countries: [...COUNTRY_ALPHA2S] as CountryAlpha2[]
 	};
 };
 
@@ -32,17 +42,16 @@ export const actions: Actions = {
 	default: async function ({ request }) {
 		const formData = await request.formData();
 
-		const quantityPerProduct: Record<string, number> = {};
-		for (const [key, value] of formData.entries()) {
-			const match = key.match(/^quantityPerProduct\[(.+?)\]$/);
-			if (match) {
-				quantityPerProduct[match[1]] = Number(value);
-			}
-		}
+		const quantityPerProduct: Record<string, number> = Object.fromEntries(
+			[...formData.entries()].flatMap(([key, value]) => {
+				const match = key.match(/^quantityPerProduct\[(.+?)\]$/);
+				return match ? [[match[1], Number(value)]] : [];
+			})
+		);
 
 		const base = z.object({
 			name: z.string().min(1).max(MAX_NAME_LIMIT),
-			subscriptionIds: z.string().array().min(1),
+			subscriptionIds: z.string().array(), // was .min(1), now optional
 			productIds: z.string().array(),
 			wholeCatalog: z.boolean({ coerce: true }).default(false),
 			beginsAt: z.date({ coerce: true }),
@@ -63,7 +72,7 @@ export const actions: Actions = {
 
 		const baseData = base.parse({
 			name: formData.get('name'),
-			subscriptionIds: JSON.parse(String(formData.get('subscriptionIds'))).map(
+			subscriptionIds: JSON.parse(String(formData.get('subscriptionIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),
 			productIds: JSON.parse(String(formData.get('productIds') ?? '[]')).map(
@@ -74,6 +83,10 @@ export const actions: Actions = {
 			endsAt: formData.get('endsAt') || null,
 			mode: formData.get('mode')
 		});
+
+		// Parse condition fields (validates payment methods, country, channels)
+		const conditionFields =
+			baseData.mode === 'percentage' ? parseDiscountConditionFields(formData) : {};
 
 		const slug = generateId(baseData.name, true);
 		const timestamp = { createdAt: new Date(), updatedAt: new Date() };
@@ -88,6 +101,7 @@ export const actions: Actions = {
 			const percentageDiscount: Extract<Discount, { mode: 'percentage' }> = {
 				_id: slug,
 				...baseData,
+				...conditionFields,
 				...timestamp,
 				mode: 'percentage',
 				percentage: parsed.data.percentage

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import { useI18n } from '$lib/i18n';
 	import { MAX_NAME_LIMIT } from '$lib/types/Product';
 	import { upperFirst } from '$lib/utils/upperFirst.js';
 	import { addDays } from 'date-fns';
 	import { MultiSelect } from 'svelte-multiselect';
+	import ProductCombinationRow from '$lib/components/ProductCombinationRow.svelte';
 
 	export let data;
-	let beginsAt = new Date().toJSON().slice(0, 10);
-	let endsAt = addDays(new Date(), 1).toJSON().slice(0, 10);
+	const { countryName } = useI18n();
+	$: sortedCountries = [...data.countries].sort((a, b) =>
+		countryName(a).localeCompare(countryName(b))
+	);
+	let beginsAt = new Date().toJSON().slice(0, 16);
+	let endsAt = addDays(new Date(), 1).toJSON().slice(0, 16);
 	let endsAtElement: HTMLInputElement;
 	let availableProductList = data.products;
 	let subscriptions = data.subscriptions;
@@ -15,6 +21,7 @@
 	let mode = 'percentage';
 	let productFreeLine = 2;
 	let productFree: string[] = [];
+	let combinations: Array<{ products: Array<{ productId: string; quantity: number }> }> = [];
 	function checkForm(event: SubmitEvent) {
 		if (endsAt && endsAt < beginsAt) {
 			endsAtElement.setCustomValidity('End date must be after beginning date');
@@ -64,11 +71,28 @@
 		</label>
 	{/if}
 
+	{#if mode === 'percentage'}
+		<label class="checkbox-label">
+			<input type="checkbox" name="showBadge" class="form-checkbox" checked />
+			Show discount badge (-X%) on product page
+		</label>
+		<label class="checkbox-label">
+			<input type="checkbox" name="showExpirationBanner" class="form-checkbox" />
+			Show discount expiration reminder on product page
+		</label>
+	{/if}
+
 	<div class="flex flex-wrap gap-4">
 		<label class="form-label">
 			Beginning date
 
-			<input class="form-input" type="date" name="beginsAt" required bind:value={beginsAt} />
+			<input
+				class="form-input"
+				type="datetime-local"
+				name="beginsAt"
+				required
+				bind:value={beginsAt}
+			/>
 		</label>
 	</div>
 	<div class="flex flex-wrap gap-4">
@@ -77,26 +101,138 @@
 
 			<input
 				class="form-input"
-				type="date"
+				type="datetime-local"
 				name="endsAt"
-				min={addDays(new Date(), 1).toJSON().slice(0, 10)}
 				bind:value={endsAt}
 				bind:this={endsAtElement}
 				on:input={() => endsAtElement?.setCustomValidity('')}
 			/>
 		</label>
 	</div>
+
+	{#if mode === 'percentage'}
+		<fieldset class="form-label">
+			<legend>Discount channel application</legend>
+			{#each [{ value: 'web', label: 'Web' }, { value: 'web-pos', label: 'Web with PoS privilege (/cart)' }, { value: 'pos-touch', label: 'Bar-restaurant PoS (/pos/touch)' }, { value: 'nostr-bot', label: 'Nostr-bot' }] as channel}
+				<label class="checkbox-label">
+					<input type="checkbox" name="channels" value={channel.value} class="form-checkbox" />
+					{channel.label}
+				</label>
+			{/each}
+		</fieldset>
+	{/if}
+
 	<!-- svelte-ignore a11y-label-has-associated-control -->
 	<label class="form-label"
-		>Required Subscription
+		>Required Subscription (optional)
 
 		<MultiSelect
 			--sms-options-bg="var(--body-mainPlan-backgroundColor)"
 			name="subscriptionIds"
 			options={subscriptions.map((p) => ({ label: p.name, value: p._id }))}
-			required
 		/>
 	</label>
+
+	{#if mode === 'percentage'}
+		<label class="form-label">
+			Required code (optional)
+			<input
+				class="form-input"
+				type="text"
+				name="promoCode"
+				maxlength="50"
+				placeholder="Enter promocode chain"
+			/>
+			<span class="text-sm text-gray-500"
+				>Tip: use 8+ characters mixing letters, numbers and special characters (e.g. SPRING_2026X4!)
+				— short codes are easy to brute-force.</span
+			>
+		</label>
+
+		<label class="form-label">
+			Required delivery country (optional)
+			<select name="deliveryCountry" class="form-input">
+				<option value="none">None</option>
+				{#each sortedCountries as country}
+					<option value={country}>{countryName(country)}</option>
+				{/each}
+			</select>
+		</label>
+
+		<label class="form-label">
+			Required billing country (optional)
+			<select name="billingCountry" class="form-input">
+				<option value="none">None</option>
+				{#each sortedCountries as country}
+					<option value={country}>{countryName(country)}</option>
+				{/each}
+			</select>
+		</label>
+
+		<fieldset class="form-label">
+			<legend>Payment method</legend>
+			{#each ['lightning', 'bank-transfer', 'point-of-sale', 'card', 'bitcoin', 'paypal'] as pm}
+				<label class="checkbox-label">
+					<input type="checkbox" name="paymentMethods" value={pm} class="form-checkbox" />
+					{pm}{pm === 'point-of-sale' ? ' (only for users with POS role)' : ''}
+				</label>
+			{/each}
+		</fieldset>
+
+		<label class="form-label">
+			Required contact address (optional)
+			<textarea
+				class="form-input"
+				name="contactAddresses"
+				rows="4"
+				placeholder="One address per line (email, npub, phone...)"
+			></textarea>
+			<span class="text-sm text-gray-500"
+				>Tip: use <code>npub*</code> to grant the discount to all Nostr-authenticated users.</span
+			>
+		</label>
+
+		<fieldset class="form-label">
+			<legend>Required product combination (optional)</legend>
+			{#each combinations as combo, comboIdx}
+				<div class="border rounded p-2 mb-2">
+					<h4 class="font-semibold">Combination {comboIdx + 1} Product</h4>
+					{#each combo.products as product, prodIdx}
+						<ProductCombinationRow
+							{product}
+							{comboIdx}
+							{prodIdx}
+							{availableProductList}
+							on:change={() => (combinations = combinations)}
+							on:remove={() => {
+								combo.products = combo.products.filter((_, idx) => idx !== prodIdx);
+								combinations = combinations;
+							}}
+						/>
+					{/each}
+					<button
+						type="button"
+						class="text-sm underline"
+						on:click={() => {
+							combo.products = [...combo.products, { productId: '', quantity: 1 }];
+							combinations = combinations;
+						}}
+					>
+						+ Add product to combination
+					</button>
+				</div>
+			{/each}
+			<button
+				type="button"
+				class="btn body-mainCTA self-start"
+				on:click={() => {
+					combinations = [...combinations, { products: [{ productId: '', quantity: 1 }] }];
+				}}
+			>
+				Add combination
+			</button>
+		</fieldset>
+	{/if}
 	{#if mode === 'percentage'}
 		<label class="checkbox-label">
 			<input
@@ -117,6 +253,17 @@
 					options={availableProductList.map((p) => ({ label: p.name, value: p._id }))}
 				/>
 			</label>
+			{#if data.tags.length}
+				<!-- svelte-ignore a11y-label-has-associated-control -->
+				<label class="form-label"
+					>Products with this tag (optional)
+					<MultiSelect
+						--sms-options-bg="var(--body-mainPlan-backgroundColor)"
+						name="requiredTagIds"
+						options={data.tags.map((t) => ({ label: t.name, value: t._id }))}
+					/>
+				</label>
+			{/if}
 		{/if}
 	{/if}
 

--- a/src/routes/(app)/cart/+page.server.ts
+++ b/src/routes/(app)/cart/+page.server.ts
@@ -1,11 +1,14 @@
 import { checkCartItems } from '$lib/server/cart';
 import { cmsFromContent } from '$lib/server/cms';
 import { collections, withTransaction } from '$lib/server/database';
+import { findActivePromoDiscount, hasAnyActivePromoDiscount } from '$lib/server/discount';
 import { applyResolvedStock, refreshAvailableStockInDb } from '$lib/server/product.js';
+import { rateLimit } from '$lib/server/rateLimit';
 import { runtimeConfig } from '$lib/server/runtime-config.js';
 import { userIdentifier, userQuery } from '$lib/server/user.js';
 import { CUSTOMER_ROLE_ID } from '$lib/types/User';
-import { error, redirect } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
 
 export async function load({ parent, locals }) {
 	if (
@@ -89,11 +92,22 @@ export async function load({ parent, locals }) {
 		locals.user?.roleId !== undefined && locals.user?.roleId !== CUSTOMER_ROLE_ID
 			? 'employee'
 			: undefined;
+
+	// Only show promo input if any active discount actually uses a promo code
+	const hasPromoDiscounts = await hasAnyActivePromoDiscount();
+
+	// Get the applied promo code from the cart in DB
+	const cartInDb = await collections.carts.findOne(userQuery(userIdentifier(locals)), {
+		projection: { promoCode: 1 }
+	});
+
 	return {
 		cart: {
 			...parentData.cart,
 			items: cartItemsWithResolvedStock
 		},
+		hasPromoDiscounts,
+		appliedPromoCode: cartInDb?.promoCode,
 		...(cmsBasketTop && {
 			cmsBasketTop,
 			cmsBasketTopData: cmsFromContent(
@@ -121,6 +135,46 @@ export async function load({ parent, locals }) {
 	};
 }
 export const actions = {
+	applyPromoCode: async ({ request, locals }) => {
+		try {
+			rateLimit(locals.clientIp, 'promo-code', 20, { hours: 3 });
+		} catch (e) {
+			// rateLimit only throws SvelteKit error(429, ...) — log abuse and return form fail
+			const status = (e as { status?: unknown })?.status;
+			if (status === 429) {
+				console.warn('Promo code rate limit hit', { clientIp: locals.clientIp });
+				return fail(429, { promoRateLimited: true });
+			}
+			throw e;
+		}
+
+		const formData = await request.formData();
+		const parsed = z.string().min(1).max(50).safeParse(formData.get('promoCode'));
+		if (!parsed.success) {
+			console.warn('Invalid promo code payload', { clientIp: locals.clientIp });
+			return fail(400, { promoError: true });
+		}
+
+		const exists = await findActivePromoDiscount(parsed.data);
+		if (!exists) {
+			return fail(400, { promoError: true });
+		}
+
+		await collections.carts.updateOne(userQuery(userIdentifier(locals)), {
+			$set: { promoCode: parsed.data, updatedAt: new Date() }
+		});
+
+		return { promoSuccess: true, promoCode: parsed.data };
+	},
+
+	removePromoCode: async ({ locals }) => {
+		await collections.carts.updateOne(userQuery(userIdentifier(locals)), {
+			$unset: { promoCode: '' },
+			$set: { updatedAt: new Date() }
+		});
+		return { promoRemoved: true };
+	},
+
 	removeAll: async ({ locals, request }) => {
 		const cart = await collections.carts.findOne(userQuery(userIdentifier(locals)));
 		if (!cart) {

--- a/src/routes/(app)/cart/+page.svelte
+++ b/src/routes/(app)/cart/+page.svelte
@@ -7,6 +7,7 @@
 	import ProductType from '$lib/components/ProductType.svelte';
 	import Trans from '$lib/components/Trans.svelte';
 	import IconInfo from '$lib/components/icons/IconInfo.svelte';
+	import IconTrash from '$lib/components/icons/IconTrash.svelte';
 	import { useI18n } from '$lib/i18n';
 	import { computeDeliveryFees } from '$lib/cart';
 	import { isAlpha2CountryCode } from '$lib/types/Country.js';
@@ -22,6 +23,8 @@
 	export let data;
 
 	let discountPanelIndex = -1;
+	let promoError = false;
+	let promoRateLimited = false;
 
 	let actionCount = 0;
 
@@ -120,8 +123,8 @@
 
 		{#if items.length && priceInfo}
 			<div
-				class="lg:grid gap-x-4 gap-y-6 overflow-hidden"
-				style="grid-template-columns: auto 1fr auto auto"
+				class="lg:grid lg:items-start gap-x-4 gap-y-6 overflow-hidden"
+				style="grid-template-columns: auto 1fr auto"
 			>
 				{#each items as item, i}
 					{@const price = priceInfo.perItem[i]}
@@ -166,19 +169,80 @@
 						{#if item.depositPercentage ?? undefined !== undefined}
 							<input type="hidden" name="depositPercentage" value={item.depositPercentage} />
 						{/if}
-						<a
-							href="/product/{item.product._id}"
-							class="w-[138px] h-[138px] min-w-[138px] min-h-[138px] rounded flex items-center"
-						>
-							{#if item.picture}
-								<Picture
-									picture={item.picture}
-									class="mx-auto rounded h-full object-contain"
-									sizes="138px"
-								/>
-							{/if}
+						<!-- Mobile-only title (lg+: shown inside info column instead) -->
+						<a href="/product/{item.product._id}" class="block mb-4 lg:hidden">
+							<h2 class="text-2xl">
+								{item.chosenVariations
+									? item.product.name +
+									  ' - ' +
+									  Object.entries(item.chosenVariations)
+											.map(([key, value]) => item.product.variationLabels?.values[key][value])
+											.join(' - ')
+									: item.product.name}
+							</h2>
 						</a>
-						<div class="flex flex-col lg:gap-2">
+
+						<!-- Mobile: flex row (image + tags). Desktop: contents → image alone in grid col 1 -->
+						<div class="flex gap-4 lg:contents">
+							<a
+								href="/product/{item.product._id}"
+								class="w-[138px] h-[138px] min-w-[138px] min-h-[138px] rounded block shrink-0"
+							>
+								{#if item.picture}
+									<Picture
+										picture={item.picture}
+										class="mx-auto rounded h-full object-contain object-top"
+										sizes="138px"
+									/>
+								{/if}
+							</a>
+							<!-- Mobile-only POS discount button next to image -->
+							{#if data.hasPosOptions}
+								<div class="flex flex-col flex-wrap gap-2 self-center lg:hidden">
+									<button
+										type="button"
+										class="text-sm px-2 py-0.5 rounded-full border self-start {item.discountPercentage
+											? 'bg-blue-500 border-blue-500 text-white'
+											: 'border-blue-400 text-blue-600 hover:bg-blue-50'}"
+										on:click={() => {
+											discountPanelIndex = discountPanelIndex === i ? -1 : i;
+										}}
+									>
+										{#if item.discountPercentage}
+											{Number.isInteger(item.discountPercentage)
+												? item.discountPercentage
+												: item.discountPercentage.toFixed(1)}%
+										{:else}
+											{t('cart.discount.button')}
+										{/if}
+									</button>
+								</div>
+							{/if}
+						</div>
+
+						<!-- Mobile-only quantity + trash under image (spaced from it) -->
+						<div class="flex items-center gap-3 mt-3 lg:hidden">
+							{#if !oneMaxPerLine(item.product)}
+								<CartQuantity {item} />
+							{/if}
+							<button
+								formaction="/cart/{item.product._id}/?/remove"
+								class="text-red-600 hover:underline"
+								aria-label={t('cart.cta.discardItem')}
+							>
+								<IconTrash class="w-5 h-5" />
+							</button>
+						</div>
+
+						<!-- Mobile-only product type under the buttons -->
+						<div class="mt-2 mb-2 lg:hidden">
+							<ProductType
+								product={item.product}
+								depositPercentage={item.depositPercentage}
+								hasDigitalFiles={item.digitalFilesCount >= 1}
+							/>
+						</div>
+						<div class="hidden lg:flex flex-col lg:gap-2">
 							<a href="/product/{item.product._id}">
 								<h2 class="text-2xl">
 									{item.chosenVariations
@@ -190,7 +254,7 @@
 										: item.product.name}
 								</h2>
 							</a>
-							<p class="text-sm hidden lg:contents">{item.product.shortDescription}</p>
+							<p class="text-sm">{item.product.shortDescription}</p>
 							{#if item.booking}
 								<p>
 									{#if item.booking.bookedDates?.length}
@@ -206,7 +270,6 @@
 									{/if}
 								</p>
 							{/if}
-							<div class="grow" />
 							<div class="flex flex-row flex-wrap lg:gap-2 gap-1">
 								<ProductType
 									product={item.product}
@@ -233,50 +296,49 @@
 									</button>
 								{/if}
 							</div>
-							<button
-								formaction="/cart/{item.product._id}/?/remove"
-								class="mt-auto mr-auto hover:underline body-hyperlink text-base font-light"
-							>
-								{t('cart.cta.discardItem')}
-							</button>
-						</div>
-						<div class="self-center">
-							{#if !oneMaxPerLine(item.product)}
-								<CartQuantity {item} />
-							{/if}
 						</div>
 
-						<div class="flex flex-col items-end justify-center lg:mb-0 mb-4">
+						<div class="flex flex-col items-end gap-2 lg:mb-0 mb-4">
+							<div class="hidden lg:flex items-center gap-3">
+								<button
+									formaction="/cart/{item.product._id}/?/remove"
+									class="text-red-600 hover:underline flex items-center gap-1 text-sm font-light"
+								>
+									<IconTrash class="w-4 h-4" />
+									{t('cart.cta.discardItem')}
+								</button>
+								{#if !oneMaxPerLine(item.product)}
+									<CartQuantity {item} />
+								{/if}
+							</div>
 							{#if item.discountPercentage}
-								<span class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded">
-									-{Number.isInteger(item.discountPercentage)
-										? item.discountPercentage
-										: item.discountPercentage.toFixed(1)}%
-								</span>
-							{/if}
-							<div class="flex gap-2 items-baseline">
-								{#if item.discountPercentage}
+								<div class="flex gap-2 items-center">
 									<PriceTag
 										amount={price.amountWithoutDiscount * toDepositFactor}
 										currency={price.currency}
 										main
-										class="text-2xl truncate line-through text-gray-500"
+										class="text-lg truncate line-through text-gray-500"
 									/>
+									<span class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded">
+										-{Number.isInteger(item.discountPercentage)
+											? item.discountPercentage
+											: item.discountPercentage.toFixed(1)}%
+									</span>
+								</div>
+							{/if}
+							<PriceTag
+								amount={(item.discountPercentage ? price.amount : price.amountWithoutDiscount) *
+									toDepositFactor}
+								currency={price.currency}
+								main
+								class="text-2xl truncate font-bold"
+							>
+								{#if item.depositPercentage}
+									{(item.depositPercentage / 100).toLocaleString($locale, {
+										style: 'percent'
+									})}
 								{/if}
-								<PriceTag
-									amount={(item.discountPercentage ? price.amount : price.amountWithoutDiscount) *
-										toDepositFactor}
-									currency={price.currency}
-									main
-									class="text-2xl truncate font-bold"
-								>
-									{#if item.depositPercentage}
-										{(item.depositPercentage / 100).toLocaleString($locale, {
-											style: 'percent'
-										})}
-									{/if}
-								</PriceTag>
-							</div>
+							</PriceTag>
 							<PriceTag
 								class="text-base truncate"
 								amount={price.amount * toDepositFactor}
@@ -288,7 +350,7 @@
 					</form>
 
 					{#if discountPanelIndex === i && data.hasPosOptions}
-						<div class="col-span-4">
+						<div class="col-span-3">
 							<CartItemDiscountPanel
 								productName={item.product.name}
 								productPrice={price.amountWithoutDiscount}
@@ -303,10 +365,10 @@
 					{/if}
 
 					{#if errorMessage && errorProductId === item.product._id}
-						<p class="text-red-600 col-span-4">{errorMessage}</p>
+						<p class="text-red-600 col-span-3">{errorMessage}</p>
 					{/if}
 
-					<div class="border-b border-gray-300 col-span-4" />
+					<div class="border-b border-gray-300 col-span-3 my-4 lg:my-0" />
 				{/each}
 			</div>
 			{#if deliveryFees}
@@ -422,6 +484,59 @@
 					<p class="text-red-500 font-light">{t('cart.minimumPhysicalAmountText')}</p>
 				{/if}
 			</div>
+			{#if data.hasPromoDiscounts}
+				<div class="flex flex-col items-end border-b border-gray-300 pb-4 mb-4 gap-2">
+					{#if data.appliedPromoCode}
+						<div class="flex items-center gap-2">
+							<span class="text-base"
+								>{t('cart.promo.applied', { code: data.appliedPromoCode })}</span
+							>
+							<form method="post" action="?/removePromoCode" use:enhance>
+								<button type="submit" class="text-sm hover:underline body-hyperlink"
+									>{t('cart.promo.remove')} 🗑️</button
+								>
+							</form>
+						</div>
+					{:else}
+						<form
+							method="post"
+							action="?/applyPromoCode"
+							class="flex items-center gap-2"
+							use:enhance={() => {
+								promoError = false;
+								promoRateLimited = false;
+								return async ({ result, update }) => {
+									if (result.type === 'failure') {
+										if (result.status === 429) {
+											promoRateLimited = true;
+										} else {
+											promoError = true;
+										}
+									}
+									await update();
+								};
+							}}
+						>
+							<span class="text-base">{t('cart.promo.question')}</span>
+							<input
+								type="text"
+								name="promoCode"
+								class="form-input w-48"
+								placeholder={t('cart.promo.placeholder')}
+								required
+							/>
+							<button type="submit" class="btn body-mainCTA text-sm">{t('cart.promo.apply')}</button
+							>
+						</form>
+						{#if promoError}
+							<p class="text-red-600 text-sm">{t('cart.promo.invalid')}</p>
+						{/if}
+						{#if promoRateLimited}
+							<p class="text-red-600 text-sm">{t('cart.promo.rateLimited')}</p>
+						{/if}
+					{/if}
+				</div>
+			{/if}
 			<form action="/checkout" class="flex justify-end">
 				<button
 					class="btn body-cta body-mainCTA"

--- a/src/routes/(app)/checkout/+page.server.ts
+++ b/src/routes/(app)/checkout/+page.server.ts
@@ -10,6 +10,13 @@ import { checkCartItems, getCartFromDb } from '$lib/server/cart.js';
 import { applyResolvedStock } from '$lib/server/product.js';
 import { userIdentifier, userQuery } from '$lib/server/user.js';
 import { CUSTOMER_ROLE_ID } from '$lib/types/User.js';
+import {
+	collectUserAddresses,
+	getActivePercentageDiscounts,
+	isAuthenticated,
+	selectBestDiscount,
+	webChannelForUser
+} from '$lib/server/discount';
 import { zodNpub } from '$lib/server/nostr.js';
 import type { JsonObject } from 'type-fest';
 import { rateLimit } from '$lib/server/rateLimit.js';
@@ -85,17 +92,74 @@ export async function load({ parent, locals }) {
 		)
 	]);
 
-	let methods = paymentMethods({ hasPosOptions: locals.user?.hasPosOptions });
-
-	for (const item of parentData.cart.items ?? []) {
-		if (item.product.paymentMethods) {
-			methods = methods.filter((method) => item.product.paymentMethods?.includes(method));
-		}
-	}
+	const initialMethods = paymentMethods({ hasPosOptions: locals.user?.hasPosOptions });
+	// Each item with explicit paymentMethods narrows the available methods (intersection)
+	const methods = (parentData.cart.items ?? []).reduce(
+		(acc, item) =>
+			item.product.paymentMethods
+				? acc.filter((m) => item.product.paymentMethods?.includes(m))
+				: acc,
+		initialMethods
+	);
 	const forceContentVersion =
 		locals.user?.roleId !== undefined && locals.user?.roleId !== CUSTOMER_ROLE_ID
 			? 'employee'
 			: undefined;
+
+	// Precompute auto discount per payment method so the frontend can switch live
+	const activeDiscounts = await getActivePercentageDiscounts();
+	const paidSubs = await collections.paidSubscriptions
+		.find({ ...userQuery(userIdentifier(locals)), paidUntil: { $gt: new Date() } })
+		.toArray();
+	const user = userIdentifier(locals);
+	const discountItemsForEval = cartItemsWithResolvedStock.map((i) => ({
+		product: i.product,
+		quantity: i.quantity,
+		...(i.customPrice && { customPrice: i.customPrice })
+	}));
+	const baseDiscountContext = {
+		userSubscriptionIds: paidSubs.map((s) => s.productId),
+		promoCode: parentData.cart.promoCode,
+		channel: webChannelForUser(locals.user?.hasPosOptions),
+		userContactAddresses: collectUserAddresses(user),
+		cartItems: cartItemsWithResolvedStock.map((i) => ({
+			productId: i.product._id,
+			quantity: i.quantity,
+			tagIds: i.product.tagIds
+		})),
+		isLoggedIn: isAuthenticated(user)
+	};
+	// Countries that can influence discount eligibility, split by condition axis.
+	// Any other country produces the same result (condition fails), so we only vary these.
+	// '' sentinel = "country not relevant to this axis".
+	const relevantShipCountries = [
+		...new Set(activeDiscounts.flatMap((d) => (d.deliveryCountry ? [d.deliveryCountry] : [])))
+	];
+	const relevantBillCountries = [
+		...new Set(activeDiscounts.flatMap((d) => (d.billingCountry ? [d.billingCountry] : [])))
+	];
+	const shipKeys: Array<CountryAlpha2 | ''> = ['', ...relevantShipCountries];
+	const billKeys: Array<CountryAlpha2 | ''> = ['', ...relevantBillCountries];
+
+	// Key format: `${ship}|${bill}|${method}`. Frontend normalizes each chosen country to ''
+	// unless it appears in the corresponding relevant list, then looks up the precomputed best.
+	const discountByContext: Record<string, Record<string, number>> = Object.fromEntries(
+		shipKeys.flatMap((ship) =>
+			billKeys.flatMap((bill) =>
+				methods.flatMap((method) => {
+					const best = selectBestDiscount(activeDiscounts, discountItemsForEval, {
+						...baseDiscountContext,
+						...(ship && { deliveryCountry: ship }),
+						...(bill && { billingCountry: bill }),
+						paymentMethod: method
+					});
+					return best
+						? [[`${ship}|${bill}|${method}`, Object.fromEntries(best.discountByProduct)]]
+						: [];
+				})
+			)
+		)
+	);
 
 	const posSubtypes = await collections.posPaymentSubtypes
 		.find({ disabled: { $ne: true } })
@@ -112,6 +176,9 @@ export async function load({ parent, locals }) {
 
 	return {
 		paymentMethods: methods,
+		discountByContext,
+		relevantShipCountries,
+		relevantBillCountries,
 		reportingTags,
 		emailsEnabled: isEmailConfigured(),
 		collectIPOnDeliverylessOrders: runtimeConfig.collectIPOnDeliverylessOrders,
@@ -522,6 +589,8 @@ export const actions = {
 						}
 					},
 					cart,
+					promoCode: cart.promoCode,
+					channel: webChannelForUser(locals.user?.hasPosOptions),
 					shippingAddress: shippingInfo?.shipping,
 					billingAddress: billingInfo?.billing || shippingInfo?.shipping,
 					userVatCountry: vatCountry,

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { applyAction, enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
-	import CartQuantity from '$lib/components/CartQuantity.svelte';
 	import Picture from '$lib/components/Picture.svelte';
 	import PriceTag from '$lib/components/PriceTag.svelte';
 	import { bech32 } from 'bech32';
@@ -28,6 +27,7 @@
 		(data.personalInfoConnected?.address?.country ?? data.countryCode) || data.vatCountry || 'FR';
 	const digitalCountry = data.countryCode || data.vatCountry || 'FR';
 	let country = defaultShippingCountry;
+	let billingCountry = defaultShippingCountry;
 
 	let isFreeVat = false;
 	let addDiscount = false;
@@ -109,6 +109,29 @@
 		: paymentMethods[0];
 
 	$: items = data.cart.items;
+	// Live discount preview: payment method, shipping country, and billing country feed into a
+	// context key that maps to the best auto-discount precomputed on the server.
+	// Manual POS per-item discount (marked by discountJustification) always wins over auto.
+	$: billingVisible =
+		showBillingInfo || (isDigital && data.isBillingAddressMandatory) || isProfessionalOrder;
+	// When billing section is hidden, billing falls back to shipping (matches orders.ts submit logic)
+	$: effectiveBillingCountry = billingVisible ? billingCountry : country;
+	$: shipKey = data.relevantShipCountries?.includes(country) ? country : '';
+	$: billKey = data.relevantBillCountries?.includes(effectiveBillingCountry)
+		? effectiveBillingCountry
+		: '';
+	$: contextDiscountMap = paymentMethod
+		? data.discountByContext?.[`${shipKey}|${billKey}|${paymentMethod}`]
+		: undefined;
+	$: effectiveItems = items.map((item) => {
+		const isPosManual = !!item.discountJustification;
+		if (isPosManual) {
+			return item;
+		}
+		const dynamicDiscount = contextDiscountMap?.[item.product._id];
+		const discountPercentage = dynamicDiscount ?? item.discountPercentage;
+		return discountPercentage !== undefined ? { ...item, discountPercentage } : item;
+	});
 	$: orderDeliveryFees = computeDeliveryFees(
 		UNDERLYING_CURRENCY,
 		country,
@@ -141,32 +164,36 @@
 
 	// A PoS operator may apply different discounts, such as on-site promotions or free delivery;
 	// thus, the price info is computed from scratch to reflect the correct value.
-	// Compute price WITHOUT discount for validation purposes
+	// Shared VAT config — duplicating it across 3 computePriceInfo calls causes drift bugs.
+	// deliveryFees stays inline so contextual typing keeps the Currency literal.
+	$: vatBaseConfig = {
+		bebopCountry: data.vatCountry,
+		deliveryFeesVatProfileId: data.deliveryFees.vatProfileId,
+		deliveryFeesVatIncluded: data.deliveryFees.vatIncludedReference,
+		freeProductUnits: data.cart.freeProductUnits,
+		userCountry: isDigital ? digitalCountry : country,
+		vatExempted: data.vatExempted,
+		vatNullOutsideSellerCountry: data.vatNullOutsideSellerCountry,
+		vatSingleCountry: data.vatSingleCountry,
+		vatProfiles: data.vatProfiles
+	};
+	// Without discount — for validation purposes
 	$: priceInfoWithoutDiscount = computePriceInfo(items, {
-		bebopCountry: data.vatCountry,
+		...vatBaseConfig,
 		deliveryFees: { amount: deliveryFeesToBill, currency: UNDERLYING_CURRENCY },
-		deliveryFeesVatProfileId: data.deliveryFees.vatProfileId,
-		deliveryFeesVatIncluded: data.deliveryFees.vatIncludedReference,
-		discount: undefined,
-		freeProductUnits: data.cart.freeProductUnits,
-		userCountry: isDigital ? digitalCountry : country,
-		vatExempted: data.vatExempted,
-		vatNullOutsideSellerCountry: data.vatNullOutsideSellerCountry,
-		vatSingleCountry: data.vatSingleCountry,
-		vatProfiles: data.vatProfiles
+		discount: undefined
 	});
-	$: priceInfo = computePriceInfo(items, {
-		bebopCountry: data.vatCountry,
+	// basePriceInfo: used by nothingToPay/paymentMethods filter (breaks reactive cycle)
+	$: basePriceInfo = computePriceInfo(items, {
+		...vatBaseConfig,
 		deliveryFees: { amount: deliveryFeesToBill, currency: UNDERLYING_CURRENCY },
-		deliveryFeesVatProfileId: data.deliveryFees.vatProfileId,
-		deliveryFeesVatIncluded: data.deliveryFees.vatIncludedReference,
-		discount: possiblyOutOfBoundsDiscount,
-		freeProductUnits: data.cart.freeProductUnits,
-		userCountry: isDigital ? digitalCountry : country,
-		vatExempted: data.vatExempted,
-		vatNullOutsideSellerCountry: data.vatNullOutsideSellerCountry,
-		vatSingleCountry: data.vatSingleCountry,
-		vatProfiles: data.vatProfiles
+		discount: possiblyOutOfBoundsDiscount
+	});
+	// priceInfo: used for display with dynamic discount from payment method
+	$: priceInfo = computePriceInfo(effectiveItems, {
+		...vatBaseConfig,
+		deliveryFees: { amount: deliveryFeesToBill, currency: UNDERLYING_CURRENCY },
+		discount: possiblyOutOfBoundsDiscount
 	});
 	$: isDigital = items.every((item) => !item.product.shipping);
 
@@ -228,14 +255,14 @@
 
 	$: nothingToPay =
 		isFreeOfCharge ||
-		toCurrency(data.currencies.main, priceInfo.totalPriceWithVat, priceInfo.currency) <= 0;
+		toCurrency(data.currencies.main, basePriceInfo.totalPriceWithVat, basePriceInfo.currency) <= 0;
 	$: paymentMethods = nothingToPay
 		? ['free']
 		: data.paymentMethods.filter(
 				(method) =>
 					method !== 'free' &&
 					(method === 'bitcoin'
-						? toCurrency('SAT', priceInfo.partialPriceWithVat, priceInfo.currency) >=
+						? toCurrency('SAT', basePriceInfo.partialPriceWithVat, basePriceInfo.currency) >=
 						  MIN_SATOSHIS_FOR_BITCOIN_PAYMENT
 						: true)
 		  );
@@ -502,12 +529,7 @@
 
 					<label class="form-label col-span-3">
 						{t('address.country')}
-						<select
-							name="billing.country"
-							class="form-input"
-							required
-							value={defaultShippingCountry}
-						>
+						<select name="billing.country" class="form-input" required bind:value={billingCountry}>
 							{#each sortedCountryCodes() as code}
 								<option value={code}>{countryName(code)}</option>
 							{/each}
@@ -747,7 +769,7 @@
 					>
 					<p>{t('checkout.numProducts', { count: data.cart.items.length ?? 0 })}</p>
 				</div>
-				{#each items as item, i}
+				{#each effectiveItems as item, i}
 					{@const price = priceInfo.perItem[i]}
 					<form
 						method="POST"
@@ -786,7 +808,9 @@
 									  Object.entries(item.chosenVariations)
 											.map(([key, value]) => item.product.variationLabels?.values[key][value])
 											.join(' - ')
-									: item.product.name}
+									: item.product.name}{#if item.quantity > 1 && !item.product.bookingSpec}<span
+										class="text-gray-500 ml-1">× {item.quantity}</span
+									>{/if}
 							</h3>
 						</a>
 
@@ -826,44 +850,36 @@
 											}).formatRange(item.booking.start, item.booking.end)}
 										{/if}
 									</p>
-								{:else}
-									<div>
-										{#if 0}
-											<CartQuantity {item} sm />
-										{:else if item.quantity > 1}
-											{t('cart.quantity')}: {item.quantity}
-										{/if}
-									</div>
 								{/if}
 							</div>
 
 							<div class="flex flex-col ml-auto items-end justify-center">
-								<div class="flex gap-2 items-center">
-									{#if item.discountPercentage}
+								{#if item.discountPercentage}
+									<div class="flex gap-2 items-center">
+										<PriceTag
+											class="text-lg truncate line-through text-gray-500"
+											amount={(price.amountWithoutDiscount * (item.depositPercentage ?? 100)) / 100}
+											currency={price.currency}
+											main
+										/>
 										<span class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded">
 											-{Number.isInteger(item.discountPercentage)
 												? item.discountPercentage
 												: item.discountPercentage.toFixed(1)}%
 										</span>
-										<PriceTag
-											class="text-2xl truncate line-through"
-											amount={(price.amountWithoutDiscount * (item.depositPercentage ?? 100)) / 100}
-											currency={price.currency}
-											main
-										/>
-									{/if}
-									<PriceTag
-										class="text-2xl truncate"
-										amount={(price.amount * (item.depositPercentage ?? 100)) / 100}
-										currency={price.currency}
-										main
-										>{item.depositPercentage
-											? `(${(item.depositPercentage / 100).toLocaleString($locale, {
-													style: 'percent'
-											  })})`
-											: ''}</PriceTag
-									>
-								</div>
+									</div>
+								{/if}
+								<PriceTag
+									class="text-2xl truncate"
+									amount={(price.amount * (item.depositPercentage ?? 100)) / 100}
+									currency={price.currency}
+									main
+									>{item.depositPercentage
+										? `(${(item.depositPercentage / 100).toLocaleString($locale, {
+												style: 'percent'
+										  })})`
+										: ''}</PriceTag
+								>
 								<PriceTag
 									amount={(price.amount * (item.depositPercentage ?? 100)) / 100}
 									currency={price.currency}

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
@@ -314,6 +314,7 @@ export const actions = {
 					userVatCountry: runtimeConfig.vatCountry,
 					shippingAddress: null,
 					cart,
+					channel: 'pos-touch',
 					peopleCountFromPosUi: orderTab.peopleCountFromPosUi
 				});
 

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -16,33 +16,62 @@ import { error, redirect } from '@sveltejs/kit';
 import { subDays, parseISO, isValid } from 'date-fns';
 import type { JsonObject } from 'type-fest';
 import { z } from 'zod';
+import {
+	collectUserAddresses,
+	discountTargetsProduct,
+	evaluateDiscountConditions,
+	getActivePercentageDiscounts,
+	isAuthenticated
+} from '$lib/server/discount';
+import type { Discount } from '$lib/types/Discount';
 
-async function fetchApplicableDiscount(productId: string, userSubscriptionIds: string[]) {
-	return collections.discounts.findOne(
+async function fetchApplicableDiscount(
+	productId: string,
+	productTagIds: string[],
+	userSubscriptionIds: string[],
+	user?: UserIdentifier | null
+) {
+	// 1. Existing: subscription-based lookup. Discount applies if product matches by id, by tag,
+	//    or the discount targets the whole catalog.
+	const productTargetMatch = [
+		{ wholeCatalog: true },
+		{ productIds: productId },
+		...(productTagIds.length ? [{ requiredTagIds: { $in: productTagIds } }] : [])
+	];
+	const subscriptionDiscount = await collections.discounts.findOne(
 		{
-			$or: [{ wholeCatalog: true }, { productIds: productId }],
-			subscriptionIds: { $in: userSubscriptionIds },
-			beginsAt: {
-				$lt: new Date()
-			},
-			mode: 'percentage',
 			$and: [
-				{
-					$or: [
-						{
-							endsAt: { $gt: new Date() }
-						},
-						{
-							endsAt: null
-						}
-					]
-				}
-			]
+				{ $or: productTargetMatch },
+				{ $or: [{ endsAt: { $gt: new Date() } }, { endsAt: null }] }
+			],
+			subscriptionIds: { $in: userSubscriptionIds.length ? userSubscriptionIds : ['__none__'] },
+			beginsAt: { $lt: new Date() },
+			mode: 'percentage'
 		},
-		{
-			sort: { percentage: -1 }
-		}
+		{ sort: { percentage: -1 } }
 	);
+
+	if (subscriptionDiscount) {
+		return subscriptionDiscount;
+	}
+
+	// 2. Auto discounts (condition-based, no subscription needed)
+	const activeDiscounts = await getActivePercentageDiscounts();
+	const applicable = activeDiscounts
+		.filter((d) => discountTargetsProduct(d, { _id: productId, tagIds: productTagIds }))
+		.filter((d) =>
+			evaluateDiscountConditions(d, {
+				userSubscriptionIds,
+				channel: 'web',
+				cartItems: [{ productId, quantity: 1, tagIds: productTagIds }],
+				userContactAddresses: collectUserAddresses(user),
+				isLoggedIn: isAuthenticated(user)
+			})
+		)
+		.filter((d): d is Extract<Discount, { mode: 'percentage' }> => d.mode === 'percentage')
+		.sort((a, b) => b.percentage - a.percentage);
+
+	return applicable[0] ?? null;
 }
 
 async function fetchProduct(
@@ -83,6 +112,7 @@ async function fetchProduct(
 	| 'bookingSpec'
 	| 'vatProfileId'
 	| 'stockReference'
+	| 'tagIds'
 > | null> {
 	return collections.products.findOne<ReturnType<Awaited<typeof fetchProduct>>>(
 		{ _id: productId },
@@ -132,7 +162,8 @@ async function fetchProduct(
 				shipping: 1,
 				bookingSpec: 1,
 				vatProfileId: 1,
-				stockReference: 1
+				stockReference: 1,
+				tagIds: 1
 			}
 		}
 	);
@@ -209,12 +240,12 @@ export const load = async ({ params, parent, locals }) => {
 		.filter((idAndCount) => idAndCount[0] === productId)
 		.reduce((acc, idAndCount) => acc + idAndCount[1], 0);
 	const freeProductsAvailable = totalFreeProducts - freeProductsInCart;
-	const discount = userSubscriptions.length
-		? await fetchApplicableDiscount(
-				productId,
-				userSubscriptions.map((sub) => sub.productId)
-		  )
-		: null;
+	const discount = await fetchApplicableDiscount(
+		productId,
+		product.tagIds ?? [],
+		userSubscriptions.map((sub) => sub.productId),
+		userIdentifier(locals)
+	);
 
 	const vatRate = computeVatRate({
 		productVatProfileId: product.vatProfileId,

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -438,6 +438,8 @@
 	$: finalPrice = unitPrice * discountMultiplier;
 	$: finalPriceWithVat = unitPriceWithVat * discountMultiplier;
 
+	let showExclTax = false;
+
 	// Schedule calendar config
 	const calendarSchedule = {
 		_id: productToScheduleId(data.product._id),
@@ -580,22 +582,38 @@
 			>
 				<hr class="border-gray-300 lg:hidden mt-4 pb-2" />
 				{#if data.displayVatIncludedInProduct}
-					<div class="flex-row gap-2 lg:flex-col lg:items-start items-center justify-between">
-						<div class="max-md:flex max-md:flex-row max-md:justify-between">
-							<div class="flex gap-4">
+					<div class="flex flex-col gap-1 lg:items-start">
+						<!-- svelte-ignore a11y-click-events-have-key-events -->
+						<!-- svelte-ignore a11y-no-static-element-interactions -->
+						<div
+							class="flex flex-col gap-1 cursor-pointer"
+							on:click={() => (showExclTax = !showExclTax)}
+						>
+							<span class="text-sm"
+								>{t('product.vatIncluded')} ({t('cart.vat')}
+								{vatRate}%)
+								<span class="text-gray-400 text-xs ml-1">{showExclTax ? '▲' : '▼'}</span></span
+							>
+							<div class="flex items-center gap-2">
 								<PriceTag
 									currency={data.product.price.currency}
-									class="text-2xl lg:text-4xl truncate max-w-full {data.discount
-										? 'line-through'
-										: ''}"
+									class={data.discount?.mode === 'percentage'
+										? 'text-xl lg:text-2xl line-through text-gray-400'
+										: 'text-2xl lg:text-3xl'}
 									short={!!data.discount}
 									amount={unitPriceWithVat}
 									main
 								/>
 								{#if data.discount?.mode === 'percentage'}
+									{#if data.discount.showBadge !== false}
+										<span
+											class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+											>-{data.discount.percentage}%</span
+										>
+									{/if}
 									<PriceTag
 										currency={data.product.price.currency}
-										class="text-2xl lg:text-4xl truncate max-w-full"
+										class="text-2xl lg:text-3xl"
 										short
 										amount={finalPriceWithVat}
 										main
@@ -604,28 +622,37 @@
 							</div>
 							<PriceTag
 								currency={data.product.price.currency}
-								amount={finalPriceWithVat}
+								amount={data.discount?.mode === 'percentage' ? finalPriceWithVat : unitPriceWithVat}
 								secondary
-								class="text-xl"
+								class="text-base"
 							/>
 						</div>
-						<span>{t('product.vatIncluded')} ({t('cart.vat')} {vatRate}%)</span>
-						<div class="max-md:flex max-md:flex-row max-md:justify-between">
-							<div class="flex gap-4">
+
+						{#if showExclTax}
+							<hr class="border-gray-400 mt-2 w-full" />
+							<span class="text-sm mt-1"
+								>{t('product.vatExcludedEstimate')} ({t('cart.vat')} {vatRate}%)</span
+							>
+							<div class="flex items-center gap-2">
 								<PriceTag
 									currency={data.product.price.currency}
-									class="text-md font-semibold truncate max-w-full {data.discount
-										? 'line-through'
-										: ''}"
+									class={data.discount?.mode === 'percentage'
+										? 'text-base line-through text-gray-400'
+										: 'text-lg'}
 									short={!!data.discount}
 									amount={unitPrice}
 									main
 								/>
-								<span class="font-semibold lg:contents hidden">{t('product.vatExcluded')}</span>
 								{#if data.discount?.mode === 'percentage'}
+									{#if data.discount.showBadge !== false}
+										<span
+											class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+											>-{data.discount.percentage}%</span
+										>
+									{/if}
 									<PriceTag
 										currency={data.product.price.currency}
-										class="text-2xl lg:text-4xl truncate max-w-full"
+										class="text-lg"
 										short
 										amount={finalPrice}
 										main
@@ -634,26 +661,31 @@
 							</div>
 							<PriceTag
 								currency={data.product.price.currency}
-								amount={finalPrice}
+								amount={data.discount?.mode === 'percentage' ? finalPrice : unitPrice}
 								secondary
-								class="text-md"
+								class="text-sm"
 							/>
-						</div>
-						<span class="font-semibold contents lg:hidden">{t('product.vatExcluded')}</span>
+						{/if}
 					</div>
 				{:else}
-					<div class="flex gap-2 lg:flex-col lg:items-start items-center justify-between">
-						<div class="flex gap-4">
+					{@const showStrikeThrough =
+						data.discount?.mode === 'percentage' && data.discount.showBadge !== false}
+					<div class="flex flex-col gap-1 lg:items-start">
+						<div class="flex items-baseline gap-3">
 							<PriceTag
 								currency={data.product.price.currency}
-								class="text-2xl lg:text-4xl truncate max-w-full {data.discount
-									? 'line-through'
+								class="text-2xl lg:text-4xl truncate max-w-full {showStrikeThrough
+									? 'line-through text-gray-400'
 									: ''}"
-								short={!!data.discount}
+								short={showStrikeThrough}
 								amount={unitPrice}
 								main
 							/>
-							{#if data.discount?.mode === 'percentage'}
+							{#if showStrikeThrough}
+								<span
+									class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+									>-{data.discount?.mode === 'percentage' ? data.discount.percentage : 0}%</span
+								>
 								<PriceTag
 									currency={data.product.price.currency}
 									class="text-2xl lg:text-4xl truncate max-w-full"
@@ -665,11 +697,11 @@
 						</div>
 						<PriceTag
 							currency={data.product.price.currency}
-							amount={finalPrice}
+							amount={showStrikeThrough ? finalPrice : unitPrice}
 							secondary
-							class="text-xl"
+							class="text-base"
 						/>
-						<span class="font-semibold">{t('product.vatExcluded')}</span>
+						<span class="font-semibold text-sm">{t('product.vatExcluded')}</span>
 					</div>
 				{/if}
 
@@ -688,7 +720,7 @@
 					</h3>
 				{/if}
 
-				{#if data.discount && data.discount.mode === 'percentage' && !data.product.hideDiscountExpiration}
+				{#if data.discount && data.discount.mode === 'percentage' && !data.product.hideDiscountExpiration && data.discount.showExpirationBanner}
 					<hr class="border-gray-300" />
 					<h3 class="text-[22px]">
 						{#if timeDifference === null}


### PR DESCRIPTION
Shop admins can now create discounts that depend on many conditions at once — promo code entered on cart, sales channel (web / POS / Nostr bot), payment method, delivery country, customer's contact info, product tags, and product combinations. Subscription is no longer required to grant a discount.

Key points:
- Promo code input appears on the cart page only when an active discount uses one, with anti-brute-force rate limiting (20 attempts per 3 hours)
- On checkout, prices recalculate live as the customer switches payment method — the customer sees the discount applied immediately without reloading
- Product page shows the best applicable discount with a red "-X%" badge and  an optional expiration reminder (both toggleable per discount in admin)
- When several discounts apply, the one giving the biggest total saving on the whole order wins
- Employee-applied POS discounts always take precedence over automatic ones

Closes #2502