### PR TITLE
:new:🤖 Allow super-admin to download global JSON of displayed orders

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/orders/json/+server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/orders/json/+server.ts
@@ -1,0 +1,22 @@
+import { collections } from '$lib/server/database';
+import { SUPER_ADMIN_ROLE_ID } from '$lib/types/User';
+import { error } from '@sveltejs/kit';
+import { z } from 'zod';
+
+export const POST = async ({ request, locals }) => {
+	// Due to the sensitive nature of a global order dump, reserve this to super-admin.
+	if (locals.user?.roleId !== SUPER_ADMIN_ROLE_ID) {
+		throw error(403, 'Forbidden. Only Super Admin can download all orders.');
+	}
+
+	const { ids } = z.object({ ids: z.string().array() }).parse(await request.json());
+
+	const orders = await collections.orders
+		.find({ _id: { $in: ids } })
+		.sort({ createdAt: -1 })
+		.toArray();
+
+	return new Response(JSON.stringify(orders), {
+		headers: { 'Content-Type': 'application/json' }
+	});
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/reporting/+page.svelte
@@ -6,6 +6,7 @@
 	import { sum } from '$lib/utils/sum.js';
 	import { sumCurrency } from '$lib/utils/sumCurrency.js';
 	import { toCurrency } from '$lib/utils/toCurrency';
+	import { SUPER_ADMIN_ROLE_ID } from '$lib/types/User.js';
 	import { endOfDay, startOfDay } from 'date-fns';
 	import MultiSelect from 'svelte-multiselect';
 
@@ -138,6 +139,30 @@
 		document.body.appendChild(link);
 		link.click();
 		document.body.removeChild(link);
+	}
+	async function downloadAllOrdersJson() {
+		const ids = orderFiltered.map((order) => order._id);
+		if (ids.length === 0) {
+			alert('No orders to export');
+			return;
+		}
+		const resp = await fetch('/admin/orders/json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ ids })
+		});
+		if (!resp.ok) {
+			alert('Error while downloading orders JSON');
+			return;
+		}
+		const url = URL.createObjectURL(await resp.blob());
+		const link = document.createElement('a');
+		link.href = url;
+		link.download = 'orders.json';
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
 	}
 	function exportcsv(tableElement: HTMLTableElement, filename: string) {
 		const table = tableElement;
@@ -422,6 +447,15 @@
 				>
 					📊 CSV
 				</button>
+				{#if data.role?._id === SUPER_ADMIN_ROLE_ID}
+					<button
+						on:click={downloadAllOrdersJson}
+						class="text-sm px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded border text-gray-700 transition-colors"
+						title="Download all displayed orders as JSON (super-admin)"
+					>
+						🧾 JSON
+					</button>
+				{/if}
 				<button
 					disabled={!!htmlStatus || isLoading}
 					class="text-sm px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded border text-gray-700 transition-colors disabled:opacity-50"


### PR DESCRIPTION
Adds a super-admin-only "JSON" button on /admin/reporting that downloads the full raw documents of the orders currently shown in the Order detail table. A new POST /admin/orders/json endpoint returns the complete order documents (same shape as the per-order /admin/order/{id}/json) for the given ids, guarded by SUPER_ADMIN_ROLE_ID since it exposes sensitive data not otherwise present in the reporting page payload.

Closes #2578