### PR TITLE
🦋 Proper handling of currencies with no cents (XPF, JPY, …)

### DIFF
--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -1,11 +1,11 @@
 import { currencies } from '$lib/stores/currencies';
-import { fixCurrencyRounding } from '$lib/utils/fixCurrencyRounding';
+import { fixCurrencyRounding, roundDownToCurrency } from '$lib/utils/fixCurrencyRounding';
 import { sum } from '$lib/utils/sum';
 import { sumCurrency } from '$lib/utils/sumCurrency';
 import { toCurrency } from '$lib/utils/toCurrency';
 import type { RuntimeConfig } from './server/runtime-config';
 import { type CountryAlpha2 } from './types/Country';
-import { computeVatRate } from './utils/vat';
+import { computeVatRate, extractVat } from './utils/vat';
 import { UNDERLYING_CURRENCY, type Currency } from './types/Currency';
 import type { DiscountType, Price } from './types/Order';
 import type { Product } from './types/Product';
@@ -267,6 +267,79 @@ function ensureDiscountWithinBounds(discount: CartDiscount, cartTotal: number): 
 	}
 }
 
+/** Resolve delivery fees as a VAT-excluded (HT) Price, back-extracting from TTC if needed. */
+function computeDeliveryFeesHt(params: {
+	deliveryFees: Price;
+	deliveryFeesVatProfileId?: string | null;
+	deliveryFeesVatIncluded?: boolean;
+	bebopCountry: CountryAlpha2 | undefined;
+	userCountry: CountryAlpha2 | undefined;
+	vatSingleCountry: boolean;
+	vatProfiles: Array<{
+		_id: string | ObjectId;
+		rates: Partial<Record<CountryAlpha2, number>>;
+	}>;
+}): Price {
+	if (!params.deliveryFeesVatIncluded) {
+		return params.deliveryFees;
+	}
+	const rate = computeVatRate({
+		productVatProfileId: params.deliveryFeesVatProfileId ?? undefined,
+		vatProfiles: params.vatProfiles,
+		bebopCountry: params.bebopCountry,
+		userCountry: params.userCountry,
+		vatSingleCountry: params.vatSingleCountry
+	});
+	return {
+		amount: extractVat(params.deliveryFees.amount, rate),
+		currency: params.deliveryFees.currency
+	};
+}
+
+/** Percentage discounts round DOWN — a smaller-than-stated discount can be illegal. */
+function applyCartDiscount(params: {
+	discount: CartDiscount;
+	totalPriceWithVat: number;
+	partialPriceWithVat: number;
+}): { totalPriceWithVat: number; partialPriceWithVat: number; discountAmount: number } {
+	const discount = ensureDiscountWithinBounds(params.discount, params.totalPriceWithVat);
+	const oldTotalPriceWithVat = params.totalPriceWithVat;
+	let totalPriceWithVat: number;
+	if (discount.type === 'percentage') {
+		const main = get(currencies).main;
+		const totalInMain = toCurrency(
+			main,
+			Math.max((oldTotalPriceWithVat * (100 - discount.amount)) / 100, 0),
+			UNDERLYING_CURRENCY
+		);
+		totalPriceWithVat = toCurrency(
+			UNDERLYING_CURRENCY,
+			roundDownToCurrency(totalInMain, main),
+			main
+		);
+	} else {
+		totalPriceWithVat = Math.max(
+			sumCurrency(UNDERLYING_CURRENCY, [
+				{ amount: oldTotalPriceWithVat, currency: UNDERLYING_CURRENCY },
+				{ amount: -discount.amount, currency: get(currencies).main }
+			]),
+			0
+		);
+	}
+	const discountAmount = oldTotalPriceWithVat - totalPriceWithVat;
+	let partialPriceWithVat = params.partialPriceWithVat;
+	if (discountAmount) {
+		partialPriceWithVat = fixCurrencyRounding(
+			Math.max(
+				partialPriceWithVat - (discountAmount * partialPriceWithVat) / oldTotalPriceWithVat,
+				0
+			),
+			UNDERLYING_CURRENCY
+		);
+	}
+	return { totalPriceWithVat, partialPriceWithVat, discountAmount };
+}
+
 /**
  * Computes different prices for cart-like objects.
  *
@@ -280,6 +353,10 @@ export function computePriceInfo(
 	params: {
 		bebopCountry: CountryAlpha2 | undefined;
 		deliveryFees: Price;
+		/** null = shop standard VAT; otherwise a VAT profile id (hex ObjectId string). */
+		deliveryFeesVatProfileId?: string | null;
+		/** true = `deliveryFees.amount` is VAT-included (TTC). */
+		deliveryFeesVatIncluded?: boolean;
 		discount?: CartDiscount;
 		freeProductUnits: Record<string, number>;
 		userCountry: CountryAlpha2 | undefined;
