### PR TITLE
🦋 Set subscription length per product

### DIFF
--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -39,6 +39,7 @@
 	import { typedFromEntries } from '$lib/utils/typedFromEntries';
 	import { type Day, dayList, productToScheduleId, type BookingSummary } from '$lib/types/Schedule';
 	import { formatDuration } from '$lib/utils/formatDuration';
+	import { formatDistance } from 'date-fns';
 	import { computeVatRate } from '$lib/utils/vat';
 	import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 
@@ -99,6 +100,8 @@
 	let paymentMethods = product.paymentMethods || [...availablePaymentMethods];
 	let restrictPaymentMethods = !!product.paymentMethods;
 	let vatProfileId = product.vatProfileId || '';
+	let subscriptionDuration = product.subscriptionDuration || '';
+	let subscriptionReminderSeconds: number | '' = product.subscriptionReminderSeconds || '';
 	let formElement: HTMLFormElement;
 	let variationInput: HTMLInputElement[] = [];
 	let disableDateChange = !isNew;
@@ -324,9 +327,6 @@
 
 	$: if (product.type === 'subscription') {
 		product.payWhatYouWant = false;
-		if (!product.subscriptionDuration) {
-			product.subscriptionDuration = 'month';
-		}
 	}
 
 	$: if (product.payWhatYouWant) {
@@ -436,10 +436,26 @@
 						<select
 							name="subscriptionDuration"
 							class="form-input max-w-[25rem]"
-							bind:value={product.subscriptionDuration}
+							bind:value={subscriptionDuration}
 						>
+							<option value="">Default (shop-wide)</option>
 							{#each SUBSCRIPTION_DURATIONS as duration}
 								<option value={duration}>{duration}</option>
+							{/each}
+						</select>
+					</label>
+					<label class="form-label">
+						Subscription reminder
+						<select
+							name="subscriptionReminderSeconds"
+							class="form-input max-w-[25rem]"
+							bind:value={subscriptionReminderSeconds}
+						>
+							<option value="">Default (shop-wide)</option>
+							{#each [86400 * 7, 86400 * 3, 86400, 3600, 5 * 60] as seconds}
+								<option value={seconds}
+									>{formatDistance(0, seconds * 1000)} before the end of the subscription</option
+								>
 							{/each}
 						</select>
 					</label>

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -40,6 +40,7 @@
 	import { type Day, dayList, productToScheduleId, type BookingSummary } from '$lib/types/Schedule';
 	import { formatDuration } from '$lib/utils/formatDuration';
 	import { computeVatRate } from '$lib/utils/vat';
+	import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 
 	const { t } = useI18n();
 
@@ -323,6 +324,9 @@
 
 	$: if (product.type === 'subscription') {
 		product.payWhatYouWant = false;
+		if (!product.subscriptionDuration) {
+			product.subscriptionDuration = 'month';
+		}
 	}
 
 	$: if (product.payWhatYouWant) {
@@ -425,6 +429,21 @@
 						<p class="text-sm text-gray-500 mt-1">Cannot be changed after creation</p>
 					{/if}
 				</label>
+
+				{#if product.type === 'subscription'}
+					<label class="form-label">
+						Subscription duration
+						<select
+							name="subscriptionDuration"
+							class="form-input max-w-[25rem]"
+							bind:value={product.subscriptionDuration}
+						>
+							{#each SUBSCRIPTION_DURATIONS as duration}
+								<option value={duration}>{duration}</option>
+							{/each}
+						</select>
+					</label>
+				{/if}
 
 				<label class="w-full block">
 					<CurrencyLabel label="Price currency" />

--- a/src/lib/components/SubscriptionDurationLabel.svelte
+++ b/src/lib/components/SubscriptionDurationLabel.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { useI18n } from '$lib/i18n';
+	import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
+
+	export let duration: SubscriptionDuration;
+	let className = '';
+	export { className as class };
+
+	const { t } = useI18n();
+</script>
+
+<span class="inline-flex items-center gap-1 text-sm text-gray-600 {className}">
+	🔁 {t('product.subscriptionDuration.' + duration)}
+</span>

--- a/src/lib/server/locks/subscription-lock.ts
+++ b/src/lib/server/locks/subscription-lock.ts
@@ -1,14 +1,34 @@
-import { addSeconds, formatDistance } from 'date-fns';
+import { addSeconds, formatDistance, subSeconds } from 'date-fns';
 import { collections, withTransaction } from '../database';
 import { Lock } from '../lock';
 import { processClosed } from '../process';
 import { setTimeout } from 'node:timers/promises';
-import { refreshPromise, runtimeConfig } from '../runtime-config';
+import { refreshPromise } from '../runtime-config';
 import { type FindCursor, ObjectId } from 'mongodb';
 import { ORIGIN } from '$lib/server/env-config';
 import { Kind } from 'nostr-tools';
 import { queueEmail } from '../email';
 import type { PaidSubscription } from '$lib/types/PaidSubscription';
+import { resolveSubscriptionReminderSeconds } from '../subscriptions';
+
+/** Per-product reminder is capped at the same 7 days as the global (see
+ * admin/config and product-schema), so this window always catches every
+ * candidate before we gate against the per-subscription resolved value. */
+const MAX_REMINDER_SECONDS = 24 * 60 * 60 * 7;
+
+async function isSubscriptionDueForReminder(
+	subscription: PaidSubscription,
+	now: Date
+): Promise<boolean> {
+	const product = await collections.products.findOne(
+		{ _id: subscription.productId },
+		{ projection: { subscriptionReminderSeconds: 1 } }
+	);
+	if (!product) {
+		return false;
+	}
+	return subSeconds(subscription.paidUntil, resolveSubscriptionReminderSeconds(product)) <= now;
+}
 
 const lock = new Lock('paid-subscriptions');
 
@@ -249,16 +269,20 @@ async function maintainLock() {
 
 		try {
 			const now = new Date();
-			const reminderWindow = addSeconds(now, runtimeConfig.subscriptionReminderSeconds);
+			const reminderWindow = addSeconds(now, MAX_REMINDER_SECONDS);
 
 			const subscriptionsToRemindNostr = getSubscriptionsToRemindViaNostr(now, reminderWindow);
 			for await (const subscription of subscriptionsToRemindNostr) {
-				await notifySubscriptionReminderViaNostr(subscription);
+				if (await isSubscriptionDueForReminder(subscription, now)) {
+					await notifySubscriptionReminderViaNostr(subscription);
+				}
 			}
 
 			const subscriptionsToRemindEmail = getSubscriptionsToRemindViaEmail(now, reminderWindow);
 			for await (const subscription of subscriptionsToRemindEmail) {
-				await notifySubscriptionReminderViaEmail(subscription);
+				if (await isSubscriptionDueForReminder(subscription, now)) {
+					await notifySubscriptionReminderViaEmail(subscription);
+				}
 			}
 		} catch (err) {
 			console.error(err);

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -7,6 +7,7 @@ import { Lock } from './lock';
 import { ORIGIN } from '$lib/server/env-config';
 import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
 import { CURRENCIES, FRACTION_DIGITS_PER_CURRENCY } from '$lib/types/Currency';
+import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
 
 async function ensureDefaultSearchlist(session?: ClientSession): Promise<void> {
 	const existing = await collections.searchlists.findOne({ _id: 'default' }, { session });
@@ -828,6 +829,22 @@ const migrations = [
 		name: 'Seed search searchlist (issue #1787)',
 		run: async (session: ClientSession) => {
 			await ensureSearchSearchlist(session);
+		}
+	},
+	{
+		_id: new ObjectId('6b1f4880e92e590e85af2388'),
+		name: 'Move subscription duration to product level (issue #2388)',
+		run: async (session: ClientSession) => {
+			const config = await collections.runtimeConfig.findOne(
+				{ _id: 'subscriptionDuration' },
+				{ session }
+			);
+			const globalDuration = (config?.data as SubscriptionDuration) ?? 'month';
+			await collections.products.updateMany(
+				{ type: 'subscription', subscriptionDuration: { $exists: false } },
+				{ $set: { subscriptionDuration: globalDuration } },
+				{ session }
+			);
 		}
 	}
 ];

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -95,7 +95,7 @@ async function ensureSearchSearchlist(session?: ClientSession): Promise<void> {
 	);
 }
 
-const migrations = [
+export const migrations = [
 	{
 		_id: new ObjectId('65281201e92e590e858af6cb'),
 		name: 'Migrate CMS page content from Markdown to HTML',

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -24,7 +24,11 @@ import {
 } from 'date-fns';
 import { runtimeConfig } from './runtime-config';
 import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
-import { freeProductsForUser, generateSubscriptionNumber } from './subscriptions';
+import {
+	freeProductsForUser,
+	generateSubscriptionNumber,
+	resolveSubscriptionDuration
+} from './subscriptions';
 import {
 	checkProductVariationsIntegrity,
 	productPriceWithVariations,
@@ -2022,7 +2026,7 @@ function addDiscountFreeProducts(
 	}
 }
 
-function getSubscriptionDuration(): Duration {
+function getSubscriptionDuration(product: { subscriptionDuration?: SubscriptionDuration }): Duration {
 	const durations: Record<SubscriptionDuration, Duration> = {
 		hour: { hours: 1 },
 		day: { days: 1 },
@@ -2030,7 +2034,7 @@ function getSubscriptionDuration(): Duration {
 		month: { months: 1 },
 		year: { years: 1 }
 	};
-	return durations[runtimeConfig.subscriptionDuration as SubscriptionDuration];
+	return durations[resolveSubscriptionDuration(product)];
 }
 
 async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSession) {
@@ -2060,7 +2064,10 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 			for (const discount of discountsForSubscription) {
 				addDiscountFreeProducts(discount, updatedFreeProductsById);
 			}
-			const newPaidUntil = add(max([existing.paidUntil, new Date()]), getSubscriptionDuration());
+			const newPaidUntil = add(
+				max([existing.paidUntil, new Date()]),
+				getSubscriptionDuration(subscription.product)
+			);
 
 			const archivedNotifications = existing.notifications.map((notif) => ({
 				...notif,
@@ -2116,7 +2123,7 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 					number: await generateSubscriptionNumber(),
 					user: order.user,
 					productId: subscription.product._id,
-					paidUntil: add(new Date(), getSubscriptionDuration()),
+					paidUntil: add(new Date(), getSubscriptionDuration(subscription.product)),
 					createdAt: new Date(),
 					updatedAt: new Date(),
 					notifications: [],

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -27,7 +27,8 @@ import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
 import {
 	freeProductsForUser,
 	generateSubscriptionNumber,
-	resolveSubscriptionDuration
+	resolveSubscriptionDuration,
+	resolveSubscriptionReminderSeconds
 } from './subscriptions';
 import {
 	checkProductVariationsIntegrity,
@@ -994,7 +995,7 @@ export async function createOrder(
 
 		if (existingSubscription) {
 			if (
-				subSeconds(existingSubscription.paidUntil, runtimeConfig.subscriptionReminderSeconds) >
+				subSeconds(existingSubscription.paidUntil, resolveSubscriptionReminderSeconds(product)) >
 				new Date()
 			) {
 				throw error(
@@ -2026,7 +2027,9 @@ function addDiscountFreeProducts(
 	}
 }
 
-function getSubscriptionDuration(product: { subscriptionDuration?: SubscriptionDuration }): Duration {
+function getSubscriptionDuration(product: {
+	subscriptionDuration?: SubscriptionDuration;
+}): Duration {
 	const durations: Record<SubscriptionDuration, Duration> = {
 		hour: { hours: 1 },
 		day: { days: 1 },

--- a/src/lib/server/subscriptions.test.ts
+++ b/src/lib/server/subscriptions.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { collections, withTransaction } from './database';
+import { runtimeConfig } from './runtime-config';
+import { resolveSubscriptionDuration, resolveSubscriptionReminderSeconds } from './subscriptions';
+import { migrations } from './migrations';
+import { cleanDb } from './test-utils';
+import { TEST_SUBSCRIPTION_PRODUCT } from './seed/product';
+import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
+
+describe('resolveSubscriptionDuration', () => {
+	let oldDuration: typeof runtimeConfig.subscriptionDuration;
+
+	beforeAll(() => {
+		oldDuration = runtimeConfig.subscriptionDuration;
+	});
+
+	beforeEach(() => {
+		runtimeConfig.subscriptionDuration = 'month';
+	});
+
+	afterAll(() => {
+		runtimeConfig.subscriptionDuration = oldDuration;
+	});
+
+	it('returns the per-product duration when defined', () => {
+		expect(resolveSubscriptionDuration({ subscriptionDuration: 'year' })).toBe('year');
+		expect(resolveSubscriptionDuration({ subscriptionDuration: 'week' })).toBe('week');
+	});
+
+	it('falls back to the global default when the product has no duration', () => {
+		expect(resolveSubscriptionDuration({})).toBe('month');
+	});
+
+	it('falls back to the global default when the per-product value is an empty string', () => {
+		expect(resolveSubscriptionDuration({ subscriptionDuration: '' })).toBe('month');
+	});
+
+	it('reflects a change to the global default', () => {
+		runtimeConfig.subscriptionDuration = 'year';
+		expect(resolveSubscriptionDuration({})).toBe('year');
+		expect(resolveSubscriptionDuration({ subscriptionDuration: '' })).toBe('year');
+	});
+
+	it('still wins over a different global when the product duration is set', () => {
+		runtimeConfig.subscriptionDuration = 'year';
+		expect(resolveSubscriptionDuration({ subscriptionDuration: 'hour' })).toBe('hour');
+	});
+});
+
+describe('resolveSubscriptionReminderSeconds', () => {
+	const ONE_DAY = 24 * 60 * 60;
+	let oldReminder: typeof runtimeConfig.subscriptionReminderSeconds;
+
+	beforeAll(() => {
+		oldReminder = runtimeConfig.subscriptionReminderSeconds;
+	});
+
+	beforeEach(() => {
+		runtimeConfig.subscriptionReminderSeconds = ONE_DAY;
+	});
+
+	afterAll(() => {
+		runtimeConfig.subscriptionReminderSeconds = oldReminder;
+	});
+
+	it('returns the per-product reminder when defined', () => {
+		expect(resolveSubscriptionReminderSeconds({ subscriptionReminderSeconds: 3600 })).toBe(3600);
+	});
+
+	it('falls back to the global default when the product has no reminder', () => {
+		expect(resolveSubscriptionReminderSeconds({})).toBe(ONE_DAY);
+	});
+
+	it('reflects a change to the global default', () => {
+		runtimeConfig.subscriptionReminderSeconds = 7 * ONE_DAY;
+		expect(resolveSubscriptionReminderSeconds({})).toBe(7 * ONE_DAY);
+	});
+
+	it('still wins over a different global when the per-product reminder is set', () => {
+		runtimeConfig.subscriptionReminderSeconds = 7 * ONE_DAY;
+		expect(resolveSubscriptionReminderSeconds({ subscriptionReminderSeconds: 300 })).toBe(300);
+	});
+});
+
+describe('migration #2388: subscriptionDuration backfill', () => {
+	const MIGRATION_ID = '6b1f4880e92e590e85af2388';
+	let migration: (typeof migrations)[number] | undefined;
+
+	beforeAll(() => {
+		migration = migrations.find((m) => m._id.toString() === MIGRATION_ID);
+	});
+
+	beforeEach(async () => {
+		await cleanDb();
+	});
+
+	async function runMigration() {
+		await withTransaction(async (session) => {
+			if (!migration) {
+				throw new Error(`migration ${MIGRATION_ID} must exist`);
+			}
+			await migration.run(session);
+		});
+	}
+
+	it('backfills products missing subscriptionDuration with the global value', async () => {
+		await collections.runtimeConfig.insertOne({
+			_id: 'subscriptionDuration',
+			data: 'year' as never,
+			updatedAt: new Date()
+		});
+		await collections.products.insertOne({
+			...TEST_SUBSCRIPTION_PRODUCT,
+			_id: 'sub-no-duration'
+		});
+
+		await runMigration();
+
+		const updated = await collections.products.findOne({ _id: 'sub-no-duration' });
+		expect(updated?.subscriptionDuration).toBe('year');
+	});
+
+	it('defaults to "month" when no global config is set', async () => {
+		await collections.products.insertOne({
+			...TEST_SUBSCRIPTION_PRODUCT,
+			_id: 'sub-no-config'
+		});
+
+		await runMigration();
+
+		const updated = await collections.products.findOne({ _id: 'sub-no-config' });
+		expect(updated?.subscriptionDuration).toBe('month');
+	});
+
+	it('leaves products with an existing subscriptionDuration untouched', async () => {
+		await collections.runtimeConfig.insertOne({
+			_id: 'subscriptionDuration',
+			data: 'year' as never,
+			updatedAt: new Date()
+		});
+		await collections.products.insertOne({
+			...TEST_SUBSCRIPTION_PRODUCT,
+			_id: 'sub-with-duration',
+			subscriptionDuration: 'week' satisfies SubscriptionDuration
+		});
+
+		await runMigration();
+
+		const updated = await collections.products.findOne({ _id: 'sub-with-duration' });
+		expect(updated?.subscriptionDuration).toBe('week');
+	});
+
+	it('is idempotent — re-running does not change anything', async () => {
+		await collections.runtimeConfig.insertOne({
+			_id: 'subscriptionDuration',
+			data: 'year' as never,
+			updatedAt: new Date()
+		});
+		await collections.products.insertOne({
+			...TEST_SUBSCRIPTION_PRODUCT,
+			_id: 'sub-idempotent'
+		});
+
+		await runMigration();
+		const first = await collections.products.findOne({ _id: 'sub-idempotent' });
+		await runMigration();
+		const second = await collections.products.findOne({ _id: 'sub-idempotent' });
+
+		expect(second?.subscriptionDuration).toBe(first?.subscriptionDuration);
+		expect(second?.subscriptionDuration).toBe('year');
+	});
+});

--- a/src/lib/server/subscriptions.ts
+++ b/src/lib/server/subscriptions.ts
@@ -7,9 +7,21 @@ import { userQuery } from './user';
 
 /** Shared resolver so order renewal and customer display never compute the fallback differently. */
 export function resolveSubscriptionDuration(product: {
-	subscriptionDuration?: SubscriptionDuration;
+	subscriptionDuration?: SubscriptionDuration | '';
 }): SubscriptionDuration {
-	return (product.subscriptionDuration ?? runtimeConfig.subscriptionDuration) as SubscriptionDuration;
+	// `||` not `??`: an empty-string snapshot (legacy data, or in-flight UI state)
+	// must also fall through to the global, otherwise durations[''] is undefined
+	// and add(date, undefined) breaks renewal.
+	return (product.subscriptionDuration ||
+		runtimeConfig.subscriptionDuration) as SubscriptionDuration;
+}
+
+/** Shared resolver so renewal eligibility, /subscription canRenew and the
+ * reminder cron all read the same value for a given product. */
+export function resolveSubscriptionReminderSeconds(product: {
+	subscriptionReminderSeconds?: number;
+}): number {
+	return product.subscriptionReminderSeconds || runtimeConfig.subscriptionReminderSeconds;
 }
 
 export async function freeProductsForUser(

--- a/src/lib/server/subscriptions.ts
+++ b/src/lib/server/subscriptions.ts
@@ -1,7 +1,16 @@
 import type { PaidSubscription } from '$lib/types/PaidSubscription';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
+import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
 import { collections } from './database';
+import { runtimeConfig } from './runtime-config';
 import { userQuery } from './user';
+
+/** Shared resolver so order renewal and customer display never compute the fallback differently. */
+export function resolveSubscriptionDuration(product: {
+	subscriptionDuration?: SubscriptionDuration;
+}): SubscriptionDuration {
+	return (product.subscriptionDuration ?? runtimeConfig.subscriptionDuration) as SubscriptionDuration;
+}
 
 export async function freeProductsForUser(
 	user: UserIdentifier,

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -945,6 +945,13 @@
 		"preorderText": "Dies ist eine Vorbestellung, Ihr Produkt wird am {date} verfügbar sein",
 		"pricePlaceholder": "Preis",
 		"seeInCabinet": "In Meinem Schrank ansehen",
+		"subscriptionDuration": {
+			"hour": "Verlängert sich jede Stunde",
+			"day": "Verlängert sich jeden Tag",
+			"week": "Verlängert sich jede Woche",
+			"month": "Verlängert sich jeden Monat",
+			"year": "Verlängert sich jedes Jahr"
+		},
 		"type": {
 			"deposit": "Auf Anzahlung",
 			"digitalResource": "Digitale Ressource",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -947,6 +947,13 @@
 		"preorderText": "This is a preorder, your product will be available on {date}",
 		"pricePlaceholder": "Price",
 		"seeInCabinet": "See in MyCabinet",
+		"subscriptionDuration": {
+			"hour": "Renews every hour",
+			"day": "Renews every day",
+			"week": "Renews every week",
+			"month": "Renews every month",
+			"year": "Renews every year"
+		},
 		"type": {
 			"deposit": "On deposit",
 			"digitalResource": "Digital Resource",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -945,6 +945,13 @@
 		"preorderText": "Esta es una preorden, el producto estará disponible el {date}",
 		"pricePlaceholder": "Precio",
 		"seeInCabinet": "Ver en el cabinet",
+		"subscriptionDuration": {
+			"hour": "Se renueva cada hora",
+			"day": "Se renueva cada día",
+			"week": "Se renueva cada semana",
+			"month": "Se renueva cada mes",
+			"year": "Se renueva cada año"
+		},
 		"type": {
 			"deposit": "En depósito",
 			"digitalResource": "Recurso digital",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -945,6 +945,13 @@
 		"preorderText": "En précommande, disponible le {date}",
 		"pricePlaceholder": "Prix",
 		"seeInCabinet": "Voir dans MonCabinet",
+		"subscriptionDuration": {
+			"hour": "Renouvelé chaque heure",
+			"day": "Renouvelé chaque jour",
+			"week": "Renouvelé chaque semaine",
+			"month": "Renouvelé chaque mois",
+			"year": "Renouvelé chaque année"
+		},
 		"type": {
 			"deposit": "Sur acompte",
 			"digitalResource": "Ressource numérique",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -945,6 +945,13 @@
 		"preorderText": "Questo è un preordine, il tuo prodotto sarà disponibile il  {date}",
 		"pricePlaceholder": "Prezzo",
 		"seeInCabinet": "Vedi in MyCabinet",
+		"subscriptionDuration": {
+			"hour": "Si rinnova ogni ora",
+			"day": "Si rinnova ogni giorno",
+			"week": "Si rinnova ogni settimana",
+			"month": "Si rinnova ogni mese",
+			"year": "Si rinnova ogni anno"
+		},
 		"type": {
 			"deposit": "In deposito",
 			"digitalResource": "Risorse digitali",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -945,6 +945,13 @@
 		"preorderText": "Dit is een voorbestelling. Uw product is beschikbaar op {date}",
 		"pricePlaceholder": "Prijs",
 		"seeInCabinet": "Zie in MijnKabinet",
+		"subscriptionDuration": {
+			"hour": "Verlengt elk uur",
+			"day": "Verlengt elke dag",
+			"week": "Verlengt elke week",
+			"month": "Verlengt elke maand",
+			"year": "Verlengt elk jaar"
+		},
 		"type": {
 			"deposit": "Op borg",
 			"digitalResource": "Digitale hulpbron",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -945,6 +945,13 @@
 		"preorderText": "Isto é uma pré-encomenda, o seu produto estará disponível em {date}",
 		"pricePlaceholder": "Preço",
 		"seeInCabinet": "Ver no Meu Armário",
+		"subscriptionDuration": {
+			"hour": "Renova a cada hora",
+			"day": "Renova a cada dia",
+			"week": "Renova a cada semana",
+			"month": "Renova a cada mês",
+			"year": "Renova a cada ano"
+		},
 		"type": {
 			"deposit": "Sob depósito",
 			"digitalResource": "Recurso Digital",

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -8,6 +8,7 @@ import type { Timestamps } from './Timestamps';
 import type { PaymentMethod } from '$lib/server/payment-methods';
 import { sumCurrency } from '$lib/utils/sumCurrency';
 import type { PickDeep } from 'type-fest';
+import type { SubscriptionDuration } from './SubscriptionDuration';
 
 export interface ProductTranslatableFields {
 	name: string;
@@ -51,6 +52,7 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 	vatProfileId?: ObjectId;
 	maxQuantityPerOrder?: number;
 	type: 'subscription' | 'resource' | 'donation';
+	subscriptionDuration?: SubscriptionDuration;
 	shipping: boolean;
 	deliveryFees?: DeliveryFees;
 	requireSpecificDeliveryFee?: boolean;

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -53,6 +53,7 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 	maxQuantityPerOrder?: number;
 	type: 'subscription' | 'resource' | 'donation';
 	subscriptionDuration?: SubscriptionDuration;
+	subscriptionReminderSeconds?: number;
 	shipping: boolean;
 	deliveryFees?: DeliveryFees;
 	requireSpecificDeliveryFee?: boolean;

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -6,7 +6,7 @@ import { collections } from '$lib/server/database';
 import { picturesForProducts } from '$lib/server/picture.js';
 import { pojo } from '$lib/server/pojo.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
-import { freeProductsForUser } from '$lib/server/subscriptions';
+import { freeProductsForUser, resolveSubscriptionDuration } from '$lib/server/subscriptions';
 import type { DigitalFile } from '$lib/types/DigitalFile';
 import { userQuery } from '$lib/server/user.js';
 import { userIdentifier } from '$lib/server/user.js';
@@ -127,6 +127,7 @@ export async function load(params) {
 							| 'paymentMethods'
 							| 'variationLabels'
 							| 'bookingSpec.slotMinutes'
+							| 'subscriptionDuration'
 						>
 					>({
 						_id: 1,
@@ -152,6 +153,7 @@ export async function load(params) {
 						paymentMethods: 1,
 						'bookingSpec.slotMinutes': 1,
 						isTicket: 1,
+						subscriptionDuration: 1,
 						variationLabels: {
 							$ifNull: [`$translations.${locals.language}.variationLabels`, '$variationLabels']
 						}
@@ -228,7 +230,12 @@ export async function load(params) {
 
 			return {
 				_id: item._id,
-				product: pojo(productDoc),
+				product: {
+					...pojo(productDoc),
+					...(productDoc.type === 'subscription' && {
+						subscriptionDuration: resolveSubscriptionDuration(productDoc)
+					})
+				},
 				picture: productPictureDoc,
 				booking: item.booking,
 				digitalFilesCount: digitalFilesDoc?.length ?? 0,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
@@ -4,7 +4,6 @@ import { ORIGIN } from '$lib/server/env-config';
 import { collections } from '$lib/server/database';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { CURRENCIES } from '$lib/types/Currency';
-import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 import { toCurrency } from '$lib/utils/toCurrency';
 import { typedKeys } from '$lib/utils/typedKeys.js';
 import { fetchAndSaveExchangeRates } from '$lib/server/locks/currency-lock';
@@ -43,7 +42,6 @@ export async function load(event) {
 		maintenanceIps: runtimeConfig.maintenanceIps,
 		checkoutButtonOnProductPage: runtimeConfig.checkoutButtonOnProductPage,
 		discovery: runtimeConfig.discovery,
-		subscriptionDuration: runtimeConfig.subscriptionDuration,
 		subscriptionReminderSeconds: runtimeConfig.subscriptionReminderSeconds,
 		vatExemptionReason: runtimeConfig.vatExemptionReason,
 		desiredPaymentTimeout: runtimeConfig.desiredPaymentTimeout,
@@ -106,7 +104,6 @@ export const actions = {
 				copyOrderEmailsToAdmin: z.boolean({ coerce: true }),
 				hideShopBankOnReceipt: z.boolean({ coerce: true }),
 				hideShopBankOnTicket: z.boolean({ coerce: true }),
-				subscriptionDuration: z.enum(SUBSCRIPTION_DURATIONS),
 				mainCurrency: z.enum([CURRENCIES[0], ...CURRENCIES.slice(1).filter((c) => c !== 'SAT')]),
 				secondaryCurrency: z
 					.enum([CURRENCIES[0], ...CURRENCIES.slice(1).filter((c) => c !== 'SAT'), ''])

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
@@ -25,6 +25,7 @@ import { isPhoenixdConfigured } from '$lib/server/phoenixd';
 import { isSwissBitcoinPayConfigured } from '$lib/server/swiss-bitcoin-pay';
 import { isBtcpayServerConfigured } from '$lib/server/btcpay-server';
 import { logAccountingEvent, employeeFromLocals } from '$lib/server/accounting-log';
+import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 
 const VAT_SETTING_KEYS = new Set([
 	'vatExempted',
@@ -42,6 +43,7 @@ export async function load(event) {
 		maintenanceIps: runtimeConfig.maintenanceIps,
 		checkoutButtonOnProductPage: runtimeConfig.checkoutButtonOnProductPage,
 		discovery: runtimeConfig.discovery,
+		subscriptionDuration: runtimeConfig.subscriptionDuration,
 		subscriptionReminderSeconds: runtimeConfig.subscriptionReminderSeconds,
 		vatExemptionReason: runtimeConfig.vatExemptionReason,
 		desiredPaymentTimeout: runtimeConfig.desiredPaymentTimeout,
@@ -118,6 +120,7 @@ export const actions = {
 				vatNullOutsideSellerCountry: z.boolean({ coerce: true }),
 				displayVatIncludedInProduct: z.boolean({ coerce: true }),
 				vatCountry: z.string().default(runtimeConfig.vatCountry),
+				subscriptionDuration: z.enum(SUBSCRIPTION_DURATIONS),
 				subscriptionReminderSeconds: z
 					.number({ coerce: true })
 					.int()

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
@@ -13,6 +13,7 @@
 	import { useI18n } from '$lib/i18n.js';
 	import CurrencyLabel from '$lib/components/CurrencyLabel.svelte';
 	import IconInfo from '$lib/components/icons/IconInfo.svelte';
+	import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 	import MultiSelect from 'svelte-multiselect';
 	import Select from 'svelte-select';
 	import ProcessorSelector from '$lib/components/ProcessorSelector.svelte';
@@ -576,9 +577,21 @@
 	/>
 
 	<h2 class="text-2xl">Timing</h2>
-	<p class="text-sm text-gray-600 bg-yellow-50 border-l-4 border-yellow-400 p-3 rounded">
-		Subscription duration moved in product settings for greater flexibility.
-	</p>
+	<label class="form-label">
+		Default subscription duration
+		<select
+			name="subscriptionDuration"
+			value={data.subscriptionDuration}
+			class="form-input max-w-[25rem]"
+		>
+			{#each SUBSCRIPTION_DURATIONS as duration}
+				<option value={duration}>{duration}</option>
+			{/each}
+		</select>
+		<p class="text-sm">
+			Used for subscription products set to "Default (shop-wide)" and for legacy snapshots.
+		</p>
+	</label>
 	<label class="form-label">
 		Subscription reminder
 		<select

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
@@ -5,7 +5,6 @@
 	import IconDownArrow from '~icons/ant-design/arrow-down-outlined';
 
 	import { sortCurrencies, currenciesToSelectOptions } from '$lib/types/Currency';
-	import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 	import { ORDER_PAYMENT_STATUSES } from '$lib/types/Order';
 	import { DELAY_MULTIPLIERS } from '$lib/utils/delayMultipliers';
 	import { typedInclude } from '$lib/utils/typedIncludes';
@@ -577,18 +576,9 @@
 	/>
 
 	<h2 class="text-2xl">Timing</h2>
-	<label class="form-label">
-		Subscription duration
-		<select
-			name="subscriptionDuration"
-			class="form-input max-w-[25rem]"
-			value={data.subscriptionDuration}
-		>
-			{#each SUBSCRIPTION_DURATIONS as duration}
-				<option value={duration}>{duration}</option>
-			{/each}
-		</select>
-	</label>
+	<p class="text-sm text-gray-600 bg-yellow-50 border-l-4 border-yellow-400 p-3 rounded">
+		Subscription duration moved in product settings for greater flexibility.
+	</p>
 	<label class="form-label">
 		Subscription reminder
 		<select

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -267,6 +267,9 @@ export const actions: Actions = {
 						...(parsed.subscriptionDuration && {
 							subscriptionDuration: parsed.subscriptionDuration
 						}),
+						...(typeof parsed.subscriptionReminderSeconds === 'number' && {
+							subscriptionReminderSeconds: parsed.subscriptionReminderSeconds
+						}),
 						...(parsed.restrictPaymentMethods && {
 							paymentMethods: parsed.paymentMethods ?? []
 						}),
@@ -303,6 +306,9 @@ export const actions: Actions = {
 						...(!parsed.depositPercentage && { deposit: '' }),
 						...(!parsed.vatProfileId && { vatProfileId: '' }),
 						...(!parsed.subscriptionDuration && { subscriptionDuration: '' }),
+						...(typeof parsed.subscriptionReminderSeconds !== 'number' && {
+							subscriptionReminderSeconds: ''
+						}),
 						...(!parsed.restrictPaymentMethods && { paymentMethods: '' }),
 						...(!hasVariations && { variations: '', variationLabels: '' }),
 						...(!parsed.hasSellDisclaimer && { sellDisclaimer: '' }),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -264,6 +264,9 @@ export const actions: Actions = {
 						},
 						updatedAt: new Date(),
 						...(parsed.vatProfileId && { vatProfileId: new ObjectId(parsed.vatProfileId) }),
+						...(parsed.subscriptionDuration && {
+							subscriptionDuration: parsed.subscriptionDuration
+						}),
 						...(parsed.restrictPaymentMethods && {
 							paymentMethods: parsed.paymentMethods ?? []
 						}),
@@ -299,6 +302,7 @@ export const actions: Actions = {
 						...(!parsed.maxQuantityPerOrder && { maxQuantityPerOrder: '' }),
 						...(!parsed.depositPercentage && { deposit: '' }),
 						...(!parsed.vatProfileId && { vatProfileId: '' }),
+						...(!parsed.subscriptionDuration && { subscriptionDuration: '' }),
 						...(!parsed.restrictPaymentMethods && { paymentMethods: '' }),
 						...(!hasVariations && { variations: '', variationLabels: '' }),
 						...(!parsed.hasSellDisclaimer && { sellDisclaimer: '' }),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -253,6 +253,9 @@ export const actions: Actions = {
 							...(parsed.subscriptionDuration && {
 								subscriptionDuration: parsed.subscriptionDuration
 							}),
+							...(typeof parsed.subscriptionReminderSeconds === 'number' && {
+								subscriptionReminderSeconds: parsed.subscriptionReminderSeconds
+							}),
 							hasSellDisclaimer: parsed.hasSellDisclaimer,
 							...(parsed.hasSellDisclaimer &&
 								parsed.sellDisclaimerTitle &&
@@ -464,6 +467,9 @@ export const actions: Actions = {
 					...(parsed.vatProfileId && { vatProfileId: new ObjectId(parsed.vatProfileId) }),
 					...(parsed.subscriptionDuration && {
 						subscriptionDuration: parsed.subscriptionDuration
+					}),
+					...(typeof parsed.subscriptionReminderSeconds === 'number' && {
+						subscriptionReminderSeconds: parsed.subscriptionReminderSeconds
 					}),
 					hideFromSEO: parsed.hideFromSEO,
 					translations: product.translations

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -250,6 +250,9 @@ export const actions: Actions = {
 									variationLabels: cleanedVariationLabels
 								}),
 							...(parsed.vatProfileId && { vatProfileId: new ObjectId(parsed.vatProfileId) }),
+							...(parsed.subscriptionDuration && {
+								subscriptionDuration: parsed.subscriptionDuration
+							}),
 							hasSellDisclaimer: parsed.hasSellDisclaimer,
 							...(parsed.hasSellDisclaimer &&
 								parsed.sellDisclaimerTitle &&
@@ -459,6 +462,9 @@ export const actions: Actions = {
 							}
 						}),
 					...(parsed.vatProfileId && { vatProfileId: new ObjectId(parsed.vatProfileId) }),
+					...(parsed.subscriptionDuration && {
+						subscriptionDuration: parsed.subscriptionDuration
+					}),
 					hideFromSEO: parsed.hideFromSEO,
 					translations: product.translations
 				},

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -1,5 +1,6 @@
 import { CURRENCIES } from '$lib/types/Currency';
 import { MAX_NAME_LIMIT, MAX_SHORT_DESCRIPTION_LIMIT } from '$lib/types/Product';
+import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 import { z } from 'zod';
 import { deliveryFeesSchema } from '../config/delivery/schema';
 import { MAX_CONTENT_LIMIT } from '$lib/types/CmsPage';
@@ -166,6 +167,7 @@ export const productBaseSchema = () => ({
 	depositPercentage: z.number({ coerce: true }).int().min(0).max(100).optional(),
 	enforceDeposit: z.boolean({ coerce: true }).default(false),
 	vatProfileId: zodObjectId().or(z.literal('')).optional(),
+	subscriptionDuration: z.enum(SUBSCRIPTION_DURATIONS).or(z.literal('')).optional(),
 	cta: z
 		.array(
 			z.object({

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -168,6 +168,16 @@ export const productBaseSchema = () => ({
 	enforceDeposit: z.boolean({ coerce: true }).default(false),
 	vatProfileId: zodObjectId().or(z.literal('')).optional(),
 	subscriptionDuration: z.enum(SUBSCRIPTION_DURATIONS).or(z.literal('')).optional(),
+	subscriptionReminderSeconds: z
+		.union([
+			z.literal(''),
+			z
+				.number({ coerce: true })
+				.int()
+				.min(0)
+				.max(24 * 60 * 60 * 7)
+		])
+		.optional(),
 	cta: z
 		.array(
 			z.object({

--- a/src/routes/(app)/cart/+page.svelte
+++ b/src/routes/(app)/cart/+page.svelte
@@ -7,6 +7,7 @@
 	import Picture from '$lib/components/Picture.svelte';
 	import PriceTag from '$lib/components/PriceTag.svelte';
 	import ProductType from '$lib/components/ProductType.svelte';
+	import SubscriptionDurationLabel from '$lib/components/SubscriptionDurationLabel.svelte';
 	import Trans from '$lib/components/Trans.svelte';
 	import IconInfo from '$lib/components/icons/IconInfo.svelte';
 	import IconTrash from '$lib/components/icons/IconTrash.svelte';
@@ -305,6 +306,9 @@
 									</button>
 								{/if}
 							</div>
+							{#if item.product.type === 'subscription' && item.product.subscriptionDuration}
+								<SubscriptionDurationLabel duration={item.product.subscriptionDuration} />
+							{/if}
 						</div>
 
 						<div class="flex flex-col items-end gap-2 lg:mb-0 mb-4">

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -8,6 +8,7 @@
 	import { typedValues } from '$lib/utils/typedValues';
 	import { typedInclude } from '$lib/utils/typedIncludes';
 	import ProductType from '$lib/components/ProductType.svelte';
+	import SubscriptionDurationLabel from '$lib/components/SubscriptionDurationLabel.svelte';
 	import { computeDeliveryFees, computePriceInfo } from '$lib/cart';
 	import { computeVatRate, extractVat } from '$lib/utils/vat';
 	import IconInfo from '$lib/components/icons/IconInfo.svelte';
@@ -828,6 +829,10 @@
 									>{/if}
 							</h3>
 						</a>
+
+						{#if item.product.type === 'subscription' && item.product.subscriptionDuration}
+							<SubscriptionDurationLabel duration={item.product.subscriptionDuration} class="mb-1" />
+						{/if}
 
 						<div class="flex flex-row gap-2">
 							<a

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -831,7 +831,10 @@
 						</a>
 
 						{#if item.product.type === 'subscription' && item.product.subscriptionDuration}
-							<SubscriptionDurationLabel duration={item.product.subscriptionDuration} class="mb-1" />
+							<SubscriptionDurationLabel
+								duration={item.product.subscriptionDuration}
+								class="mb-1"
+							/>
 						{/if}
 
 						<div class="flex flex-row gap-2">

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -2,6 +2,7 @@ import { addToCartInDb } from '$lib/server/cart';
 import { cmsFromContent } from '$lib/server/cms';
 import { collections } from '$lib/server/database';
 import { applyResolvedStock, resolveStockProduct } from '$lib/server/product';
+import { resolveSubscriptionDuration } from '$lib/server/subscriptions';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { userIdentifier, userQuery } from '$lib/server/user';
 import { CURRENCIES, parsePriceAmount } from '$lib/types/Currency';
@@ -113,6 +114,7 @@ async function fetchProduct(
 	| 'vatProfileId'
 	| 'stockReference'
 	| 'tagIds'
+	| 'subscriptionDuration'
 > | null> {
 	return collections.products.findOne<ReturnType<Awaited<typeof fetchProduct>>>(
 		{ _id: productId },
@@ -163,7 +165,8 @@ async function fetchProduct(
 				bookingSpec: 1,
 				vatProfileId: 1,
 				stockReference: 1,
-				tagIds: 1
+				tagIds: 1,
+				subscriptionDuration: 1
 			}
 		}
 	);
@@ -256,7 +259,13 @@ export const load = async ({ params, parent, locals }) => {
 	});
 
 	return {
-		product: { ...product, vatProfileId: product.vatProfileId?.toString() },
+		product: {
+			...product,
+			vatProfileId: product.vatProfileId?.toString(),
+			...(product.type === 'subscription' && {
+				subscriptionDuration: resolveSubscriptionDuration(product)
+			})
+		},
 		pictures,
 		discount,
 		vatRate,

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { marked } from 'marked';
 	import Picture from '$lib/components/Picture.svelte';
 	import PriceTag from '$lib/components/PriceTag.svelte';
+	import SubscriptionDurationLabel from '$lib/components/SubscriptionDurationLabel.svelte';
 	import { applyAction, enhance } from '$app/forms';
 	import IconInfo from '$lib/components/icons/IconInfo.svelte';
 	import { productAddedToCart } from '$lib/stores/productAddedToCart';
@@ -704,6 +705,10 @@
 						/>
 						<span class="font-semibold text-sm">{t('product.vatExcluded')}</span>
 					</div>
+				{/if}
+
+				{#if data.product.type === 'subscription' && data.product.subscriptionDuration}
+					<SubscriptionDurationLabel duration={data.product.subscriptionDuration} />
 				{/if}
 
 				{#if freeProductsAvailable}

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -1,6 +1,9 @@
 import { collections } from '$lib/server/database';
 import { createOrder } from '$lib/server/orders';
-import { resolveSubscriptionDuration } from '$lib/server/subscriptions';
+import {
+	resolveSubscriptionDuration,
+	resolveSubscriptionReminderSeconds
+} from '$lib/server/subscriptions';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { userQuery } from '$lib/server/user.js';
 import { error, redirect } from '@sveltejs/kit';
@@ -24,7 +27,8 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 			projection: {
 				_id: 1,
 				name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] },
-				subscriptionDuration: 1
+				subscriptionDuration: 1,
+				subscriptionReminderSeconds: 1
 			}
 		}
 	);
@@ -42,7 +46,7 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 
 	const canRenewAfter = subSeconds(
 		subscription.paidUntil,
-		runtimeConfig.subscriptionReminderSeconds
+		resolveSubscriptionReminderSeconds(product)
 	);
 
 	return {

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -1,5 +1,6 @@
 import { collections } from '$lib/server/database';
 import { createOrder } from '$lib/server/orders';
+import { resolveSubscriptionDuration } from '$lib/server/subscriptions';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { userQuery } from '$lib/server/user.js';
 import { error, redirect } from '@sveltejs/kit';
@@ -22,7 +23,8 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		{
 			projection: {
 				_id: 1,
-				name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] }
+				name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] },
+				subscriptionDuration: 1
 			}
 		}
 	);
@@ -53,7 +55,8 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		},
 		product: {
 			_id: product._id,
-			name: product.name
+			name: product.name,
+			subscriptionDuration: resolveSubscriptionDuration(product)
 		},
 		picture: picture ?? undefined,
 		canRenew: canRenewAfter < new Date()

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ProductItem from '$lib/components/ProductItem.svelte';
+	import SubscriptionDurationLabel from '$lib/components/SubscriptionDurationLabel.svelte';
 	import Trans from '$lib/components/Trans.svelte';
 	import { useI18n } from '$lib/i18n';
 
@@ -45,6 +46,8 @@
 			<span class="text-red-500">({t('subscription.status.expired')})</span>
 		{/if}
 	</p>
+
+	<SubscriptionDurationLabel duration={data.product.subscriptionDuration} />
 
 	<form action="?/renew" method="post">
 		<button


### PR DESCRIPTION
Until now the renewal period for subscriptions (weekly, monthly, yearly, etc.) was a single global setting shared by the whole shop. Admins can now choose the length on each subscription product individually, so one be-BOP can sell, for example, a monthly and a yearly subscription side by side.

- Each subscription product has its own duration; leaving it on "Default" keeps using the shop-wide value, so nothing needs touching to keep current behaviour
- All existing subscription products automatically inherit the previous global value when this update is rolled out — no manual reconfiguration.
- The old global duration setting is replaced by a note pointing admins to the product page; the reminder timing setting stays where it was.
- Customers now see the renewal period (for example "Renews every week", translated in all languages) on the product page, the subscription page, the cart and checkout.

Closes #2388