### PR TITLE
🆕🤖 Create /booking page for customer to list bookings with sort and i…

### DIFF
--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -26,6 +26,21 @@
 		"agreement": "Ich habe die Zugangsbedingungen gelesen, erfülle sie und respektiere sie",
 		"navigate": "Weiter stöbern"
 	},
+	"booking": {
+		"exportIcal": "iCal exportieren",
+		"listTitle": "Ihre Buchungen",
+		"noBookings": "Sie haben noch keine Buchungen.",
+		"noUpcoming": "Keine anstehenden Buchungen.",
+		"showCanceled": "Stornierte Buchungen anzeigen",
+		"showPast": "Vergangene Buchungen anzeigen",
+		"sort": {
+			"dateAsc": "Buchungsdatum (älteste zuerst)",
+			"dateDesc": "Buchungsdatum (neueste zuerst)",
+			"label": "Sortieren nach",
+			"orderNumberAsc": "Bestellnummer (aufsteigend)",
+			"orderNumberDesc": "Bestellnummer (absteigend)"
+		}
+	},
 	"cart": {
 		"cta": {
 			"checkout": "Zur Kasse",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -26,6 +26,21 @@
 		"agreement": "I have read the access conditions, fulfill them and respect them",
 		"navigate": "Continue browsing"
 	},
+	"booking": {
+		"exportIcal": "Export iCal",
+		"listTitle": "Your bookings",
+		"noBookings": "You have no bookings yet.",
+		"noUpcoming": "No upcoming bookings.",
+		"showCanceled": "Show canceled bookings",
+		"showPast": "Show past bookings",
+		"sort": {
+			"dateAsc": "Booking date (oldest first)",
+			"dateDesc": "Booking date (newest first)",
+			"label": "Sort by",
+			"orderNumberAsc": "Order number (ascending)",
+			"orderNumberDesc": "Order number (descending)"
+		}
+	},
 	"cart": {
 		"cta": {
 			"checkout": "Checkout",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -26,6 +26,21 @@
 		"agreement": "He leído las condiciones de acceso, las cumplo y las respeto",
 		"navigate": "Continuar navegando"
 	},
+	"booking": {
+		"exportIcal": "Exportar iCal",
+		"listTitle": "Sus reservas",
+		"noBookings": "Aún no tiene reservas.",
+		"noUpcoming": "No hay reservas próximas.",
+		"showCanceled": "Mostrar reservas canceladas",
+		"showPast": "Mostrar reservas pasadas",
+		"sort": {
+			"dateAsc": "Fecha de reserva (más antiguas primero)",
+			"dateDesc": "Fecha de reserva (más recientes primero)",
+			"label": "Ordenar por",
+			"orderNumberAsc": "Número de pedido (ascendente)",
+			"orderNumberDesc": "Número de pedido (descendente)"
+		}
+	},
 	"cart": {
 		"cta": {
 			"checkout": "Pagar",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -26,6 +26,21 @@
 		"agreement": "J'ai pris connaissance des conditions d'accès, les remplis et les respecte.",
 		"navigate": "Continuer la navigation"
 	},
+	"booking": {
+		"exportIcal": "Exporter iCal",
+		"listTitle": "Vos réservations",
+		"noBookings": "Vous n'avez pas encore de réservations.",
+		"noUpcoming": "Aucune réservation à venir.",
+		"showCanceled": "Afficher les réservations annulées",
+		"showPast": "Afficher les réservations passées",
+		"sort": {
+			"dateAsc": "Date de réservation (les plus anciennes d'abord)",
+			"dateDesc": "Date de réservation (les plus récentes d'abord)",
+			"label": "Trier par",
+			"orderNumberAsc": "Numéro de commande (croissant)",
+			"orderNumberDesc": "Numéro de commande (décroissant)"
+		}
+	},
 	"cart": {
 		"cta": {
 			"checkout": "Commander",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -26,6 +26,21 @@
 		"agreement": "Ho letto le condizioni di accesso, le adempio e le rispetto",
 		"navigate": "Continua la navigazione"
 	},
+	"booking": {
+		"exportIcal": "Esporta iCal",
+		"listTitle": "Le tue prenotazioni",
+		"noBookings": "Non hai ancora prenotazioni.",
+		"noUpcoming": "Nessuna prenotazione in programma.",
+		"showCanceled": "Mostra prenotazioni annullate",
+		"showPast": "Mostra prenotazioni passate",
+		"sort": {
+			"dateAsc": "Data prenotazione (meno recenti prima)",
+			"dateDesc": "Data prenotazione (più recenti prima)",
+			"label": "Ordina per",
+			"orderNumberAsc": "Numero ordine (crescente)",
+			"orderNumberDesc": "Numero ordine (decrescente)"
+		}
+	},
 	"cart": {
 		"cta": {
 			"checkout": "Pagamento",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -26,6 +26,21 @@
 		"agreement": "Ik heb de toegangsvoorwaarden gelezen, voldoe eraan en respecteer ze",
 		"navigate": "Vervolg de navigatie"
 	},
+	"booking": {
+		"exportIcal": "iCal exporteren",
+		"listTitle": "Uw boekingen",
+		"noBookings": "U heeft nog geen boekingen.",
+		"noUpcoming": "Geen aankomende boekingen.",
+		"showCanceled": "Geannuleerde boekingen tonen",
+		"showPast": "Voorbije boekingen tonen",
+		"sort": {
+			"dateAsc": "Boekingsdatum (oudste eerst)",
+			"dateDesc": "Boekingsdatum (nieuwste eerst)",
+			"label": "Sorteren op",
+			"orderNumberAsc": "Bestelnummer (oplopend)",
+			"orderNumberDesc": "Bestelnummer (aflopend)"
+		}
+	},
 	"cart": {
 		"cta": {
 			"checkout": "Uitchecken",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -26,6 +26,21 @@
 		"agreement": "Li e cumpro as condições de acesso e respeito-as",
 		"navigate": "Continuar a navegar"
 	},
+	"booking": {
+		"exportIcal": "Exportar iCal",
+		"listTitle": "As suas reservas",
+		"noBookings": "Ainda não tem reservas.",
+		"noUpcoming": "Sem reservas próximas.",
+		"showCanceled": "Mostrar reservas canceladas",
+		"showPast": "Mostrar reservas passadas",
+		"sort": {
+			"dateAsc": "Data da reserva (mais antigas primeiro)",
+			"dateDesc": "Data da reserva (mais recentes primeiro)",
+			"label": "Ordenar por",
+			"orderNumberAsc": "Número da encomenda (ascendente)",
+			"orderNumberDesc": "Número da encomenda (descendente)"
+		}
+	},
 	"cart": {
 		"cta": {
 			"checkout": "Finalizar compra",

--- a/src/lib/types/Schedule.ts
+++ b/src/lib/types/Schedule.ts
@@ -109,6 +109,11 @@ export function scheduleToProductId(scheduleId: string) {
 	return match[1] as Product['_id'];
 }
 
+export function tryScheduleToProductId(scheduleId: string): Product['_id'] | null {
+	const match = scheduleId.match(/product:(.+)/);
+	return match ? (match[1] as Product['_id']) : null;
+}
+
 export function minutesToTime(minutes: number) {
 	const hours = Math.floor(minutes / 60);
 	const remainingMinutes = minutes % 60;

--- a/src/routes/(app)/booking/+page.server.ts
+++ b/src/routes/(app)/booking/+page.server.ts
@@ -1,0 +1,64 @@
+import { collections } from '$lib/server/database';
+import type { Order } from '$lib/types/Order';
+import { tryScheduleToProductId } from '$lib/types/Schedule';
+import { userIdentifier, userQuery } from '$lib/server/user';
+
+const BOOKING_LIST_LIMIT = 500;
+
+export async function load({ locals }) {
+	const userQ = userQuery(userIdentifier(locals));
+
+	const orders = await collections.orders
+		.find(userQ)
+		.project<Pick<Order, '_id' | 'number'>>({ _id: 1, number: 1 })
+		.toArray();
+
+	if (!orders.length) {
+		return { bookings: [] };
+	}
+
+	const orderIds = orders.map((o) => o._id);
+	const orderNumberById = new Map(orders.map((o) => [o._id, o.number]));
+
+	const events = await collections.scheduleEvents
+		.find({ orderId: { $in: orderIds }, status: { $in: ['confirmed', 'canceled'] } })
+		.sort({ beginsAt: -1 })
+		.limit(BOOKING_LIST_LIMIT)
+		.toArray();
+
+	const productIdByEvent = new Map(
+		events.map((e) => [e._id.toString(), tryScheduleToProductId(e.scheduleId)] as const)
+	);
+
+	const productIds = [
+		...new Set([...productIdByEvent.values()].filter((id): id is string => !!id))
+	];
+
+	const products = productIds.length
+		? await collections.products
+				.find({ _id: { $in: productIds } })
+				.project<{ _id: string; name: string }>({
+					_id: 1,
+					name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] }
+				})
+				.toArray()
+		: [];
+
+	const productNameById = new Map(products.map((p) => [p._id, p.name]));
+
+	return {
+		bookings: events.map((e) => {
+			const productId = productIdByEvent.get(e._id.toString()) ?? null;
+			return {
+				_id: e._id.toString(),
+				orderId: e.orderId,
+				orderNumber: orderNumberById.get(e.orderId) ?? null,
+				productId,
+				productName: (productId ? productNameById.get(productId) : null) ?? e.title,
+				beginsAt: e.beginsAt,
+				endsAt: e.endsAt,
+				status: e.status
+			};
+		})
+	};
+}

--- a/src/routes/(app)/booking/+page.svelte
+++ b/src/routes/(app)/booking/+page.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { useI18n } from '$lib/i18n';
+	import { exportToICS } from '$lib/types/Schedule';
+	import IconDownloadWindow from '$lib/components/icons/IconDownloadWindow.svelte';
+
+	const { t, locale } = useI18n();
+	export let data;
+
+	type SortKey = 'dateAsc' | 'dateDesc' | 'orderNumberAsc' | 'orderNumberDesc';
+	let sortKey = 'dateAsc' as SortKey;
+	let showPast = false;
+	let showCanceled = false;
+
+	let now = new Date();
+	const tick = setInterval(() => (now = new Date()), 60_000);
+	onDestroy(() => clearInterval(tick));
+
+	$: filtered = data.bookings.filter((b) => {
+		if (!showCanceled && b.status === 'canceled') {
+			return false;
+		}
+		if (!showPast && new Date(b.endsAt) < now) {
+			return false;
+		}
+		return true;
+	});
+
+	$: sorted = [...filtered].sort((a, b) => {
+		switch (sortKey) {
+			case 'orderNumberAsc':
+				return (a.orderNumber ?? 0) - (b.orderNumber ?? 0);
+			case 'orderNumberDesc':
+				return (b.orderNumber ?? 0) - (a.orderNumber ?? 0);
+			case 'dateAsc':
+				return new Date(a.beginsAt).getTime() - new Date(b.beginsAt).getTime();
+			case 'dateDesc':
+				return new Date(b.beginsAt).getTime() - new Date(a.beginsAt).getTime();
+			default:
+				sortKey satisfies never;
+				return 0;
+		}
+	});
+
+	function statusEmoji(b: { beginsAt: Date | string; endsAt: Date | string }) {
+		const begins = new Date(b.beginsAt);
+		const ends = new Date(b.endsAt);
+		if (begins > now) {
+			return '\u{1F535}';
+		}
+		if (ends > now) {
+			return '\u{1F7E0}';
+		}
+		return '\u{1F7E2}';
+	}
+</script>
+
+<main class="mx-auto max-w-7xl p-4 sm:p-6 body-mainPlan flex flex-col gap-4 sm:gap-6">
+	<h1 class="text-2xl sm:text-3xl">{t('booking.listTitle')}</h1>
+
+	{#if data.bookings.length}
+		<div class="flex flex-col gap-3">
+			<label class="form-label">
+				{t('booking.sort.label')}
+				<select class="form-input" bind:value={sortKey}>
+					<option value="dateAsc">{t('booking.sort.dateAsc')}</option>
+					<option value="dateDesc">{t('booking.sort.dateDesc')}</option>
+					<option value="orderNumberAsc">{t('booking.sort.orderNumberAsc')}</option>
+					<option value="orderNumberDesc">{t('booking.sort.orderNumberDesc')}</option>
+				</select>
+			</label>
+			<label class="checkbox-label">
+				<input class="form-checkbox" type="checkbox" bind:checked={showPast} />
+				{t('booking.showPast')}
+			</label>
+			<label class="checkbox-label">
+				<input class="form-checkbox" type="checkbox" bind:checked={showCanceled} />
+				{t('booking.showCanceled')}
+			</label>
+		</div>
+
+		{#if sorted.length}
+			<ul class="flex flex-col gap-3">
+				{#each sorted as b (b._id)}
+					<li class="border rounded-lg p-3 sm:p-4 flex flex-col gap-2">
+						<div class="flex flex-wrap items-baseline justify-between gap-2">
+							<div class="flex items-center gap-2">
+								<span aria-hidden="true">{statusEmoji(b)}</span>
+								<a
+									href="/order/{b.orderId}"
+									target="_blank"
+									rel="noopener"
+									class="body-hyperlink underline font-semibold"
+								>
+									{#if b.orderNumber !== null}
+										#{b.orderNumber.toLocaleString($locale)}
+									{:else}
+										{b.orderId}
+									{/if}
+								</a>
+							</div>
+							{#if b.productId}
+								<a
+									href="/product/{b.productId}"
+									target="_blank"
+									rel="noopener"
+									class="font-medium body-hyperlink underline"
+								>
+									{b.productName}
+								</a>
+							{:else}
+								<span class="font-medium">{b.productName}</span>
+							{/if}
+						</div>
+						<div class="text-sm flex flex-wrap items-center gap-1">
+							<time datetime={new Date(b.beginsAt).toISOString()}>
+								{new Date(b.beginsAt).toLocaleString($locale)}
+							</time>
+							<span aria-hidden="true">–</span>
+							<time datetime={new Date(b.endsAt).toISOString()}>
+								{new Date(b.endsAt).toLocaleString($locale)}
+							</time>
+						</div>
+						<div>
+							<a
+								href={exportToICS(
+									{ title: b.productName, slug: '', beginsAt: b.beginsAt, endsAt: b.endsAt },
+									0
+								)}
+								download="{b.productName}.ics"
+								class="btn btn-black inline-flex items-center gap-2 text-sm"
+							>
+								<IconDownloadWindow class="h-4 w-auto" />
+								{t('booking.exportIcal')}
+							</a>
+						</div>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p class="text-gray-500">{t('booking.noUpcoming')}</p>
+		{/if}
+	{:else}
+		<p class="text-gray-500">{t('booking.noBookings')}</p>
+	{/if}
+</main>


### PR DESCRIPTION
…Cal export

For coworking use, when you book quite often, even few times a day, users need a booking dashboard more practical than /orders

Now, people can check directly their booking without accessing their orders one by one.

<img width="999" height="830" alt="image" src="https://github.com/user-attachments/assets/8b1be36a-11cc-42b1-90e7-f5272be38c58" />

<img width="1080" height="2392" alt="image" src="https://github.com/user-attachments/assets/26291b23-53a2-4b40-916e-5cfed0c973db" />

Close #2562 
