### PR TITLE
🐛🤖 Stack /login post-session CTAs vertically on mobile

### DIFF
--- a/src/routes/(app)/login/+page.svelte
+++ b/src/routes/(app)/login/+page.svelte
@@ -53,7 +53,7 @@
 	</ul>
 	{#if !data.emailToLogin && !data.npubToLogin}
 		<p>{t('login.session.identityPrefill')}</p>
-		<div class="flex gap-4">
+		<div class="flex flex-col items-center sm:flex-row sm:items-start gap-4">
 			<a class="btn body-mainCTA min-h-[2em] h-auto" href="/identity">{t('login.cta.identity')}</a>
 			{#if data.email || data.npub || data.sso?.length}
 				<a class="btn body-mainCTA min-h-[2em] h-auto" href="/orders">{t('login.cta.orders')}</a>


### PR DESCRIPTION
The "My account" / "Orders" / "Sign out" CTAs sat on a single non-responsive flex row, overflowing the viewport on mobile. Switch to a column layout that centers items by default and only goes back to a row from the sm breakpoint upward.

<img width="424" height="717" alt="image" src="https://github.com/user-attachments/assets/2fdec219-c107-49f1-82d0-0276df51cd77" />

Closes #2564