### PR TITLE
🦋 Add OSB payment provider for French Polynesia

### DIFF
--- a/src/lib/components/Order/PaymentQRCodes.svelte
+++ b/src/lib/components/Order/PaymentQRCodes.svelte
@@ -32,6 +32,13 @@
 		</a>
 	{/if}
 
+	<!-- OSB redirect link -->
+	{#if payment.method === 'osb' && payment.address}
+		<a href={payment.address} class="btn btn-primary" target="_blank" rel="noopener">
+			{t('checkout.paymentMethod.osb')}
+		</a>
+	{/if}
+
 	<!-- Card QR (if not hidden) -->
 	{#if payment.method === 'card' && !hideCreditCardQrCode}
 		<img src="{$page.url.pathname}/payment/{payment.id}/qrcode" class="w-96 h-96" alt="QR code" />

--- a/src/lib/server/locks/order-lock.ts
+++ b/src/lib/server/locks/order-lock.ts
@@ -84,6 +84,7 @@ async function handleTapToPayCheck(
 			case 'swiss-bitcoin-pay':
 			case 'bitcoin-nodeless':
 			case 'taler':
+			case 'osb':
 				throw new Error(
 					`Tap-to-pay payment ${payment._id} requests processor ` +
 						`${payment.processor}, but Tap-to-pay using this processor is ` +

--- a/src/lib/server/locks/order-notifications.ts
+++ b/src/lib/server/locks/order-notifications.ts
@@ -212,6 +212,9 @@ async function handleOrderNotification(order: Order): Promise<void> {
 							case 'taler':
 								templateKey = 'order.payment.pending.taler';
 								break;
+							case 'osb':
+								templateKey = 'order.payment.pending.osb';
+								break;
 							case 'point-of-sale':
 							case 'free':
 								// no email

--- a/src/lib/server/payment-methods.ts
+++ b/src/lib/server/payment-methods.ts
@@ -10,7 +10,8 @@ export const ALL_PAYMENT_METHODS = [
 	'point-of-sale',
 	'free',
 	'paypal',
-	'taler'
+	'taler',
+	'osb'
 ] as const;
 export type PaymentMethod = (typeof ALL_PAYMENT_METHODS)[number];
 
@@ -24,7 +25,8 @@ export const ALL_PAYMENT_PROCESSORS = [
 	'stripe',
 	'sumup',
 	'swiss-bitcoin-pay',
-	'taler'
+	'taler',
+	'osb'
 ] as const;
 export type PaymentProcessor = (typeof ALL_PAYMENT_PROCESSORS)[number];
 
@@ -50,6 +52,7 @@ export const paymentMethods = (opts?: {
 						case 'bitcoin':
 						case 'lightning':
 						case 'taler':
+						case 'osb':
 							return getProcessorsForMethod(method).some((pp) => pp.isEnabled());
 						case 'bank-transfer':
 							return runtimeConfig.sellerIdentity?.bank;

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -240,6 +240,11 @@ const baseConfig = {
 		backendApiKey: '',
 		currency: 'CHF' as Currency
 	},
+	osb: {
+		shopId: '',
+		password: '',
+		hmacKey: ''
+	},
 	bity: {
 		clientId: ''
 	},
@@ -384,6 +389,12 @@ Amount: {{amount}} {{currency}}</p>`,
 			default: true as boolean
 		},
 		'order.payment.pending.taler': {
+			subject: 'Order #{{orderNumber}}',
+			html: `<p>Payment for order #{{orderNumber}} is pending, see <a href="{{orderLink}}">{{orderLink}}</a></p>
+<p>Please pay using this link: <a href="{{paymentLink}}">{{paymentLink}}</a></p>`,
+			default: true as boolean
+		},
+		'order.payment.pending.osb': {
 			subject: 'Order #{{orderNumber}}',
 			html: `<p>Payment for order #{{orderNumber}} is pending, see <a href="{{orderLink}}">{{orderLink}}</a></p>
 <p>Please pay using this link: <a href="{{paymentLink}}">{{paymentLink}}</a></p>`,

--- a/src/lib/server/sdk/contrib/PPOsb.ts
+++ b/src/lib/server/sdk/contrib/PPOsb.ts
@@ -1,0 +1,151 @@
+import { runtimeConfig } from '$lib/server/runtime-config';
+import { toCurrency } from '$lib/utils/toCurrency';
+import { ORIGIN } from '$lib/server/env-config';
+import { z } from 'zod';
+import type {
+	PaymentProcessorDefinition,
+	CreatePaymentParams,
+	CreatePaymentResult,
+	CheckPaymentResult
+} from '../pp';
+import type { Order } from '$lib/types/Order';
+
+// --- OSB (PayZen/Lyra) REST V4 API helpers ---
+
+const OSB_API_BASE = 'https://api.secure.osb.pf/api-payment/V4';
+
+function isOsbEnabled(): boolean {
+	return !!runtimeConfig.osb.shopId && !!runtimeConfig.osb.password;
+}
+
+function osbAuthHeader(): string {
+	return (
+		'Basic ' +
+		Buffer.from(`${runtimeConfig.osb.shopId}:${runtimeConfig.osb.password}`).toString('base64')
+	);
+}
+
+async function osbRequest(endpoint: string, body: object): Promise<unknown> {
+	const resp = await fetch(`${OSB_API_BASE}/${endpoint}`, {
+		method: 'POST',
+		headers: {
+			Authorization: osbAuthHeader(),
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify(body)
+	});
+	if (!resp.ok) {
+		const errText = await resp.text();
+		throw new Error(`OSB ${endpoint} failed (${resp.status}): ${errText}`);
+	}
+	const json = await resp.json();
+	if (json?.status && json.status !== 'SUCCESS') {
+		const code = json.answer?.errorCode ?? 'UNKNOWN';
+		const msg = json.answer?.errorMessage ?? JSON.stringify(json);
+		throw new Error(`OSB ${endpoint}: ${json.status} ${code} — ${msg}`);
+	}
+	return json;
+}
+
+// --- Zod schemas for API responses ---
+
+const osbCreatePaymentOrderSchema = z.object({
+	status: z.literal('SUCCESS'),
+	answer: z.object({
+		paymentOrderId: z.string(),
+		paymentURL: z.string().url(),
+		paymentOrderStatus: z.string(),
+		amount: z.number(),
+		currency: z.literal('XPF')
+	})
+});
+
+const osbPaymentOrderGetSchema = z.object({
+	status: z.literal('SUCCESS'),
+	answer: z.object({
+		paymentOrderId: z.string(),
+		paymentOrderStatus: z.enum(['RUNNING', 'PAID', 'REFUSED', 'EXPIRED', 'CANCELED']),
+		amount: z.number(),
+		currency: z.literal('XPF')
+	})
+});
+
+// --- SDK Payment Processor ---
+
+export default {
+	meta: { processor: 'osb', method: 'osb', emoji: '🇵🇫' },
+
+	isEnabled: () => isOsbEnabled(),
+
+	paymentPrice(price) {
+		return {
+			amount: toCurrency('XPF', price.amount, price.currency),
+			currency: 'XPF'
+		};
+	},
+
+	async createPayment(params: CreatePaymentParams): Promise<CreatePaymentResult> {
+		// XPF has 0 decimals (ISO 4217), but FRACTION_DIGITS_PER_CURRENCY.XPF = 2 in codebase
+		// Math.round ensures we send an integer to OSB API
+		const amount = Math.round(toCurrency('XPF', params.toPay.amount, params.toPay.currency));
+
+		const resp = osbCreatePaymentOrderSchema.parse(
+			await osbRequest('Charge/CreatePaymentOrder', {
+				amount,
+				currency: 'XPF',
+				orderId: String(params.orderNumber),
+				channelOptions: { channelType: 'URL' },
+				successUrl: `${ORIGIN}/order/${params.orderId}`,
+				cancelUrl: `${ORIGIN}/order/${params.orderId}?cancel=true`,
+				errorUrl: `${ORIGIN}/order/${params.orderId}`,
+				...(params.expiresAt && { expirationDate: params.expiresAt.toISOString() })
+			})
+		);
+
+		return {
+			checkoutId: resp.answer.paymentOrderId,
+			address: resp.answer.paymentURL,
+			processor: 'osb'
+		};
+	},
+
+	async checkPayment(
+		payment: Order['payments'][number],
+		order: Order // eslint-disable-line @typescript-eslint/no-unused-vars
+	): Promise<CheckPaymentResult> {
+		if (!payment.checkoutId) {
+			return { status: 'pending' };
+		}
+
+		let resp;
+		try {
+			resp = osbPaymentOrderGetSchema.parse(
+				await osbRequest('Charge/PaymentOrder/Get', {
+					paymentOrderId: payment.checkoutId
+				})
+			);
+		} catch (err) {
+			throw new Error(`OSB checkPayment failed for ${payment.checkoutId}: ${err}`);
+		}
+
+		const st = resp.answer.paymentOrderStatus;
+
+		if (st === 'PAID') {
+			return {
+				status: 'paid',
+				received: { amount: resp.answer.amount, currency: 'XPF' }
+			};
+		}
+		if (st === 'REFUSED' || st === 'CANCELED') {
+			return { status: 'failed' };
+		}
+		if (st === 'EXPIRED') {
+			return { status: 'expired' };
+		}
+		if (payment.expiresAt && payment.expiresAt < new Date()) {
+			return { status: 'expired' };
+		}
+
+		return { status: 'pending' };
+	}
+} satisfies PaymentProcessorDefinition;

--- a/src/lib/server/sdk/pp-registry.ts
+++ b/src/lib/server/sdk/pp-registry.ts
@@ -9,6 +9,7 @@ import PPBitcoinNodeless from './contrib/PPBitcoinNodeless';
 import PPBitcoind from './contrib/PPBitcoind';
 import PPPaypal from './contrib/PPPaypal';
 import PPTaler from './contrib/PPTaler';
+import PPOsb from './contrib/PPOsb';
 
 // Registration order = default priority per method (when no user preference set)
 
@@ -31,3 +32,6 @@ registerProcessor(PPPaypal);
 
 // taler: single provider
 registerProcessor(PPTaler);
+
+// osb: single provider (French Polynesia)
+registerProcessor(PPOsb);

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -137,6 +137,7 @@
 			"paypal": "Paypal",
 			"point-of-sale": "Point of Sale",
 			"taler": "Taler",
+			"osb": "OSB (Bankkarte)",
 			"unavailable": "Keine Zahlungsmethoden verfügbar."
 		},
 		"paymentStatus": "Zahlungsstatus",
@@ -531,7 +532,8 @@
 			"lightning": "Bezahlt mit: Lightning-Transaktion (1 {paymentCurrency} = {exchangeRate} {mainCurrency} zum Zeitpunkt der Bestellung)",
 			"paypal": "Bezahlt mit: Paypal",
 			"point-of-sale": "Im Geschäft bezahlt",
-			"taler": "Bezahlt mit: Taler"
+			"taler": "Bezahlt mit: Taler",
+			"osb": "Bezahlt mit: OSB-Bankkarte"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Bezahlt mit: verifizierter Banküberweisung",
@@ -540,7 +542,8 @@
 			"free": "Nichts bezahlt",
 			"lightning": "Bezahlt mit: Lightning-Transaktion",
 			"point-of-sale": "Im Geschäft bezahlt",
-			"taler": "Bezahlt mit: Taler"
+			"taler": "Bezahlt mit: Taler",
+			"osb": "Bezahlt mit: OSB"
 		},
 		"payToComplete": "Bezahlen Sie, um die Bestellung abzuschließen.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -137,6 +137,7 @@
 			"paypal": "Paypal",
 			"point-of-sale": "Point of sale",
 			"taler": "Taler",
+			"osb": "OSB (Bank card)",
 			"unavailable": "No payment methods available."
 		},
 		"paymentStatus": "Payment status",
@@ -531,7 +532,8 @@
 			"lightning": "Paid with: Lightning transaction (1 {paymentCurrency} = {exchangeRate} {mainCurrency} at the time of the order)",
 			"paypal": "Paid with: paypal",
 			"point-of-sale": "Paid in store",
-			"taler": "Paid with: Taler"
+			"taler": "Paid with: Taler",
+			"osb": "Paid with: OSB bank card"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Paid with: verified bank transfer",
@@ -540,7 +542,8 @@
 			"free": "Paid Nothing",
 			"lightning": "Paid with: Lightning transaction",
 			"point-of-sale": "Paid in store",
-			"taler": "Paid with: Taler"
+			"taler": "Paid with: Taler",
+			"osb": "Paid with: OSB"
 		},
 		"payToComplete": "Pay to complete the order.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -137,6 +137,7 @@
 			"paypal": "Paypal",
 			"point-of-sale": "Punto de venta",
 			"taler": "Taler",
+			"osb": "OSB (Tarjeta bancaria)",
 			"unavailable": "No hay métodos de pago disponibles."
 		},
 		"paymentStatus": "Estado del pago",
@@ -531,7 +532,8 @@
 			"lightning": "Pagado con: transacción Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento del pedido)",
 			"paypal": "Pagado con: paypal",
 			"point-of-sale": "Pagado en tienda",
-			"taler": "Pagado con: Taler"
+			"taler": "Pagado con: Taler",
+			"osb": "Pagado con: tarjeta bancaria OSB"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Pagado con: transferencia bancaria verificada",
@@ -540,7 +542,8 @@
 			"free": "No se pagó nada",
 			"lightning": "Pagado con: transacción Lightning",
 			"point-of-sale": "Pagado en tienda",
-			"taler": "Pagado con: Taler"
+			"taler": "Pagado con: Taler",
+			"osb": "Pagado con: OSB"
 		},
 		"payToComplete": "Pagar para completar el pedido.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -137,6 +137,7 @@
 			"paypal": "Paypal",
 			"point-of-sale": "Point of sale",
 			"taler": "Taler",
+			"osb": "OSB (Carte bancaire)",
 			"unavailable": "Aucun mode de paiement disponible."
 		},
 		"paymentStatus": "Statut de paiement",
@@ -531,7 +532,8 @@
 			"lightning": "Payé avec : Transaction Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} au moment de la commande)",
 			"paypal": "Payé avec: paypal",
 			"point-of-sale": "Payé en magasin",
-			"taler": "Payé avec : Taler"
+			"taler": "Payé avec : Taler",
+			"osb": "Payé avec : carte bancaire OSB"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Payé avec : virement bancaire vérifié",
@@ -540,7 +542,8 @@
 			"free": "N'a rien payé",
 			"lightning": "Payé avec : Transaction Lightning",
 			"point-of-sale": "Payé en magasin",
-			"taler": "Payé avec : Taler"
+			"taler": "Payé avec : Taler",
+			"osb": "Payé avec : OSB"
 		},
 		"payToComplete": "Payez pour finaliser la commande.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -137,6 +137,7 @@
 			"paypal": "PayPal",
 			"point-of-sale": "Punto di vendita",
 			"taler": "Taler",
+			"osb": "OSB (Carta bancaria)",
 			"unavailable": "Nessun metodo di pagamento valido."
 		},
 		"paymentStatus": "Status del pagamento",
@@ -531,7 +532,8 @@
 			"lightning": "Pagato con: transazione Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento dell'ordine)",
 			"paypal": "Pagato con:  paypal",
 			"point-of-sale": "Pagato in magazzino",
-			"taler": "Pagato con: Taler"
+			"taler": "Pagato con: Taler",
+			"osb": "Pagato con: carta bancaria OSB"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Pagato con: bonifico bancario verificato",
@@ -540,7 +542,8 @@
 			"free": "Nessun pagamento",
 			"lightning": "Pagato con: transazione Lightning",
 			"point-of-sale": "Pagato in magazzino",
-			"taler": "Pagato con: Taler"
+			"taler": "Pagato con: Taler",
+			"osb": "Pagato con: OSB"
 		},
 		"payToComplete": "Paga per completare l'ordine.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -137,6 +137,7 @@
 			"paypal": "Paypal",
 			"point-of-sale": "Verkooppunt",
 			"taler": "Taler",
+			"osb": "OSB (Bankkaart)",
 			"unavailable": "Geen betaalmethoden beschikbaar."
 		},
 		"paymentStatus": "Betalingsstatus",
@@ -531,7 +532,8 @@
 			"lightning": "Betaald met: Lightning-transactie (1 {paymentCurrency} = {exchangeRate} {mainCurrency} op het moment van de bestelling)",
 			"paypal": "Betaald met: paypal",
 			"point-of-sale": "Betaald in de winkel",
-			"taler": "Betaald met: Taler"
+			"taler": "Betaald met: Taler",
+			"osb": "Betaald met: OSB-bankkaart"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Betaald met: geverifieerde bankoverschrijving",
@@ -540,7 +542,8 @@
 			"free": "Niets betaald",
 			"lightning": "Betaald met: Lightning-transactie",
 			"point-of-sale": "Betaald in de winkel",
-			"taler": "Betaald met: Taler"
+			"taler": "Betaald met: Taler",
+			"osb": "Betaald met: OSB"
 		},
 		"payToComplete": "Betaal om de bestelling af te ronden.",
 		"payToCompleteBitcoin": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -137,6 +137,7 @@
 			"paypal": "Paypal",
 			"point-of-sale": "Ponto de venda",
 			"taler": "Taler",
+			"osb": "OSB (Cartão bancário)",
 			"unavailable": "Nenhum método de pagamento disponível."
 		},
 		"paymentStatus": "Estado do pagamento",
@@ -531,7 +532,8 @@
 			"lightning": "Pago com: transação Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} no momento da encomenda)",
 			"paypal": "Pago com: paypal",
 			"point-of-sale": "Pago na loja",
-			"taler": "Pago com: Taler"
+			"taler": "Pago com: Taler",
+			"osb": "Pago com: cartão bancário OSB"
 		},
 		"paidWithSummary": {
 			"bank-transfer": "Pago com: transferência bancária verificada",
@@ -540,7 +542,8 @@
 			"free": "Pago nada",
 			"lightning": "Pago com: transação Lightning",
 			"point-of-sale": "Pago na loja",
-			"taler": "Pago com: Taler"
+			"taler": "Pago com: Taler",
+			"osb": "Pago com: OSB"
 		},
 		"payToComplete": "Pague para completar a encomenda.",
 		"payToCompleteBitcoin": {

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -405,7 +405,8 @@ export const PAYMENT_METHOD_EMOJI: Record<PaymentMethod, string> = {
 	lightning: '⚡',
 	bitcoin: '₿',
 	free: '🆓',
-	taler: '🅣'
+	taler: '🅣',
+	osb: '🇵🇫'
 };
 
 export const ORDER_PAGINATION_LIMIT = 50;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
@@ -151,6 +151,10 @@ export const adminLinks: AdminLinks = [
 				label: 'Taler'
 			},
 			{
+				href: '/admin/osb',
+				label: 'OSB'
+			},
+			{
 				href: '/admin/pos-payments',
 				label: 'PoS Payments'
 			}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.server.ts
@@ -1,0 +1,49 @@
+import { collections } from '$lib/server/database.js';
+import { runtimeConfig } from '$lib/server/runtime-config';
+import { z } from 'zod';
+
+export async function load() {
+	return {
+		osb: runtimeConfig.osb
+	};
+}
+
+export const actions = {
+	save: async function ({ request }) {
+		const osb = z
+			.object({
+				shopId: z.string().min(1),
+				password: z.string().min(1),
+				hmacKey: z.string().default('')
+			})
+			.parse(Object.fromEntries(await request.formData()));
+
+		await collections.runtimeConfig.updateOne(
+			{
+				_id: 'osb'
+			},
+			{
+				$set: {
+					data: osb,
+					updatedAt: new Date()
+				}
+			},
+			{
+				upsert: true
+			}
+		);
+
+		runtimeConfig.osb = osb;
+	},
+	delete: async function () {
+		await collections.runtimeConfig.deleteOne({
+			_id: 'osb'
+		});
+
+		runtimeConfig.osb = {
+			shopId: '',
+			password: '',
+			hmacKey: ''
+		};
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	export let data;
+</script>
+
+<h1 class="text-3xl">OSB</h1>
+
+<form class="contents" method="post" action="?/save">
+	<label class="form-label">
+		Shop ID
+		<input class="form-input" type="text" name="shopId" value={data.osb.shopId} required />
+	</label>
+
+	<label class="form-label">
+		REST API Password
+		<input class="form-input" type="password" name="password" value={data.osb.password} required />
+	</label>
+
+	<label class="form-label">
+		HMAC-SHA-256 Key (optional)
+		<input class="form-input" type="password" name="hmacKey" value={data.osb.hmacKey} />
+	</label>
+
+	<p class="text-sm text-gray-500">Currency: XPF (fixed)</p>
+
+	<div class="flex justify-between">
+		<button class="btn btn-black" type="submit">Save</button>
+		<button class="btn btn-red" type="submit" form="delete-form">Reset</button>
+	</div>
+</form>
+<form class="contents" method="post" action="?/delete" id="delete-form"></form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.ts
@@ -1,0 +1,6 @@
+export async function load({ data }) {
+	return {
+		...data,
+		bodyClass: 'max-w-7xl mx-auto'
+	};
+}


### PR DESCRIPTION
A new payment method "OSB" is now available for merchants in French Polynesia. OSB is a card payment gateway (Visa, Mastercard, CB, Amex) that works with the local currency XPF (CFP Franc).

How it works:
- Admin configures OSB credentials in a new settings page (/admin/osb)
- Customers see "OSB" as a payment option at checkout
- Clicking the payment link redirects to OSB's hosted payment page
- After payment, customers return to the order page where the status updates automatically

Key points:
- Supports XPF (CFP Franc) — the standard currency in French Polynesia
- Same architecture as PayPal — redirect to external page + automatic status polling
- No additional JavaScript or external scripts needed on the shop side

Closes #2513