### PR TITLE
🐛 Fix English text on booking date picker for non-English locales

### DIFF
--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -860,7 +860,12 @@
 				"other": "{count} Minuten"
 			},
 			"time": "Tageszeit",
-			"timezone": "Zeitzone: {timeZone}"
+			"timezone": "Zeitzone: {timeZone}",
+			"selectDateRange": "Start- und Enddatum auswählen (zweimal klicken, um einen Bereich auszuwählen)",
+			"selectedDate": "Ausgewählt: {date}",
+			"selectedRangeWithAvailable": "{totalDays} Tage ausgewählt, {availableDays} Tage verfügbar: {dates}",
+			"noAvailableDays": "Keine verfügbaren Tage im ausgewählten Bereich",
+			"maxRangeInfo": "Maximaler Buchungszeitraum: {days} Tage"
 		},
 		"checkBackLater": "Bitte schauen Sie später wieder vorbei",
 		"cta": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -860,7 +860,12 @@
 				"other": "{count} minutos"
 			},
 			"time": "Hora del día",
-			"timezone": "Zona horaria: {timeZone}"
+			"timezone": "Zona horaria: {timeZone}",
+			"selectDateRange": "Seleccione las fechas de inicio y fin (haga clic dos veces para seleccionar un rango)",
+			"selectedDate": "Seleccionado: {date}",
+			"selectedRangeWithAvailable": "{totalDays} días seleccionados, {availableDays} días disponibles: {dates}",
+			"noAvailableDays": "No hay días disponibles en el rango seleccionado",
+			"maxRangeInfo": "Período máximo de reserva: {days} días"
 		},
 		"checkBackLater": "Por favor, revise más tarde",
 		"cta": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -860,7 +860,12 @@
 				"other": "{count} minutes"
 			},
 			"time": "Heure de la journée",
-			"timezone": "Fuseau horaire: {timeZone}"
+			"timezone": "Fuseau horaire: {timeZone}",
+			"selectDateRange": "Sélectionnez les dates de début et de fin (cliquez deux fois pour sélectionner une plage)",
+			"selectedDate": "Sélectionné: {date}",
+			"selectedRangeWithAvailable": "{totalDays} jours sélectionnés, {availableDays} jours disponibles: {dates}",
+			"noAvailableDays": "Aucun jour disponible dans la plage sélectionnée",
+			"maxRangeInfo": "Période de réservation maximale: {days} jours"
 		},
 		"checkBackLater": "Veuillez revenir plus tard",
 		"cta": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -860,7 +860,12 @@
 				"other": "{count} minuti"
 			},
 			"time": "Ora del giorno",
-			"timezone": "Fuso orario: {timeZone}"
+			"timezone": "Fuso orario: {timeZone}",
+			"selectDateRange": "Seleziona le date di inizio e fine (clicca due volte per selezionare un intervallo)",
+			"selectedDate": "Selezionato: {date}",
+			"selectedRangeWithAvailable": "{totalDays} giorni selezionati, {availableDays} giorni disponibili: {dates}",
+			"noAvailableDays": "Nessun giorno disponibile nell'intervallo selezionato",
+			"maxRangeInfo": "Periodo massimo di prenotazione: {days} giorni"
 		},
 		"checkBackLater": "Ricontrolla tra un po'",
 		"cta": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -860,7 +860,12 @@
 				"other": "{count} minuten"
 			},
 			"time": "Tijd van de dag",
-			"timezone": "Tijdzone: {timeZone}"
+			"timezone": "Tijdzone: {timeZone}",
+			"selectDateRange": "Selecteer begin- en einddatum (klik twee keer om een bereik te selecteren)",
+			"selectedDate": "Geselecteerd: {date}",
+			"selectedRangeWithAvailable": "{totalDays} dagen geselecteerd, {availableDays} dagen beschikbaar: {dates}",
+			"noAvailableDays": "Geen beschikbare dagen in het geselecteerde bereik",
+			"maxRangeInfo": "Maximale boekingsperiode: {days} dagen"
 		},
 		"checkBackLater": "Kom later nog eens terug",
 		"cta": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -860,7 +860,12 @@
 				"other": "{count} minutos"
 			},
 			"time": "Hora do dia",
-			"timezone": "Fuso horário: {timeZone}"
+			"timezone": "Fuso horário: {timeZone}",
+			"selectDateRange": "Selecione as datas de início e fim (clique duas vezes para selecionar um intervalo)",
+			"selectedDate": "Selecionado: {date}",
+			"selectedRangeWithAvailable": "{totalDays} dias selecionados, {availableDays} dias disponíveis: {dates}",
+			"noAvailableDays": "Nenhum dia disponível no intervalo selecionado",
+			"maxRangeInfo": "Período máximo de reserva: {days} dias"
 		},
 		"checkBackLater": "Por favor, volte a verificar mais tarde",
 		"cta": {


### PR DESCRIPTION
Translated booking date picker labels (under product.booking) into French, German, Spanish, Italian, Dutch and Portuguese

Closes #2573