### PR TITLE
🐛 Fix nostr-relaypool reconnect backoff never resetting

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
 	},
 	"pnpm": {
 		"patchedDependencies": {
-			"date-fns@3.6.0": "patches/date-fns@3.6.0.patch"
+			"date-fns@3.6.0": "patches/date-fns@3.6.0.patch",
+			"nostr-relaypool@0.6.28": "patches/nostr-relaypool@0.6.28.patch"
 		}
 	}
 }

--- a/patches/nostr-relaypool@0.6.28.patch
+++ b/patches/nostr-relaypool@0.6.28.patch
@@ -1,0 +1,46 @@
+diff --git a/lib/nostr-relaypool.esm.js b/lib/nostr-relaypool.esm.js
+index 210ae4b7d2858d7dea6f5bfa85cb4bc863a5e60d..e55572478cac63b9d9a4e18ea869647768fb9966 100644
+--- a/lib/nostr-relaypool.esm.js
++++ b/lib/nostr-relaypool.esm.js
+@@ -135,7 +135,8 @@ var RelayC = class {
+   reconnectTimeout = 0;
+   #reconnect() {
+     setTimeout(() => {
+-      this.reconnectTimeout = Math.max(2e3, this.reconnectTimeout * 3);
++      const base = Math.min(6e5, Math.max(2e3, this.reconnectTimeout * 3));
++      this.reconnectTimeout = Math.floor(base * (0.75 + Math.random() * 0.5));
+       console.log(
+         this.url,
+         "reconnecting after " + this.reconnectTimeout / 1e3 + "s"
+@@ -233,6 +234,7 @@ var RelayC = class {
+       this.resolveClose();
+       return;
+     }
++    this.reconnectTimeout = 0;
+     for (const subid in this.openSubs) {
+       if (this.logging) {
+         console.log("REQ", this.url, subid, ...this.openSubs[subid].filters);
+diff --git a/relay.ts b/relay.ts
+index 3f06b05162da6c42f881a265db8899eab10786b8..c64a8944e7d5bcdfe793a8b1ec89f99ca101dcce 100644
+--- a/relay.ts
++++ b/relay.ts
+@@ -126,7 +126,8 @@ class RelayC {
+   reconnectTimeout: number = 0;
+   #reconnect() {
+     setTimeout(() => {
+-      this.reconnectTimeout = Math.max(2000, this.reconnectTimeout * 3);
++      const base = Math.min(600000, Math.max(2000, this.reconnectTimeout * 3));
++      this.reconnectTimeout = Math.floor(base * (0.75 + Math.random() * 0.5));
+       console.log(
+         this.url,
+         "reconnecting after " + this.reconnectTimeout / 1000 + "s"
+@@ -229,8 +230,7 @@ class RelayC {
+       this.resolveClose();
+       return;
+     }
+-    // console.log("#onopen setting reconnectTimeout to 0");
+-    // this.reconnectTimeout = 0;
++    this.reconnectTimeout = 0;
+     // TODO: Send ephereal messages after subscription, permament before
+     for (const subid in this.openSubs) {
+       if (this.logging) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ patchedDependencies:
   date-fns@3.6.0:
     hash: wsglen72mvliwnhurznyj5erze
     path: patches/date-fns@3.6.0.patch
+  nostr-relaypool@0.6.28:
+    hash: yivktc2sx2wjczvdsu5tmfgdhy
+    path: patches/nostr-relaypool@0.6.28.patch
 
 dependencies:
   '@auth/core':
@@ -95,7 +98,7 @@ dependencies:
     version: 6.9.3
   nostr-relaypool:
     specifier: ^0.6.28
-    version: 0.6.28(ws@8.14.2)
+    version: 0.6.28(patch_hash=yivktc2sx2wjczvdsu5tmfgdhy)(ws@8.14.2)
   nostr-tools:
     specifier: ^1.11.1
     version: 1.11.1
@@ -3897,7 +3900,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /nostr-relaypool@0.6.28(ws@8.14.2):
+  /nostr-relaypool@0.6.28(patch_hash=yivktc2sx2wjczvdsu5tmfgdhy)(ws@8.14.2):
     resolution: {integrity: sha512-kyLChBunf6IB2O3MSPHBe9iSokBGyqZHvAJXZ5+eh9C4znAu7iY8L/yh0V4Ta/P9TtzDna3QTEgFWVan4m0vBA==}
     dependencies:
       '@jest/source-map': 29.4.3
@@ -3907,6 +3910,7 @@ packages:
     transitivePeerDependencies:
       - ws
     dev: false
+    patched: true
 
   /nostr-tools@1.11.1:
     resolution: {integrity: sha512-b8BpCiD3wxjBZwrn0wc+CkVj6/7s4sQxp+Az7UkCG80mJu7xTspZsOoUP/geBNwZVYETzEwj+CPBvW8WIP8mBQ==}

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -246,12 +246,7 @@ const baseConfig = {
 	nostr: {
 		privateKey: ''
 	},
-	nostrRelays: [
-		'wss://nostr.wine',
-		'wss://nostr.lu.ke',
-		'wss://nos.lol',
-		'wss://relay.snort.social'
-	],
+	nostrRelays: ['wss://nostr.wine', 'wss://nos.lol', 'wss://relay.snort.social'],
 	visitorDarkLightMode: 'system' as 'light' | 'dark' | 'system',
 	employeeDarkLightMode: 'system' as 'light' | 'dark' | 'system',
 	removeBebopLogoPOS: false,


### PR DESCRIPTION
Fixes the nostr bot going silent after several hours of uptime and staying silent for many hours after a transient network issue — users had to wait for a process restart to get replies to !help, !cart, etc.

Root cause is a reconnect backoff in the upstream nostr-relaypool library that kept growing and was never reset after a successful reconnect, so any prolonged network blip effectively put the pool to sleep until the process was restarted.

After the fix the bot recovers on its own within 10 minutes of any network issue, regardless of how long it lasted. No restart needed.