### PR TITLE
🦋 Add OSB payment provider for French Polynesia

### DIFF
--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -32,6 +32,19 @@
 			"discardItem": "Verwerfen",
 			"view": "Warenkorb anzeigen"
 		},
+		"discount": {
+			"button": "% Rabatt",
+			"noDiscount": "Kein Rabatt",
+			"title": "Rabatt — {productName}",
+			"customPercent": "Benutzerdefinierte %",
+			"customAmount": "Benutzerdefinierter Betrag ({currency})",
+			"justification": "Begründung",
+			"justificationPlaceholder": "Grund für den Rabatt...",
+			"cancel": "Abbrechen",
+			"validate": "Bestätigen",
+			"customPercentPlaceholder": "z. B. 15",
+			"customAmountPlaceholder": "z. B. 5,00"
+		},
 		"empty": "Der Warenkorb ist leer",
 		"fillProductAlias": "Produkt-Alias ausfüllen",
 		"items": "Produkte",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -32,6 +32,19 @@
 			"discardItem": "Descartar",
 			"view": "Al carrito"
 		},
+		"discount": {
+			"button": "% Descuento",
+			"noDiscount": "Sin descuento",
+			"title": "Descuento — {productName}",
+			"customPercent": "% personalizado",
+			"customAmount": "Monto personalizado ({currency})",
+			"justification": "Justificación",
+			"justificationPlaceholder": "Motivo del descuento...",
+			"cancel": "Cancelar",
+			"validate": "Validar",
+			"customPercentPlaceholder": "p. ej. 15",
+			"customAmountPlaceholder": "p. ej. 5.00"
+		},
 		"empty": "La lista de compras está vacía",
 		"fillProductAlias": "Rellenar alias de producto",
 		"items": "Productos",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -32,6 +32,19 @@
 			"discardItem": "Supprimer",
 			"view": "Voir le panier"
 		},
+		"discount": {
+			"button": "% Remise",
+			"noDiscount": "Aucune remise",
+			"title": "Remise — {productName}",
+			"customPercent": "% personnalisé",
+			"customAmount": "Montant personnalisé ({currency})",
+			"justification": "Justification",
+			"justificationPlaceholder": "Raison de la remise...",
+			"cancel": "Annuler",
+			"validate": "Valider",
+			"customPercentPlaceholder": "par ex. 15",
+			"customAmountPlaceholder": "par ex. 5,00"
+		},
 		"empty": "Le panier est vide",
 		"fillProductAlias": "Remplir l'alias du produit",
 		"items": "Produits",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -32,6 +32,19 @@
 			"discardItem": "Togli",
 			"view": "Guarda il carrello"
 		},
+		"discount": {
+			"button": "% Sconto",
+			"noDiscount": "Nessuno sconto",
+			"title": "Sconto — {productName}",
+			"customPercent": "% personalizzato",
+			"customAmount": "Importo personalizzato ({currency})",
+			"justification": "Motivazione",
+			"justificationPlaceholder": "Motivo dello sconto...",
+			"cancel": "Annulla",
+			"validate": "Conferma",
+			"customPercentPlaceholder": "es. 15",
+			"customAmountPlaceholder": "es. 5,00"
+		},
 		"empty": "Il cartello è vuoto",
 		"fillProductAlias": "Compila l'alias del prodotto",
 		"items": "Prodotti",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -32,6 +32,19 @@
 			"discardItem": "Weggooien",
 			"view": "Bekijk winkelwagen"
 		},
+		"discount": {
+			"button": "% Korting",
+			"noDiscount": "Geen korting",
+			"title": "Korting — {productName}",
+			"customPercent": "Aangepast %",
+			"customAmount": "Aangepast bedrag ({currency})",
+			"justification": "Rechtvaardiging",
+			"justificationPlaceholder": "Reden voor de korting...",
+			"cancel": "Annuleren",
+			"validate": "Bevestigen",
+			"customPercentPlaceholder": "bijv. 15",
+			"customAmountPlaceholder": "bijv. 5,00"
+		},
 		"empty": "Winkelwagen is leeg",
 		"fillProductAlias": "Productalias invullen",
 		"items": "Producten",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -32,6 +32,19 @@
 			"discardItem": "Descartar",
 			"view": "Ver carrinho"
 		},
+		"discount": {
+			"button": "% Desconto",
+			"noDiscount": "Sem desconto",
+			"title": "Desconto — {productName}",
+			"customPercent": "% personalizado",
+			"customAmount": "Valor personalizado ({currency})",
+			"justification": "Justificativa",
+			"justificationPlaceholder": "Motivo do desconto...",
+			"cancel": "Cancelar",
+			"validate": "Confirmar",
+			"customPercentPlaceholder": "ex. 15",
+			"customAmountPlaceholder": "ex. 5,00"
+		},
 		"empty": "O carrinho está vazio",
 		"fillProductAlias": "Preencher o alias do produto",
 		"items": "Produtos",


### PR DESCRIPTION
A new payment method "OSB" is now available for merchants in French Polynesia. OSB is a card payment gateway (Visa, Mastercard, CB, Amex) that works with the local currency XPF (CFP Franc).

How it works:
- Admin configures OSB credentials in a new settings page (/admin/osb)
- Customers see "OSB" as a payment option at checkout
- Clicking the payment link redirects to OSB's hosted payment page
- After payment, customers return to the order page where the status updates automatically

Key points:
- Supports XPF (CFP Franc) — the standard currency in French Polynesia
- Same architecture as PayPal — redirect to external page + automatic status polling
- No additional JavaScript or external scripts needed on the shop side

Closes #2513