### PR TITLE
🦋🤖 Store be-BOP version on order creation (#2551)

### DIFF
--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -32,6 +32,7 @@ import {
 import { error, redirect } from '@sveltejs/kit';
 import { toSatoshis } from '$lib/utils/toSatoshis';
 import { ORIGIN } from '$lib/server/env-config';
+import { PUBLIC_VERSION } from '$env/static/public';
 import { isEmailConfigured, queueEmail } from './email';
 import { sum } from '$lib/utils/sum';
 import { type Cart } from '$lib/types/Cart';
@@ -1373,6 +1374,7 @@ export async function createOrder(
 			_id: orderId,
 			locale: params.locale,
 			number: orderNumber,
+			bebopVersion: PUBLIC_VERSION,
 			createdAt: new Date(),
 			updatedAt: new Date(),
 			status: 'pending',

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -196,6 +196,13 @@ export interface Order extends Timestamps {
 	number: number;
 	locale: LanguageKey;
 
+	/**
+	 * be-BOP version (git commit SHA from PUBLIC_VERSION) at the time the order was created.
+	 * Useful for post-mortem diagnosis if something goes wrong with a saved order.
+	 * Optional for backwards compatibility with orders created before this field existed.
+	 */
+	bebopVersion?: string;
+
 	items: Array<{
 		/**
 		 * Unique identifier for a line in the order.


### PR DESCRIPTION
## Summary

Closes #2551. Stores the be-BOP version (git commit SHA from `PUBLIC_VERSION`, the same value served at `/.well-known/version.txt`) on each order at creation time, so that if something goes wrong with a saved order, we know exactly which build produced it.

## Changes

- `src/lib/types/Order.ts` — add optional `bebopVersion?: string` to the `Order` interface (optional for backwards compatibility with existing orders).
- `src/lib/server/orders.ts` — import `PUBLIC_VERSION` from `$env/static/public` and set `bebopVersion: PUBLIC_VERSION` on the order object literal in `createOrder` (the single insert site).

The field is captured **at order creation only** — a redeploy mid-flight will not rewrite the field on existing orders, which is exactly what we want for post-mortem diagnosis.

## Not in this PR (deferred — consider for near future)

Storing the version on `OrderPayment` as well. Useful for diagnosing payment-flow issues when the order itself was created on an older build than the payment that resolves later. Worth a follow-up issue/PR.

## Test plan

- [ ] Create a new order on a build where `PUBLIC_VERSION` is set → verify `order.bebopVersion` matches `/.well-known/version.txt`.
- [ ] Existing orders (without the field) still load and render correctly in admin order views.
- [ ] Type-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)