### PR TITLE
🦋 Forbid delivery to specific countries

### DIFF
--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -426,6 +426,7 @@ export function computeDeliveryFees(
 			Product,
 			| 'price'
 			| 'deliveryFees'
+			| 'defaultBlacklist'
 			| 'applyDeliveryFeesOnlyOnce'
 			| 'shipping'
 			| 'requireSpecificDeliveryFee'
@@ -441,7 +442,11 @@ export function computeDeliveryFees(
 	}
 
 	if (deliveryFeesConfig.mode === 'flatFee' && !deliveryFeesConfig.applyFlatFeeToEachItem) {
-		const cfg = deliveryFeesConfig.deliveryFees[country] || deliveryFeesConfig.deliveryFees.default;
+		const cfg =
+			deliveryFeesConfig.deliveryFees[country] ||
+			(deliveryFeesConfig.defaultBlacklist?.includes(country)
+				? undefined
+				: deliveryFeesConfig.deliveryFees.default);
 
 		if (!cfg) {
 			return NaN;
@@ -453,14 +458,19 @@ export function computeDeliveryFees(
 	const fees = items.map(({ product, quantity }) => {
 		const cfg = (() => {
 			const defaultConfig =
-				deliveryFeesConfig.deliveryFees[country] || deliveryFeesConfig.deliveryFees.default;
+				deliveryFeesConfig.deliveryFees[country] ||
+				(deliveryFeesConfig.defaultBlacklist?.includes(country)
+					? undefined
+					: deliveryFeesConfig.deliveryFees.default);
 			if (deliveryFeesConfig.mode === 'flatFee') {
 				return defaultConfig;
 			}
 
-			let cfg = product.deliveryFees?.[country] || product.deliveryFees?.default;
+			let cfg =
+				product.deliveryFees?.[country] ||
+				(product.defaultBlacklist?.includes(country) ? undefined : product.deliveryFees?.default);
 
-			if (!product.requireSpecificDeliveryFee) {
+			if (!product.requireSpecificDeliveryFee && !product.defaultBlacklist?.includes(country)) {
 				cfg ||= defaultConfig;
 			}
 

--- a/src/lib/components/DeliveryFeesSelector.svelte
+++ b/src/lib/components/DeliveryFeesSelector.svelte
@@ -9,6 +9,7 @@
 	import { currencies } from '$lib/stores/currencies';
 
 	export let deliveryFees: DeliveryFees = {};
+	export let defaultBlacklist: CountryAlpha2[] = [];
 	export let defaultCurrency: Currency;
 	export let disabled = false;
 
@@ -36,11 +37,39 @@
 	}
 
 	$: countriesWithNoFee = ['default' as const, ...sortedCountryCodes()].filter(
-		(country) => !deliveryFees[country]
+		(country) =>
+			!deliveryFees[country] &&
+			(country === 'default' || !blacklistSelection.some((option) => option.value === country))
 	);
 	$: feeCountryToAdd = countriesWithNoFee.includes(feeCountryToAdd)
 		? feeCountryToAdd
 		: countriesWithNoFee[0];
+
+	// Stable ref: svelte-select re-emits `value` on every `items` ref change → infinite loop
+	let blacklistOptions: Array<{ value: CountryAlpha2; label: string }> = [];
+	let blacklistOptionsSignature: string | null = null;
+	$: {
+		const used = Object.keys(deliveryFees)
+			.filter((c) => c !== 'default')
+			.sort();
+		const signature = used.join(',');
+		if (signature !== blacklistOptionsSignature) {
+			blacklistOptionsSignature = signature;
+			const usedSet = new Set(used);
+			blacklistOptions = sortedCountryCodes()
+				.filter((c) => !usedSet.has(c))
+				.map((c) => ({ value: c, label: countryName(c) }));
+		}
+	}
+
+	// Seeded once: a reactive backfill would re-add a chip the user just removed
+	let blacklistSelection: Array<{ value: CountryAlpha2; label: string }> = (
+		defaultBlacklist ?? []
+	).map((c) => ({ value: c, label: countryName(c) }));
+	// svelte-select clears the last chip to undefined, not [] — normalise
+	$: if (!blacklistSelection) {
+		blacklistSelection = [];
+	}
 </script>
 
 {#if countriesWithNoFee.length}
@@ -106,6 +135,22 @@
 				/>
 			</label>
 		</div>
+		{#if country === 'default'}
+			<div class="w-full">
+				Forbid delivery in these countries
+				<Select
+					items={blacklistOptions}
+					multiple
+					searchable={true}
+					bind:value={blacklistSelection}
+					{disabled}
+					class="form-input"
+				/>
+			</div>
+			{#each blacklistSelection as c, i (c.value)}
+				<input type="hidden" name="defaultBlacklist[{i}]" value={c.value} />
+			{/each}
+		{/if}
 		<button
 			type="button"
 			class="text-red-500 underline text-left"

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -1351,6 +1351,7 @@
 							{#if globalDeliveryFees.mode === 'perItem'}
 								<DeliveryFeesSelector
 									bind:deliveryFees={product.deliveryFees}
+									defaultBlacklist={product.defaultBlacklist}
 									defaultCurrency={product.price.currency}
 								/>
 

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -149,7 +149,8 @@ const baseConfig = {
 				amount: 0,
 				currency: 'EUR'
 			}
-		} satisfies DeliveryFees as DeliveryFees
+		} satisfies DeliveryFees as DeliveryFees,
+		defaultBlacklist: [] as CountryAlpha2[]
 	},
 	specialRolesCreated: {
 		[TICKET_CHECKER_ROLE_ID]: false

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -1,5 +1,6 @@
 import type { LanguageKey } from '$lib/translations';
 import type { ObjectId } from 'mongodb';
+import type { CountryAlpha2 } from './Country';
 import type { Currency } from './Currency';
 import type { DeliveryFees } from './DeliveryFees';
 import type { Price } from './Order';
@@ -57,6 +58,7 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 	type: 'subscription' | 'resource' | 'donation';
 	shipping: boolean;
 	deliveryFees?: DeliveryFees;
+	defaultBlacklist?: CountryAlpha2[];
 	requireSpecificDeliveryFee?: boolean;
 	applyDeliveryFeesOnlyOnce?: boolean;
 	isTicket: boolean;

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -108,6 +108,7 @@ export async function load(params) {
 							| 'shipping'
 							| 'preorder'
 							| 'deliveryFees'
+							| 'defaultBlacklist'
 							| 'applyDeliveryFeesOnlyOnce'
 							| 'requireSpecificDeliveryFee'
 							| 'payWhatYouWant'
@@ -134,6 +135,7 @@ export async function load(params) {
 						availableDate: 1,
 						preorder: 1,
 						deliveryFees: 1,
+						defaultBlacklist: 1,
 						applyDeliveryFeesOnlyOnce: 1,
 						requireSpecificDeliveryFee: 1,
 						payWhatYouWant: 1,
@@ -150,7 +152,9 @@ export async function load(params) {
 						}
 					})
 					.map((p) =>
-						runtimeConfig.deliveryFees.mode !== 'perItem' ? { ...p, deliveryFees: undefined } : p
+						runtimeConfig.deliveryFees.mode !== 'perItem'
+							? { ...p, deliveryFees: undefined, defaultBlacklist: undefined }
+							: p
 					)
 					.toArray()
 			: [],

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.server.ts
@@ -3,7 +3,7 @@ import type { JsonObject } from 'type-fest';
 import { set } from '$lib/utils/set';
 import { z } from 'zod';
 import { collections } from '$lib/server/database';
-import { deliveryFeesSchema } from './schema';
+import { defaultBlacklistSchema, deliveryFeesSchema } from './schema';
 
 export const actions = {
 	default: async function ({ request }) {
@@ -20,6 +20,7 @@ export const actions = {
 				onlyPayHighest: z.boolean({ coerce: true }),
 				applyFlatFeeToEachItem: z.boolean({ coerce: true }),
 				deliveryFees: deliveryFeesSchema.default({}),
+				defaultBlacklist: defaultBlacklistSchema.default([]),
 				allowFreeForPOS: z.boolean({ coerce: true })
 			})
 			.parse(json);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.svelte
@@ -9,6 +9,7 @@
 	let applyFlatFeeToEachItem = data.deliveryFees.applyFlatFeeToEachItem;
 
 	let deliveryFees = data.deliveryFees.deliveryFees || {};
+	let defaultBlacklist = data.deliveryFees.defaultBlacklist ?? [];
 </script>
 
 {#if form?.success}
@@ -66,7 +67,11 @@
 		</label>
 	{/if}
 
-	<DeliveryFeesSelector {deliveryFees} defaultCurrency={data.currencies.priceReference} />
+	<DeliveryFeesSelector
+		{deliveryFees}
+		{defaultBlacklist}
+		defaultCurrency={data.currencies.priceReference}
+	/>
 
 	<button type="submit" class="btn btn-black self-start"> Save config </button>
 </form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/schema.ts
@@ -1,4 +1,4 @@
-import { COUNTRY_ALPHA2S } from '$lib/types/Country';
+import { COUNTRY_ALPHA2S, type CountryAlpha2 } from '$lib/types/Country';
 import { CURRENCIES } from '$lib/types/Currency';
 import { z } from 'zod';
 
@@ -8,4 +8,8 @@ export const deliveryFeesSchema = z.record(
 		amount: z.number({ coerce: true }).min(0),
 		currency: z.enum([CURRENCIES[0], ...CURRENCIES.slice(1)])
 	})
+);
+
+export const defaultBlacklistSchema = z.array(
+	z.enum([...COUNTRY_ALPHA2S] as [CountryAlpha2, ...CountryAlpha2[]])
 );

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -201,6 +201,9 @@ export const actions: Actions = {
 						standalone: parsed.payWhatYouWant || parsed.standalone,
 						free: parsed.free,
 						...(parsed.deliveryFees && { deliveryFees: parsed.deliveryFees }),
+						...(parsed.defaultBlacklist?.length && {
+							defaultBlacklist: parsed.defaultBlacklist
+						}),
 						applyDeliveryFeesOnlyOnce: parsed.applyDeliveryFeesOnlyOnce,
 						requireSpecificDeliveryFee: parsed.requireSpecificDeliveryFee,
 						...(parsed.maxQuantityPerOrder && { maxQuantityPerOrder: parsed.maxQuantityPerOrder }),
@@ -278,6 +281,7 @@ export const actions: Actions = {
 						...(!parsed.customPreorderText && { customPreorderText: '' }),
 						...(!parsed.availableDate && { availableDate: '' }),
 						...(!parsed.deliveryFees && { deliveryFees: '' }),
+						...(!parsed.defaultBlacklist?.length && { defaultBlacklist: '' }),
 						...(parsed.stock === undefined && { stock: '' }),
 						...(!parsed.stockReferenceProductId && { stockReference: '' }),
 						...(!parsed.maxQuantityPerOrder && { maxQuantityPerOrder: '' }),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -177,6 +177,9 @@ export const actions: Actions = {
 							bookingSpec: parsed.bookingSpec,
 							displayShortDescription: parsed.displayShortDescription,
 							...(parsed.deliveryFees && { deliveryFees: parsed.deliveryFees }),
+							...(parsed.defaultBlacklist?.length && {
+								defaultBlacklist: parsed.defaultBlacklist
+							}),
 							applyDeliveryFeesOnlyOnce: parsed.applyDeliveryFeesOnlyOnce,
 							requireSpecificDeliveryFee: parsed.requireSpecificDeliveryFee,
 							...(parsed.stock !== undefined && {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -1,7 +1,7 @@
 import { CURRENCIES } from '$lib/types/Currency';
 import { MAX_NAME_LIMIT, MAX_SHORT_DESCRIPTION_LIMIT } from '$lib/types/Product';
 import { z } from 'zod';
-import { deliveryFeesSchema } from '../config/delivery/schema';
+import { defaultBlacklistSchema, deliveryFeesSchema } from '../config/delivery/schema';
 import { MAX_CONTENT_LIMIT } from '$lib/types/CmsPage';
 import { zodObjectId } from '$lib/server/zod';
 import { paymentMethods, type PaymentMethod } from '$lib/server/payment-methods';
@@ -22,6 +22,7 @@ export const productBaseSchema = () => ({
 	shipping: z.boolean({ coerce: true }).default(false),
 	displayShortDescription: z.boolean({ coerce: true }).default(false),
 	deliveryFees: deliveryFeesSchema.optional(),
+	defaultBlacklist: defaultBlacklistSchema.optional(),
 	restrictPaymentMethods: z.boolean({ coerce: true }).default(false),
 	paymentMethods: z
 		.array(z.enum(paymentMethods({ includePOS: true }) as [PaymentMethod, ...PaymentMethod[]]))

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -115,6 +115,8 @@
 		data.deliveryFees
 	);
 	$: deliveryFeesToBill = offerDeliveryFees ? 0 : orderDeliveryFees;
+	// Order is blocked elsewhere when this is NaN; feed 0 so the summary isn't all €NaN
+	$: deliveryFeesForPriceInfo = isNaN(deliveryFeesToBill) ? 0 : deliveryFeesToBill;
 
 	$: isFreeOfCharge = addDiscount && discountType === 'percentage' && discountAmount === 100;
 
@@ -131,7 +133,7 @@
 	// Compute price WITHOUT discount for validation purposes
 	$: priceInfoWithoutDiscount = computePriceInfo(items, {
 		bebopCountry: data.vatCountry,
-		deliveryFees: { amount: deliveryFeesToBill, currency: UNDERLYING_CURRENCY },
+		deliveryFees: { amount: deliveryFeesForPriceInfo, currency: UNDERLYING_CURRENCY },
 		discount: undefined,
 		freeProductUnits: data.cart.freeProductUnits,
 		userCountry: isDigital ? digitalCountry : country,
@@ -142,7 +144,7 @@
 	});
 	$: priceInfo = computePriceInfo(items, {
 		bebopCountry: data.vatCountry,
-		deliveryFees: { amount: deliveryFeesToBill, currency: UNDERLYING_CURRENCY },
+		deliveryFees: { amount: deliveryFeesForPriceInfo, currency: UNDERLYING_CURRENCY },
 		discount: possiblyOutOfBoundsDiscount,
 		freeProductUnits: data.cart.freeProductUnits,
 		userCountry: isDigital ? digitalCountry : country,

--- a/src/routes/(app)/pos/session/formatCartOrder.ts
+++ b/src/routes/(app)/pos/session/formatCartOrder.ts
@@ -22,6 +22,7 @@ type FormattedCartItem = {
 			| 'name'
 			| 'maxQuantityPerOrder'
 			| 'deliveryFees'
+			| 'defaultBlacklist'
 			| 'price'
 			| 'shortDescription'
 			| 'type'
@@ -63,6 +64,7 @@ export async function formatCart(
 					| 'shipping'
 					| 'preorder'
 					| 'deliveryFees'
+					| 'defaultBlacklist'
 					| 'applyDeliveryFeesOnlyOnce'
 					| 'requireSpecificDeliveryFee'
 					| 'payWhatYouWant'
@@ -86,6 +88,7 @@ export async function formatCart(
 						availableDate: 1,
 						preorder: 1,
 						deliveryFees: 1,
+						defaultBlacklist: 1,
 						applyDeliveryFeesOnlyOnce: 1,
 						requireSpecificDeliveryFee: 1,
 						payWhatYouWant: 1,
@@ -116,6 +119,7 @@ export async function formatCart(
 				const productDoc = productById[item.productId];
 				if (runtimeConfig.deliveryFees.mode !== 'perItem') {
 					delete productDoc.deliveryFees;
+					delete productDoc.defaultBlacklist;
 				}
 				return {
 					product: pojo(productDoc),


### PR DESCRIPTION
Shop owners can already set a delivery fee per country, or one fee for "all other countries". This adds the missing piece: a list of countries you simply cannot deliver to.

Under the "Other countries" delivery option there is now a "Forbid delivery in these countries" field. Orders shipping to a forbidden country are blocked at checkout. It works both in the global delivery settings and per individual product.

- Pick forbidden countries from a list (countries already used by another option are hidden)
- A specific country fee always takes priority — setting a fee for a country un-forbids it
- A customer choosing a forbidden country sees a clear "not available" message and can't proceed
- Existing shops are unaffected — no setup required, everything works as before

Closes #1855