@@ -296,8 +373,20 @@ export function computePriceInfo(
 	const isPhysicalVatExempted =
 		params.vatNullOutsideSellerCountry && params.bebopCountry !== params.userCountry;
 	const singleVatCountry = params.vatSingleCountry && !!params.bebopCountry;
-	const cartPrice = computeCartPrice(items, {
+
+	// Resolve HT before computeCartPrice so subtotal and VAT use the same base.
+	const deliveryFeesHt = computeDeliveryFeesHt({
 		deliveryFees: params.deliveryFees,
+		deliveryFeesVatProfileId: params.deliveryFeesVatProfileId,
+		deliveryFeesVatIncluded: params.deliveryFeesVatIncluded,
+		bebopCountry: params.bebopCountry,
+		userCountry: params.userCountry,
+		vatSingleCountry: params.vatSingleCountry,
+		vatProfiles: params.vatProfiles
+	});
+
+	const cartPrice = computeCartPrice(items, {
+		deliveryFees: deliveryFeesHt,
 		freeUnits
 	});
 	const { partialAmount: partialPrice, totalAmount: totalPrice } = cartPrice.cart;
@@ -308,7 +397,11 @@ export function computePriceInfo(
 	});
 	const deliveryFeeVat = computeVatForItem(
 		{
-			product: { shipping: true, price: params.deliveryFees },
+			product: {
+				shipping: true,
+				price: deliveryFeesHt,
+				vatProfileId: params.deliveryFeesVatProfileId ?? undefined
+			},
 			quantity: 1
 		},
 		{ ...params, freeUnits: 0, isPhysicalVatExempted }
@@ -328,32 +421,14 @@ export function computePriceInfo(
 	let discountAmount = 0;
 
 	if (params.discount) {
-		const discount = ensureDiscountWithinBounds(params.discount, totalPriceWithVat);
-		const oldTotalPriceWithVat = totalPriceWithVat;
-		if (discount.type === 'percentage') {
-			totalPriceWithVat = fixCurrencyRounding(
-				Math.max((totalPriceWithVat * (100 - discount.amount)) / 100, 0),
-				UNDERLYING_CURRENCY
-			);
-		} else {
-			totalPriceWithVat = Math.max(
-				sumCurrency(UNDERLYING_CURRENCY, [
-					{ amount: totalPriceWithVat, currency: UNDERLYING_CURRENCY },
-					{ amount: -discount.amount, currency: get(currencies).main }
-				]),
-				0
-			);
-		}
-		discountAmount = oldTotalPriceWithVat - totalPriceWithVat;
-		if (discountAmount) {
-			partialPriceWithVat = fixCurrencyRounding(
-				Math.max(
-					partialPriceWithVat - (discountAmount * partialPriceWithVat) / oldTotalPriceWithVat,
-					0
-				),
-				UNDERLYING_CURRENCY
-			);
-		}
+		const discounted = applyCartDiscount({
+			discount: params.discount,
+			totalPriceWithVat,
+			partialPriceWithVat
+		});
+		totalPriceWithVat = discounted.totalPriceWithVat;
+		partialPriceWithVat = discounted.partialPriceWithVat;
+		discountAmount = discounted.discountAmount;
 	}
 
 	// Round final prices to display precision (2 decimals for fiat)
@@ -399,6 +474,12 @@ export function computePriceInfo(
 				partialPrice: vatItem.partialPrice
 			});
 		}
+	}
+
+	// Round each VAT rate once — never sum line-level rounded values.
+	for (const v of reducedVat) {
+		v.price.amount = fixCurrencyRounding(v.price.amount, v.price.currency);
+		v.partialPrice.amount = fixCurrencyRounding(v.partialPrice.amount, v.partialPrice.currency);
 	}
 
 	return {

--- a/src/lib/components/DeliveryFeesSelector.svelte
+++ b/src/lib/components/DeliveryFeesSelector.svelte
@@ -7,10 +7,16 @@
 	import Select from 'svelte-select';
 	import CurrencyLabel from '$lib/components/CurrencyLabel.svelte';
 	import { currencies } from '$lib/stores/currencies';
+	import { applyVat, extractVat } from '$lib/utils/vat';
+	import { fixCurrencyRounding } from '$lib/utils/fixCurrencyRounding';
 
 	export let deliveryFees: DeliveryFees = {};
 	export let defaultCurrency: Currency;
 	export let disabled = false;
+	// vatIncludedReference: entered amounts are TTC (true) or HT (false). vatRate (%): drives
+	// the helper-text showing the inverse value under each input; 0 hides it.
+	export let vatIncludedReference = false;
+	export let vatRate = 0;
 
 	let feeCountryToAdd: CountryAlpha2 | 'default' = 'default';
 
@@ -41,6 +47,17 @@
 	$: feeCountryToAdd = countriesWithNoFee.includes(feeCountryToAdd)
 		? feeCountryToAdd
 		: countriesWithNoFee[0];
+
+	function onAmountInput(country: CountryAlpha2 | 'default', event: Event) {
+		const fee = deliveryFees[country];
+		if (!fee) {
+			return;
+		}
+		const input = event.target as HTMLInputElement;
+		const parsed = parseFloat(input.value);
+		fee.amount = isNaN(parsed) ? 0 : parsed;
+		deliveryFees = deliveryFees;
+	}
 </script>
 
 {#if countriesWithNoFee.length}
@@ -74,7 +91,7 @@
 		</h3>
 		<div class="gap-4 flex flex-col md:flex-row">
 			<label class="w-full">
-				Amount
+				Amount {vatIncludedReference ? '(VAT included)' : '(VAT excluded)'}
 				<input
 					class="form-input"
 					type="number"
@@ -85,8 +102,23 @@
 					value={deliveryFee?.amount
 						.toLocaleString('en', { maximumFractionDigits: 8 })
 						.replace(/,/g, '')}
+					on:input={(e) => onAmountInput(country, e)}
 					required
 				/>
+				{#if vatRate > 0 && deliveryFee && selectedCurrencies[country]}
+					{@const selectedCurrency = selectedCurrencies[country]?.value}
+					{#if selectedCurrency}
+						<small class="text-gray-500 block mt-1">
+							{#if vatIncludedReference}
+								= {fixCurrencyRounding(extractVat(deliveryFee.amount, vatRate), selectedCurrency)}
+								{selectedCurrency} (VAT excluded)
+							{:else}
+								= {fixCurrencyRounding(applyVat(deliveryFee.amount, vatRate), selectedCurrency)}
+								{selectedCurrency} (VAT included)
+							{/if}
+						</small>
+					{/if}
+				{/if}
 			</label>
 
 			<label class="w-full">

--- a/src/lib/components/PriceFieldsWithVat.svelte
+++ b/src/lib/components/PriceFieldsWithVat.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import { FRACTION_DIGITS_PER_CURRENCY, type Currency } from '$lib/types/Currency';
+	import { applyVat, extractVat } from '$lib/utils/vat';
+	import { fixCurrencyRounding } from '$lib/utils/fixCurrencyRounding';
+	import { hasMoreDecimalsThanCurrency } from '$lib/utils/currency-validation';
+
+	export let priceVatExcluded: number;
+	export let currency: Currency;
+	export let vatRate: number;
+	export let vatProfileLabel = 'No custom VAT profile';
+	export let disabled = false;
+
+	// Computed TTC is rounded to currency precision (float artifact: 17.24137931 × 1.16 =
+	// 19.999999999599996); user-typed TTC is kept raw so decimal validation can fire on "19.99".
+	let priceVatIncluded = fixCurrencyRounding(applyVat(priceVatExcluded, vatRate), currency);
+
+	function onHtInput(event: Event) {
+		const value = parseFloat((event.target as HTMLInputElement).value);
+		// Empty/invalid field: keep previous value — a 0 price becomes a free product server-side.
+		if (Number.isNaN(value)) {
+			return;
+		}
+		priceVatExcluded = value;
+		priceVatIncluded = fixCurrencyRounding(applyVat(value, vatRate), currency);
+	}
+
+	function onTtcInput(event: Event) {
+		const value = parseFloat((event.target as HTMLInputElement).value);
+		if (Number.isNaN(value)) {
+			return;
+		}
+		priceVatIncluded = value;
+		priceVatExcluded = vatRate === 0 ? value : extractVat(value, vatRate);
+	}
+
+	// Recompute TTC on rate/currency change only — never clobber a raw user-typed TTC.
+	let lastVatRate = vatRate;
+	let lastCurrency = currency;
+	$: if (vatRate !== lastVatRate || currency !== lastCurrency) {
+		lastVatRate = vatRate;
+		lastCurrency = currency;
+		priceVatIncluded = fixCurrencyRounding(applyVat(priceVatExcluded, vatRate), currency);
+	}
+
+	$: vatAmount = priceVatExcluded * (vatRate / 100);
+	$: displayedExcluded = fixCurrencyRounding(priceVatExcluded, currency);
+	$: displayedVat = fixCurrencyRounding(vatAmount, currency);
+	$: hasDecimalError = hasMoreDecimalsThanCurrency(priceVatIncluded, currency);
+</script>
+
+<div class="gap-4 flex flex-col md:flex-row">
+	<label class="w-full">
+		<span class="text-red-500">*</span> Price amount (VAT excluded)
+		<input
+			class="form-input"
+			type="number"
+			step="any"
+			name="priceAmount"
+			value={priceVatExcluded}
+			on:input={onHtInput}
+			on:wheel|preventDefault
+			{disabled}
+			required
+		/>
+	</label>
+
+	<label class="w-full">
+		<span class="text-red-500">*</span> Price amount (VAT included)
+		<input
+			class="form-input"
+			class:border-red-500={hasDecimalError}
+			type="number"
+			step="any"
+			name="priceAmountVatIncluded"
+			value={priceVatIncluded}
+			on:input={onTtcInput}
+			on:wheel|preventDefault
+			{disabled}
+			required
+		/>
+		<small class="text-gray-500 block mt-1">
+			Fill your end user price here. More info about price definition (i)
+		</small>
+	</label>
+</div>
+
+{#if hasDecimalError}
+	<p class="alert-error">
+		{currency} currency has {FRACTION_DIGITS_PER_CURRENCY[currency]} decimal. Your current price amount
+		(VAT included) has more. Please correct that otherwise you will have accounting and taxes errors.
+	</p>
+{/if}
+
+<div class="gap-4 flex flex-col md:flex-row">
+	<label class="w-full">
+		VAT profile
+		<input class="form-input" value={vatProfileLabel} disabled />
+	</label>
+
+	<label class="w-full">
+		VAT rate (%)
+		<input class="form-input" type="number" value={vatRate} disabled />
+	</label>
+
+	<label class="w-full">
+		VAT amount
+		<input class="form-input" type="number" value={vatAmount} disabled />
+	</label>
+</div>
+
+<div class="gap-4 flex flex-col md:flex-row">
+	<label class="w-full">
+		Displayed estimated price amount (VAT excluded)
+		<input class="form-input" type="number" value={displayedExcluded} disabled />
+	</label>
+
+	<label class="w-full">
+		Displayed estimated price amount (VAT included)
+		<input
+			class="form-input"
+			class:border-red-500={hasDecimalError}
+			type="number"
+			value={priceVatIncluded}
+			disabled
+		/>
+	</label>
+
+	<label class="w-full">
+		Displayed estimated VAT amount
+		<input class="form-input" type="number" value={displayedVat} disabled />
+	</label>
+</div>

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -2,7 +2,6 @@
 	import {
 		CURRENCY_UNIT,
 		computePriceForStorage,
-		readStoredPrice,
 		sortCurrencies,
 		currenciesToSelectOptions
 	} from '$lib/types/Currency';
@@ -20,6 +19,7 @@
 	import type { LayoutServerData } from '../../routes/(app)/$types';
 	import DeliveryFeesSelector from './DeliveryFeesSelector.svelte';
 	import CurrencyLabel from './CurrencyLabel.svelte';
+	import PriceFieldsWithVat from './PriceFieldsWithVat.svelte';
 	import Editor from '@tinymce/tinymce-svelte';
 	import { MAX_CONTENT_LIMIT } from '$lib/types/CmsPage';
 	import {
@@ -32,12 +32,14 @@
 	import type { ProductActionSettings } from '$lib/types/ProductActionSettings';
 	import { preUploadPicture } from '$lib/types/Picture';
 	import { currencies } from '$lib/stores/currencies';
+	import { page } from '$app/stores';
 	import type { PojoObject } from '$lib/server/pojo';
 	import type { PaymentMethod } from '$lib/server/payment-methods';
 	import { useI18n } from '$lib/i18n';
 	import { typedFromEntries } from '$lib/utils/typedFromEntries';
 	import { type Day, dayList, productToScheduleId, type BookingSummary } from '$lib/types/Schedule';
 	import { formatDuration } from '$lib/utils/formatDuration';
+	import { computeVatRate } from '$lib/utils/vat';
 
 	const { t } = useI18n();
 
@@ -97,7 +99,6 @@
 	let restrictPaymentMethods = !!product.paymentMethods;
 	let vatProfileId = product.vatProfileId || '';
 	let formElement: HTMLFormElement;
-	let priceAmountElement: HTMLInputElement;
 	let variationInput: HTMLInputElement[] = [];
 	let disableDateChange = !isNew;
 	let displayPreorderCustomText = !!product.customPreorderText;
@@ -119,9 +120,8 @@
 		: 3;
 	let displayRawHTMLBefore = false;
 	let displayRawHTMLAfter = false;
-	let displayVATCalculator = false;
-	let priceAmountVATIncluded = product.price.amount;
-	let vatRate = 0;
+
+	let priceVatExcluded = product.price.amount;
 
 	// Currency options for Select component (sorted: priceRef → main → secondary → BTC/SAT → fiat A-Z)
 	const sortedCurrencies = sortCurrencies(
@@ -132,14 +132,23 @@
 	const allCurrenciesOptions = currenciesToSelectOptions(sortedCurrencies);
 	let selectedCurrency =
 		allCurrenciesOptions.find((c) => c.value === product.price.currency) || null;
+	let currency: import('$lib/types/Currency').Currency = product.price.currency;
 	$: if (selectedCurrency) {
-		product.price.currency = selectedCurrency.value;
+		currency = selectedCurrency.value;
 	}
-	$: product.price = computePriceForStorage(
-		(100 * priceAmountVATIncluded) / (100 + vatRate),
-		product.price.currency
-	);
-	$: displayPrecision = readStoredPrice(product.price).precision;
+
+	$: vatRate = computeVatRate({
+		productVatProfileId: vatProfileId || undefined,
+		vatProfiles,
+		bebopCountry: $page.data.vatCountry,
+		userCountry: $page.data.vatCountry,
+		vatSingleCountry: true
+	});
+	$: vatProfileLabel =
+		vatProfiles.find((p) => p._id === vatProfileId)?.name ?? 'No custom VAT profile';
+
+	$: product.price = computePriceForStorage(priceVatExcluded, currency);
+
 	if (product._id && isNew) {
 		product.name = product.name + ' (duplicate)';
 		product._id = generateId(product.name, false);
@@ -163,30 +172,34 @@
 		});
 		//--- end
 
+		const priceAmountInput = formElement.querySelector<HTMLInputElement>(
+			'input[name="priceAmount"]'
+		);
 		try {
 			if (
-				priceAmountElement.value &&
-				+priceAmountElement.value < CURRENCY_UNIT[product.price.currency] &&
+				priceAmountInput &&
+				priceAmountInput.value &&
+				+priceAmountInput.value < CURRENCY_UNIT[product.price.currency] &&
 				!product.payWhatYouWant &&
 				!product.free
 			) {
 				if (
-					parseInt(priceAmountElement.value) === 0 &&
+					parseInt(priceAmountInput.value) === 0 &&
 					!confirm('Do you want to save this product as free product? (current price == 0)')
 				) {
-					priceAmountElement.setCustomValidity(
+					priceAmountInput.setCustomValidity(
 						'Price must be greater than or equal to ' +
 							CURRENCY_UNIT[product.price.currency] +
 							' ' +
 							product.price.currency +
 							' or might be free'
 					);
-					priceAmountElement.reportValidity();
+					priceAmountInput.reportValidity();
 					event.preventDefault();
 					return;
 				}
-			} else {
-				priceAmountElement.setCustomValidity('');
+			} else if (priceAmountInput) {
+				priceAmountInput.setCustomValidity('');
 			}
 
 			const seen = new Set<string>();
@@ -413,82 +426,17 @@
 					{/if}
 				</label>
 
-				<div class="gap-4 flex flex-col md:flex-row">
-					<label class="w-full">
-						<span class="text-red-500">*</span> Price amount (VAT excluded)
-						<input
-							class="form-input"
-							type="number"
-							name="priceAmount"
-							placeholder="0.00"
-							step="any"
-							disabled={product.free}
-							value={product.price.amount
-								.toLocaleString('en', { maximumFractionDigits: 8 })
-								.replace(/,/g, '')}
-							bind:this={priceAmountElement}
-							on:input={() => priceAmountElement?.setCustomValidity('')}
-							required
-						/>
-					</label>
-
-					<label class="w-full">
-						<CurrencyLabel label="Price currency" />
-						<Select
-							items={allCurrenciesOptions}
-							searchable={true}
-							clearable={false}
-							bind:value={selectedCurrency}
-							on:change={() => priceAmountElement?.setCustomValidity('')}
-							class="form-input"
-						/>
-						<input type="hidden" name="priceCurrency" value={selectedCurrency?.value || ''} />
-					</label>
-				</div>
-
-				<!-- svelte-ignore a11y-invalid-attribute -->
-				<a
-					href="#"
-					class="text-blue-600 hover:text-blue-800 underline text-sm"
-					on:click|preventDefault={() => (displayVATCalculator = !displayVATCalculator)}
-				>
-					{displayVATCalculator ? 'Hide VAT calculator' : 'Show VAT calculator'}
-				</a>
-
-				{#if displayVATCalculator}
-					<div class="bg-gray-50 p-4 rounded-lg">
-						<div class="gap-4 flex flex-col md:flex-row">
-							<label class="w-full">
-								Price amount (VAT included)
-								<input
-									class="form-input"
-									type="number"
-									bind:value={priceAmountVATIncluded}
-									step="any"
-								/>
-							</label>
-							<label class="w-full">
-								VAT rate (%)
-								<input class="form-input" type="number" bind:value={vatRate} step="any" />
-							</label>
-							<label class="w-full">
-								Price amount (VAT excluded)
-								<input
-									class="form-input"
-									type="number"
-									value={product.price.amount
-										.toLocaleString('en', {
-											maximumFractionDigits: displayPrecision,
-											minimumFractionDigits: 0
-										})
-										.replace(/,/g, '')}
-									step="any"
-									readonly
-								/>
-							</label>
-						</div>
-					</div>
-				{/if}
+				<label class="w-full block">
+					<CurrencyLabel label="Price currency" />
+					<Select
+						items={allCurrenciesOptions}
+						searchable={true}
+						clearable={false}
+						bind:value={selectedCurrency}
+						class="form-input"
+					/>
+					<input type="hidden" name="priceCurrency" value={selectedCurrency?.value || ''} />
+				</label>
 
 				{#if vatProfiles.length}
 					<label class="form-label">
@@ -501,6 +449,14 @@
 						</select>
 					</label>
 				{/if}
+
+				<PriceFieldsWithVat
+					bind:priceVatExcluded
+					{currency}
+					{vatRate}
+					{vatProfileLabel}
+					disabled={product.free}
+				/>
 
 				{#if isNew && !duplicateFromId}
 					<label class="form-label">
@@ -650,13 +606,7 @@
 			</summary>
 			<div class="p-4 pt-0 space-y-4">
 				<label class="checkbox-label">
-					<input
-						class="form-checkbox"
-						type="checkbox"
-						bind:checked={product.free}
-						on:input={() => priceAmountElement?.setCustomValidity('')}
-						name="free"
-					/>
+					<input class="form-checkbox" type="checkbox" bind:checked={product.free} name="free" />
 					This is a free product
 				</label>
 
@@ -665,7 +615,6 @@
 						class="form-checkbox"
 						type="checkbox"
 						bind:checked={product.standalone}
-						on:input={() => priceAmountElement?.setCustomValidity('')}
 						name="standalone"
 						disabled={product.payWhatYouWant}
 					/>
@@ -677,7 +626,6 @@
 						class="form-checkbox"
 						type="checkbox"
 						bind:checked={product.payWhatYouWant}
-						on:input={() => priceAmountElement?.setCustomValidity('')}
 						name="payWhatYouWant"
 						disabled={product.type === 'subscription'}
 					/>
@@ -1814,14 +1762,7 @@
 		<!-- Form Actions -->
 		<div class="bg-white border border-gray-200 rounded-lg p-6 shadow-sm">
 			<div class="flex flex-wrap justify-between gap-3">
-				<button
-					type="submit"
-					class="btn btn-blue px-8 py-3 font-medium"
-					on:click={() => {
-						priceAmountElement?.setCustomValidity('');
-					}}
-					disabled={submitting}
-				>
+				<button type="submit" class="btn btn-blue px-8 py-3 font-medium" disabled={submitting}>
 					{#if submitting}
 						<svg
 							class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -6,6 +6,7 @@ import type { OrderPayment } from '$lib/types/Order';
 import { Lock } from './lock';
 import { ORIGIN } from '$lib/server/env-config';
 import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
+import { CURRENCIES, FRACTION_DIGITS_PER_CURRENCY } from '$lib/types/Currency';
 
 const migrations = [
 	{
@@ -670,6 +671,29 @@ const migrations = [
 					createdAt: new Date(),
 					updatedAt: new Date()
 				})),
+				{ session }
+			);
+		}
+	},
+	{
+		_id: new ObjectId('6a0f4880e92e590e85af2535'),
+		name: 'Round product prices to integer for zero-decimal currencies (issue #2535)',
+		run: async (session: ClientSession) => {
+			// SAT excluded: crypto unit, already integer.
+			const ZERO_DECIMAL_CURRENCIES = CURRENCIES.filter(
+				(c) => FRACTION_DIGITS_PER_CURRENCY[c] === 0 && c !== 'SAT'
+			);
+
+			await collections.products.updateMany(
+				{ 'price.currency': { $in: ZERO_DECIMAL_CURRENCIES } },
+				[
+					{
+						$set: {
+							'price.amount': { $round: ['$price.amount', 0] },
+							'price.precision': 0
+						}
+					}
+				],
 				{ session }
 			);
 		}

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -868,6 +868,8 @@ export async function createOrder(
 	const priceInfo = computePriceInfo(items, {
 		bebopCountry: runtimeConfig.vatCountry,
 		deliveryFees: shippingPrice,
+		deliveryFeesVatProfileId: runtimeConfig.deliveryFees.vatProfileId,
+		deliveryFeesVatIncluded: runtimeConfig.deliveryFees.vatIncludedReference,
 		discount: discountInfo,
 		freeProductUnits: await freeProductsForUser(
 			params.user,

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -144,6 +144,8 @@ const baseConfig = {
 		applyFlatFeeToEachItem: false,
 		onlyPayHighest: false,
 		allowFreeForPOS: false,
+		vatIncludedReference: false,
+		vatProfileId: null as string | null,
 		deliveryFees: {
 			default: {
 				amount: 0,

--- a/src/lib/types/Currency.ts
+++ b/src/lib/types/Currency.ts
@@ -182,7 +182,7 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 	BDT: 2,
 	BGN: 2,
 	BHD: 2,
-	BIF: 2,
+	BIF: 0,
 	BMD: 2,
 	BND: 2,
 	BOB: 2,
@@ -195,14 +195,14 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 	CAD: 2,
 	CDF: 2,
 	CHF: 2,
-	CLP: 2,
+	CLP: 0,
 	CNY: 2,
 	COP: 2,
 	CRC: 2,
 	CUP: 2,
 	CVE: 2,
 	CZK: 2,
-	DJF: 2,
+	DJF: 0,
 	DKK: 2,
 	DOP: 2,
 	DZD: 2,
@@ -217,7 +217,7 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 	GHS: 2,
 	GIP: 2,
 	GMD: 2,
-	GNF: 2,
+	GNF: 0,
 	GTQ: 2,
 	GYD: 2,
 	HKD: 2,
@@ -230,15 +230,15 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 	INR: 2,
 	IQD: 2,
 	IRR: 2,
-	ISK: 2,
+	ISK: 0,
 	JMD: 2,
 	JOD: 2,
-	JPY: 2,
+	JPY: 0,
 	KES: 2,
 	KGS: 2,
 	KHR: 2,
-	KMF: 2,
-	KRW: 2,
+	KMF: 0,
+	KRW: 0,
 	KWD: 2,
 	KYD: 2,
 	KZT: 2,
@@ -277,12 +277,12 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 	PHP: 2,
 	PKR: 2,
 	PLN: 2,
-	PYG: 2,
+	PYG: 0,
 	QAR: 2,
 	RON: 2,
 	RSD: 2,
 	RUB: 2,
-	RWF: 2,
+	RWF: 0,
 	SAR: 2,
 	SBD: 2,
 	SCR: 2,
@@ -305,18 +305,18 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 	TWD: 2,
 	TZS: 2,
 	UAH: 2,
-	UGX: 2,
+	UGX: 0,
 	USD: 2,
 	UYU: 2,
 	UZS: 2,
 	VES: 2,
 	VND: 2,
-	VUV: 2,
+	VUV: 0,
 	WST: 2,
-	XAF: 2,
+	XAF: 0,
 	XCD: 2,
-	XOF: 2,
-	XPF: 2,
+	XOF: 0,
+	XPF: 0,
 	YER: 2,
 	ZAR: 2,
 	ZMK: 2,
@@ -326,13 +326,14 @@ export const FRACTION_DIGITS_PER_CURRENCY = Object.freeze({
 
 /**
  * Maximum number of decimal places for storing prices WITHOUT VAT.
- * This allows merchants to set precise base prices that result in round
- * numbers after VAT calculation (e.g., 4.6253 CHF → 5.00 CHF with 8.1% VAT).
+ * 8 decimals for fiat allows merchants to enter a clean VAT-included price
+ * and store the resulting VAT-excluded base with enough precision to round-trip
+ * exactly (e.g., 20 XPF TTC → store HT 17.24137931 → display TTC back as 20).
  *
- * Display precision remains FRACTION_DIGITS_PER_CURRENCY (2 for most currencies).
+ * Display precision remains FRACTION_DIGITS_PER_CURRENCY (per ISO 4217).
  */
 const STORAGE_FRACTION_DIGITS_PER_CURRENCY = Object.freeze(
-	Object.fromEntries(CURRENCIES.map((c) => [c, c === 'BTC' ? 8 : c === 'SAT' ? 0 : 4]))
+	Object.fromEntries(CURRENCIES.map((c) => [c, c === 'SAT' ? 0 : 8]))
 ) as Record<Currency, number>;
 
 export const CURRENCY_UNIT = Object.freeze(
@@ -340,7 +341,7 @@ export const CURRENCY_UNIT = Object.freeze(
 ) as Record<Currency, number>;
 
 export function parsePriceAmount(amount: string, currency: Currency): number {
-	// Use storage precision (4 decimals for fiat, 8 for BTC) instead of display precision
+	// Use storage precision (8 decimals for fiat & BTC, 0 for SAT) instead of display precision
 	const storageDecimals = STORAGE_FRACTION_DIGITS_PER_CURRENCY[currency];
 	const priceAmount =
 		(parseFloat(amount) * Math.pow(10, storageDecimals)) / Math.pow(10, storageDecimals);
@@ -354,13 +355,15 @@ export function parsePriceAmount(amount: string, currency: Currency): number {
 
 /**
  * Compute price for storage in database with full precision.
- * Uses STORAGE_FRACTION_DIGITS_PER_CURRENCY (4 decimals for fiat, 8 for BTC).
+ * Uses STORAGE_FRACTION_DIGITS_PER_CURRENCY (8 decimals for fiat & BTC, 0 for SAT).
  *
- * Use this when saving prices to preserve full precision for VAT calculations.
+ * Use this when saving prices to preserve full precision for VAT calculations
+ * and clean round-trip with VAT-included input
+ * (e.g., 20 XPF TTC → store HT 17.24137931 → display TTC back as 20).
  *
  * @example
- * computePriceForStorage(4.6253, 'CHF')
- * // Returns: { amount: 4.6253, currency: 'CHF', precision: 4 }
+ * computePriceForStorage(17.24137931, 'XPF')
+ * // Returns: { amount: 17.24137931, currency: 'XPF', precision: 8 }
  */
 export function computePriceForStorage(amount: string | number, currency: Currency): Price {
 	const precision = STORAGE_FRACTION_DIGITS_PER_CURRENCY[currency];

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -28,13 +28,14 @@ export type Price = {
 	 * Number of decimal places for storing this price.
 	 *
 	 * **Optional for backwards compatibility** - when undefined, defaults to
-	 * FRACTION_DIGITS_PER_CURRENCY (2 for fiat, 8 for BTC).
+	 * FRACTION_DIGITS_PER_CURRENCY (per ISO 4217).
 	 *
 	 * New prices saved with storage precision will have this set to
-	 * STORAGE_FRACTION_DIGITS_PER_CURRENCY (4 for fiat, 8 for BTC).
+	 * STORAGE_FRACTION_DIGITS_PER_CURRENCY (8 for fiat & BTC, 0 for SAT).
 	 *
-	 * This allows storing precise base prices (e.g., 4.6253 CHF) that result
-	 * in round numbers after VAT calculation (e.g., 5.00 CHF with 8.1% VAT).
+	 * This allows storing precise base prices (e.g., 17.24137931 XPF HT) that
+	 * result in a clean round-trip when input was a VAT-included value
+	 * (e.g., 20 XPF TTC at 16% VAT).
 	 *
 	 * @example
 	 * // Old price from DB (no precision field):
@@ -42,7 +43,7 @@ export type Price = {
 	 *
 	 * @example
 	 * // New price from DB (with precision):
-	 * { amount: 4.6253, currency: 'CHF', precision: 4 }
+	 * { amount: 17.24137931, currency: 'XPF', precision: 8 }
 	 */
 	precision?: number;
 };

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -1,6 +1,5 @@
 import type { LanguageKey } from '$lib/translations';
 import type { ObjectId } from 'mongodb';
-import type { Currency } from './Currency';
 import type { DeliveryFees } from './DeliveryFees';
 import type { Price } from './Order';
 import type { ProductActionSettings } from './ProductActionSettings';
@@ -40,10 +39,7 @@ export interface ProductTranslatableFields {
 export interface Product extends Timestamps, ProductTranslatableFields {
 	_id: string;
 	alias: string[];
-	price: {
-		amount: number;
-		currency: Currency;
-	};
+	price: Price;
 	stock?: {
 		available: number;
 		total: number;

--- a/src/lib/utils/currency-validation.ts
+++ b/src/lib/utils/currency-validation.ts
@@ -1,0 +1,10 @@
+import { FRACTION_DIGITS_PER_CURRENCY, type Currency } from '$lib/types/Currency';
+
+/** True when `amount` has more decimal places than `currency` supports (e.g. 19.99 on XPF). */
+export function hasMoreDecimalsThanCurrency(amount: number, currency: Currency): boolean {
+	if (Number.isInteger(amount)) {
+		return false;
+	}
+	const decimals = amount.toString().split('.')[1]?.length ?? 0;
+	return decimals > FRACTION_DIGITS_PER_CURRENCY[currency];
+}

--- a/src/lib/utils/fixCurrencyRounding.ts
+++ b/src/lib/utils/fixCurrencyRounding.ts
@@ -1,6 +1,15 @@
-import type { Currency } from '$lib/types/Currency';
+import { FRACTION_DIGITS_PER_CURRENCY, type Currency } from '$lib/types/Currency';
 import { toCurrency } from './toCurrency';
 
 export function fixCurrencyRounding(amount: number, currency: Currency) {
 	return toCurrency(currency, amount, currency);
+}
+
+/**
+ * Round `amount` DOWN to the currency's display precision — used for discounts so rounding
+ * favors the customer (a smaller-than-stated discount can be illegal).
+ */
+export function roundDownToCurrency(amount: number, currency: Currency): number {
+	const factor = Math.pow(10, FRACTION_DIGITS_PER_CURRENCY[currency]);
+	return Math.floor(amount * factor) / factor;
 }

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -303,6 +303,8 @@ export async function load(params) {
 			amount: deliveryFees || 0,
 			currency: UNDERLYING_CURRENCY
 		},
+		deliveryFeesVatProfileId: runtimeConfig.deliveryFees.vatProfileId,
+		deliveryFeesVatIncluded: runtimeConfig.deliveryFees.vatIncludedReference,
 		freeProductUnits: cartFreeProductUnits,
 		userCountry: locals.countryCode,
 		vatExempted: runtimeConfig.vatExempted,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.server.ts
@@ -4,6 +4,7 @@ import { set } from '$lib/utils/set';
 import { z } from 'zod';
 import { collections } from '$lib/server/database';
 import { deliveryFeesSchema } from './schema';
+import { zodObjectId } from '$lib/server/zod';
 
 export const actions = {
 	default: async function ({ request }) {
@@ -20,7 +21,12 @@ export const actions = {
 				onlyPayHighest: z.boolean({ coerce: true }),
 				applyFlatFeeToEachItem: z.boolean({ coerce: true }),
 				deliveryFees: deliveryFeesSchema.default({}),
-				allowFreeForPOS: z.boolean({ coerce: true })
+				allowFreeForPOS: z.boolean({ coerce: true }),
+				vatIncludedReference: z.boolean({ coerce: true }).default(false),
+				vatProfileId: zodObjectId()
+					.or(z.literal(''))
+					.optional()
+					.transform((s) => s || null)
 			})
 			.parse(json);
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import DeliveryFeesSelector from '$lib/components/DeliveryFeesSelector.svelte';
+	import { computeVatRate } from '$lib/utils/vat';
 
 	export let data;
 	export let form;
@@ -7,8 +8,18 @@
 	let mode: 'flatFee' | 'perItem' = data.deliveryFees.mode;
 	let onlyPayHighest = data.deliveryFees.onlyPayHighest;
 	let applyFlatFeeToEachItem = data.deliveryFees.applyFlatFeeToEachItem;
+	let vatIncludedReference = data.deliveryFees.vatIncludedReference ?? false;
+	let vatProfileId = data.deliveryFees.vatProfileId ?? '';
 
 	let deliveryFees = data.deliveryFees.deliveryFees || {};
+
+	$: deliveryVatRate = computeVatRate({
+		productVatProfileId: vatProfileId || undefined,
+		vatProfiles: data.vatProfiles,
+		bebopCountry: data.vatCountry,
+		userCountry: data.vatCountry,
+		vatSingleCountry: true
+	});
 </script>
 
 {#if form?.success}
@@ -66,7 +77,32 @@
 		</label>
 	{/if}
 
-	<DeliveryFeesSelector {deliveryFees} defaultCurrency={data.currencies.priceReference} />
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="vatIncludedReference"
+			bind:checked={vatIncludedReference}
+		/>
+		Use delivery fees price reference as VAT included price instead of VAT excluded
+	</label>
+
+	<label class="form-label">
+		VAT profile for delivery fees
+		<select name="vatProfileId" class="form-input" bind:value={vatProfileId}>
+			<option value="">Use shop standard VAT</option>
+			{#each data.vatProfiles as profile}
+				<option value={profile._id}>{profile.name}</option>
+			{/each}
+		</select>
+	</label>
+
+	<DeliveryFeesSelector
+		{deliveryFees}
+		defaultCurrency={data.currencies.priceReference}
+		{vatIncludedReference}
+		vatRate={deliveryVatRate}
+	/>
 
 	<button type="submit" class="btn btn-black self-start"> Save config </button>
 </form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -3,7 +3,13 @@ import { error, redirect } from '@sveltejs/kit';
 import type { Actions } from './$types';
 import { z } from 'zod';
 import { deletePicture } from '$lib/server/picture';
-import { CURRENCIES, parsePriceAmount } from '$lib/types/Currency';
+import {
+	CURRENCIES,
+	FRACTION_DIGITS_PER_CURRENCY,
+	computePriceForStorage,
+	parsePriceAmount
+} from '$lib/types/Currency';
+import { hasMoreDecimalsThanCurrency } from '$lib/utils/currency-validation';
 import type { JsonObject } from 'type-fest';
 import { set } from '$lib/utils/set';
 import { productBaseSchema } from '../product-schema';
@@ -140,6 +146,18 @@ export const actions: Actions = {
 		if (!parsed.free && !parsed.payWhatYouWant && parsed.priceAmount === '0') {
 			parsed.free = true;
 		}
+
+		// Re-check decimal mismatch server-side (direct API calls bypass the form).
+		if (!parsed.free && parsed.priceAmountVatIncluded) {
+			const ttc = parsePriceAmount(parsed.priceAmountVatIncluded, priceCurrency);
+			if (hasMoreDecimalsThanCurrency(ttc, priceCurrency)) {
+				throw error(
+					400,
+					`${priceCurrency} currency has ${FRACTION_DIGITS_PER_CURRENCY[priceCurrency]} decimal. ` +
+						`Price (VAT included) cannot have more.`
+				);
+			}
+		}
 		const variationsParsedPrice = parsed.variations.map((variation) => ({
 			...variation,
 			price: Math.max(parsePriceAmount(variation.price, parsed.priceCurrency), 0)
@@ -174,10 +192,7 @@ export const actions: Actions = {
 						alias: parsed.alias ? [params.id, parsed.alias] : [params.id],
 						description: parsed.description,
 						shortDescription: parsed.shortDescription,
-						price: {
-							amount: priceAmount,
-							currency: priceCurrency
-						},
+						price: computePriceForStorage(priceAmount, priceCurrency),
 						...(parsed.availableDate && { availableDate: parsed.availableDate }),
 						shipping: parsed.shipping,
 						displayShortDescription: parsed.displayShortDescription,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -13,7 +13,12 @@ import { ORIGIN } from '$lib/server/env-config';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import type { Product } from '$lib/types/Product';
 import { Kind } from 'nostr-tools';
-import { parsePriceAmount } from '$lib/types/Currency';
+import {
+	FRACTION_DIGITS_PER_CURRENCY,
+	computePriceForStorage,
+	parsePriceAmount
+} from '$lib/types/Currency';
+import { hasMoreDecimalsThanCurrency } from '$lib/utils/currency-validation';
 import { s3ProductPrefix, getS3Client } from '$lib/server/s3';
 import type { JsonObject } from 'type-fest';
 import { set } from '$lib/utils/set';
@@ -98,6 +103,19 @@ export const actions: Actions = {
 			? 0
 			: parsePriceAmount(parsed.priceAmount, parsed.priceCurrency);
 
+		// Re-check decimal mismatch server-side (direct API calls bypass the form).
+		if (!parsed.free && parsed.priceAmountVatIncluded) {
+			const ttc = parsePriceAmount(parsed.priceAmountVatIncluded, parsed.priceCurrency);
+			if (hasMoreDecimalsThanCurrency(ttc, parsed.priceCurrency)) {
+				throw error(
+					400,
+					`${parsed.priceCurrency} currency has ${
+						FRACTION_DIGITS_PER_CURRENCY[parsed.priceCurrency]
+					} decimal. Price (VAT included) cannot have more.`
+				);
+			}
+		}
+
 		if (parsed.type !== 'resource') {
 			delete parsed.availableDate;
 		}
@@ -148,10 +166,7 @@ export const actions: Actions = {
 							shortDescription: parsed.shortDescription.replaceAll('\r', ''),
 							name: parsed.name,
 							isTicket: parsed.isTicket,
-							price: {
-								currency: parsed.priceCurrency,
-								amount: priceAmount
-							},
+							price: computePriceForStorage(priceAmount, parsed.priceCurrency),
 							hideDiscountExpiration: parsed.hideDiscountExpiration,
 							type: parsed.type,
 							availableDate: parsed.availableDate || undefined,
@@ -354,10 +369,7 @@ export const actions: Actions = {
 					shortDescription: parsed.shortDescription.replaceAll('\r', ''),
 					name: parsed.name,
 					isTicket: parsed.isTicket,
-					price: {
-						currency: parsed.priceCurrency,
-						amount: parseFloat(parsed.priceAmount)
-					},
+					price: computePriceForStorage(parseFloat(parsed.priceAmount), parsed.priceCurrency),
 					type: product.type,
 					availableDate: parsed.availableDate || undefined,
 					preorder: parsed.preorder,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -15,6 +15,10 @@ export const productBaseSchema = () => ({
 		.string()
 		.regex(/^\d+(\.\d+)?$/)
 		.default('0'),
+	priceAmountVatIncluded: z
+		.string()
+		.regex(/^\d+(\.\d+)?$/)
+		.optional(),
 	priceCurrency: z.enum([CURRENCIES[0], ...CURRENCIES.slice(1)]),
 	availableDate: z.date({ coerce: true }).optional(),
 	preorder: z.boolean({ coerce: true }).default(false),

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -9,6 +9,7 @@
 	import { typedInclude } from '$lib/utils/typedIncludes';
 	import ProductType from '$lib/components/ProductType.svelte';
 	import { computeDeliveryFees, computePriceInfo } from '$lib/cart';
+	import { computeVatRate, extractVat } from '$lib/utils/vat';
 	import IconInfo from '$lib/components/icons/IconInfo.svelte';
 	import { toCurrency } from '$lib/utils/toCurrency.js';
 	import { UNDERLYING_CURRENCY } from '$lib/types/Currency.js';
@@ -116,6 +117,18 @@
 	);
 	$: deliveryFeesToBill = offerDeliveryFees ? 0 : orderDeliveryFees;
 
+	// Display delivery HT (not the raw TTC) so the breakdown sums up to Total.
+	$: deliveryFeesVatRate = computeVatRate({
+		productVatProfileId: data.deliveryFees.vatProfileId ?? undefined,
+		vatProfiles: data.vatProfiles,
+		bebopCountry: data.vatCountry,
+		userCountry: isDigital ? digitalCountry : country,
+		vatSingleCountry: data.vatSingleCountry
+	});
+	$: deliveryFeesToDisplay = data.deliveryFees.vatIncludedReference
+		? extractVat(deliveryFeesToBill, deliveryFeesVatRate)
+		: deliveryFeesToBill;
+
 	$: isFreeOfCharge = addDiscount && discountType === 'percentage' && discountAmount === 100;
 
 	$: possiblyOutOfBoundsDiscount =
@@ -132,6 +145,8 @@
 	$: priceInfoWithoutDiscount = computePriceInfo(items, {
 		bebopCountry: data.vatCountry,
 		deliveryFees: { amount: deliveryFeesToBill, currency: UNDERLYING_CURRENCY },
+		deliveryFeesVatProfileId: data.deliveryFees.vatProfileId,
+		deliveryFeesVatIncluded: data.deliveryFees.vatIncludedReference,
 		discount: undefined,
 		freeProductUnits: data.cart.freeProductUnits,
 		userCountry: isDigital ? digitalCountry : country,
@@ -143,6 +158,8 @@
 	$: priceInfo = computePriceInfo(items, {
 		bebopCountry: data.vatCountry,
 		deliveryFees: { amount: deliveryFeesToBill, currency: UNDERLYING_CURRENCY },
+		deliveryFeesVatProfileId: data.deliveryFees.vatProfileId,
+		deliveryFeesVatIncluded: data.deliveryFees.vatIncludedReference,
 		discount: possiblyOutOfBoundsDiscount,
 		freeProductUnits: data.cart.freeProductUnits,
 		userCountry: isDigital ? digitalCountry : country,
@@ -866,12 +883,12 @@
 						<div class="flex flex-col ml-auto items-end justify-center">
 							<PriceTag
 								class="text-2xl truncate"
-								amount={deliveryFeesToBill}
+								amount={deliveryFeesToDisplay}
 								currency={UNDERLYING_CURRENCY}
 								main
 							/>
 							<PriceTag
-								amount={deliveryFeesToBill}
+								amount={deliveryFeesToDisplay}
 								currency={UNDERLYING_CURRENCY}
 								class="text-base truncate"
 								secondary


### PR DESCRIPTION
Currencies that have no fractional unit — like the Pacific Franc (XPF) used in Tahiti — were showing cents everywhere, which is incorrect for accounting and tax. This corrects pricing end to end for those currencies.

- Prices in zero-decimal currencies now display and store as whole numbers, no cents
- The product form lets merchants enter the customer-facing price (tax included) directly, with the tax-excluded price calculated for them, and warns if the entered price has more decimals than the currency allows
- VAT on multi-item carts is now calculated correctly — totals always add up instead of drifting by a unit due to rounding
- Percentage discounts always round in the customer's favour
- Delivery fees can be set as tax-included and use their own VAT profile

Closes #2535