### PR TITLE
 🦋 Let shop owners add their own fields to checkout

### DIFF
--- a/src/lib/components/CheckoutFieldInput.svelte
+++ b/src/lib/components/CheckoutFieldInput.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { useI18n } from '$lib/i18n';
+	import type { CheckoutFieldDisplay } from '$lib/types/CheckoutFieldConfig';
+
+	export let field: CheckoutFieldDisplay;
+
+	const { t, countryName, sortedCountryCodes } = useI18n();
+
+	let isCompany = false;
+
+	$: addressPrefix = `checkoutFieldAddress.${field.slug}`;
+	let inputMode: 'numeric' | 'text';
+	$: inputMode = field.free?.format === 'number' ? 'numeric' : 'text';
+</script>
+
+{#if field.type === 'options'}
+	<label class="form-label">
+		<span
+			>{field.isPersonalData ? '🛡️ ' : ''}{field.label}{#if field.required}<span
+					class="text-red-500">*</span
+				>{/if}</span
+		>
+		<select name="checkoutField.{field.slug}" class="form-input" required={field.required}>
+			<option value="">--</option>
+			{#each field.options ?? [] as option}
+				<option value={option}>{option}</option>
+			{/each}
+		</select>
+	</label>
+{:else if field.type === 'free'}
+	<label class="form-label">
+		<span
+			>{field.isPersonalData ? '🛡️ ' : ''}{field.label}{#if field.required}<span
+					class="text-red-500">*</span
+				>{/if}</span
+		>
+		<input
+			type="text"
+			name="checkoutField.{field.slug}"
+			class="form-input"
+			required={field.required}
+			maxlength={field.free?.maxLength}
+			inputmode={inputMode}
+		/>
+	</label>
+{:else if field.type === 'address'}
+	<fieldset class="grid grid-cols-6 gap-2">
+		<legend class="form-label">
+			<span
+				>{field.isPersonalData ? '🛡️ ' : ''}{field.label}{#if field.required}<span
+						class="text-red-500">*</span
+					>{/if}</span
+			>
+		</legend>
+
+		<label class="form-label col-span-3">
+			{t('address.firstName')}
+			<input
+				type="text"
+				class="form-input"
+				name="{addressPrefix}.firstName"
+				required={field.required}
+			/>
+		</label>
+		<label class="form-label col-span-3">
+			{t('address.lastName')}
+			<input
+				type="text"
+				class="form-input"
+				name="{addressPrefix}.lastName"
+				required={field.required}
+			/>
+		</label>
+		<label class="form-label col-span-6">
+			{t('address.address')}
+			<input
+				type="text"
+				class="form-input"
+				name="{addressPrefix}.address"
+				required={field.required}
+			/>
+		</label>
+		<label class="form-label col-span-3">
+			{t('address.country')}
+			<select name="{addressPrefix}.country" class="form-input" required={field.required}>
+				{#each sortedCountryCodes() as code}
+					<option value={code}>{countryName(code)}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="form-label col-span-3">
+			{t('address.state')}
+			<input type="text" class="form-input" name="{addressPrefix}.state" />
+		</label>
+		<label class="form-label col-span-3">
+			{t('address.city')}
+			<input type="text" class="form-input" name="{addressPrefix}.city" required={field.required} />
+		</label>
+		<label class="form-label col-span-3">
+			{t('address.zipCode')}
+			<input type="text" class="form-input" name="{addressPrefix}.zip" required={field.required} />
+		</label>
+		<label class="form-label col-span-6">
+			{t('address.phone')}
+			<input type="tel" class="form-input" name="{addressPrefix}.phone" />
+		</label>
+
+		<label class="col-span-6 checkbox-label">
+			<input
+				type="checkbox"
+				name="{addressPrefix}.isCompany"
+				value="true"
+				bind:checked={isCompany}
+			/>
+			{t('address.companyName')}
+		</label>
+
+		{#if isCompany}
+			<label class="form-label col-span-3">
+				{t('address.companyName')}
+				<input type="text" class="form-input" name="{addressPrefix}.companyName" required />
+			</label>
+			<label class="form-label col-span-3">
+				{t('address.vatNumber')}
+				<input type="text" class="form-input" name="{addressPrefix}.vatNumber" />
+			</label>
+		{/if}
+	</fieldset>
+{/if}

--- a/src/lib/server/checkoutFields.test.ts
+++ b/src/lib/server/checkoutFields.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { collectCheckoutFieldValues } from './checkoutFields';
+import type { CheckoutFieldConfig } from '$lib/types/CheckoutFieldConfig';
+
+function makeField(overrides: Partial<CheckoutFieldConfig> = {}): CheckoutFieldConfig {
+	return {
+		_id: new ObjectId(),
+		slug: 'field',
+		name: 'field',
+		label: 'Field',
+		type: 'free',
+		sortOrder: 0,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides
+	};
+}
+
+function expectHttpError(fn: () => unknown, status: number) {
+	try {
+		fn();
+		expect.fail('expected to throw');
+	} catch (e) {
+		expect((e as { status?: number }).status).toBe(status);
+	}
+}
+
+describe('collectCheckoutFieldValues', () => {
+	it('skips optional free field when missing', () => {
+		const field = makeField({ slug: 'note', type: 'free', required: false });
+		expect(collectCheckoutFieldValues([field], {})).toEqual([]);
+	});
+
+	it('throws 400 when required free field is missing', () => {
+		const field = makeField({ slug: 'note', type: 'free', required: true });
+		expectHttpError(() => collectCheckoutFieldValues([field], {}), 400);
+	});
+
+	it('collects a free text value', () => {
+		const field = makeField({ slug: 'note', type: 'free', required: true });
+		const result = collectCheckoutFieldValues([field], { checkoutField: { note: 'Hello' } });
+		expect(result).toEqual([
+			{
+				fieldId: field._id.toString(),
+				slug: 'note',
+				name: 'field',
+				label: 'Field',
+				type: 'free',
+				value: 'Hello'
+			}
+		]);
+	});
+
+	it('rejects non-numeric value for number-format free field', () => {
+		const field = makeField({
+			slug: 'code',
+			type: 'free',
+			required: true,
+			free: { format: 'number' }
+		});
+		expectHttpError(
+			() => collectCheckoutFieldValues([field], { checkoutField: { code: 'abc' } }),
+			400
+		);
+	});
+
+	it('accepts numeric value for number-format free field', () => {
+		const field = makeField({
+			slug: 'code',
+			type: 'free',
+			required: true,
+			free: { format: 'number' }
+		});
+		const result = collectCheckoutFieldValues([field], { checkoutField: { code: '42' } });
+		expect(result[0]).toMatchObject({ slug: 'code', value: '42' });
+	});
+
+	it('rejects value not matching alphanumeric format', () => {
+		const field = makeField({
+			slug: 'ref',
+			type: 'free',
+			required: true,
+			free: { format: 'alphanumeric' }
+		});
+		expectHttpError(
+			() => collectCheckoutFieldValues([field], { checkoutField: { ref: 'ab-12' } }),
+			400
+		);
+	});
+
+	it('rejects value exceeding maxLength', () => {
+		const field = makeField({
+			slug: 'note',
+			type: 'free',
+			required: true,
+			free: { maxLength: 3 }
+		});
+		expectHttpError(
+			() => collectCheckoutFieldValues([field], { checkoutField: { note: 'toolong' } }),
+			400
+		);
+	});
+
+	it('collects a valid option', () => {
+		const field = makeField({
+			slug: 'size',
+			type: 'options',
+			required: true,
+			options: ['S', 'M', 'L']
+		});
+		const result = collectCheckoutFieldValues([field], { checkoutField: { size: 'M' } });
+		expect(result[0]).toMatchObject({ slug: 'size', value: 'M' });
+	});
+
+	it('rejects an option not in the allowed list', () => {
+		const field = makeField({
+			slug: 'size',
+			type: 'options',
+			required: true,
+			options: ['S', 'M', 'L']
+		});
+		expectHttpError(
+			() => collectCheckoutFieldValues([field], { checkoutField: { size: 'XXL' } }),
+			400
+		);
+	});
+
+	it('skips optional address when not submitted', () => {
+		const field = makeField({ slug: 'shipping', type: 'address', required: false });
+		expect(collectCheckoutFieldValues([field], {})).toEqual([]);
+	});
+
+	it('throws 400 (not 500) on partial address', () => {
+		const field = makeField({ slug: 'shipping', type: 'address', required: false });
+		expectHttpError(
+			() =>
+				collectCheckoutFieldValues([field], {
+					checkoutFieldAddress: { shipping: { firstName: 'John' } }
+				}),
+			400
+		);
+	});
+
+	it('collects a valid address', () => {
+		const field = makeField({ slug: 'shipping', type: 'address', required: true });
+		const result = collectCheckoutFieldValues([field], {
+			checkoutFieldAddress: {
+				shipping: {
+					firstName: 'John',
+					lastName: 'Doe',
+					address: '1 Street',
+					city: 'Paris',
+					zip: '75001',
+					country: 'FR'
+				}
+			}
+		});
+		expect(result[0]).toMatchObject({ slug: 'shipping', type: 'address' });
+		expect(result[0].address).toMatchObject({
+			firstName: 'John',
+			lastName: 'Doe',
+			country: 'FR',
+			isCompany: false
+		});
+		expect(result[0].address?.companyName).toBeUndefined();
+	});
+
+	it('requires companyName when isCompany is true', () => {
+		const field = makeField({ slug: 'billing', type: 'address', required: true });
+		expectHttpError(
+			() =>
+				collectCheckoutFieldValues([field], {
+					checkoutFieldAddress: {
+						billing: {
+							firstName: 'John',
+							lastName: 'Doe',
+							address: '1 Street',
+							city: 'Paris',
+							zip: '75001',
+							country: 'FR',
+							isCompany: true
+						}
+					}
+				}),
+			400
+		);
+	});
+
+	it('keeps companyName when isCompany is true', () => {
+		const field = makeField({ slug: 'billing', type: 'address', required: true });
+		const result = collectCheckoutFieldValues([field], {
+			checkoutFieldAddress: {
+				billing: {
+					firstName: 'John',
+					lastName: 'Doe',
+					address: '1 Street',
+					city: 'Paris',
+					zip: '75001',
+					country: 'FR',
+					isCompany: true,
+					companyName: 'Acme'
+				}
+			}
+		});
+		expect(result[0].address).toMatchObject({ isCompany: true, companyName: 'Acme' });
+	});
+
+	it('propagates isPersonalData=true into the collected snapshot', () => {
+		const field = makeField({
+			slug: 'dob',
+			type: 'free',
+			required: true,
+			isPersonalData: true
+		});
+		const result = collectCheckoutFieldValues([field], {
+			checkoutField: { dob: '1990-01-01' }
+		});
+		expect(result[0].isPersonalData).toBe(true);
+	});
+
+	it('omits isPersonalData when the config does not set it', () => {
+		const field = makeField({ slug: 'note', type: 'free', required: true });
+		const result = collectCheckoutFieldValues([field], {
+			checkoutField: { note: 'Hello' }
+		});
+		expect(result[0].isPersonalData).toBeUndefined();
+	});
+});

--- a/src/lib/server/checkoutFields.ts
+++ b/src/lib/server/checkoutFields.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import { error } from '@sveltejs/kit';
+import type { JsonObject } from 'type-fest';
+import { collections } from '$lib/server/database';
+import { COUNTRY_ALPHA2S, type CountryAlpha2 } from '$lib/types/Country';
+import type {
+	CheckoutFieldConfig,
+	CheckoutFieldDisplay,
+	FreeInputFormat
+} from '$lib/types/CheckoutFieldConfig';
+import type { CollectedCheckoutField } from '$lib/types/Order';
+
+export function loadEnabledCheckoutFields() {
+	return collections.checkoutFieldConfigs
+		.find({ disabled: { $ne: true } })
+		.sort({ sortOrder: 1 })
+		.toArray();
+}
+
+export function toDisplayDTO(field: CheckoutFieldConfig): CheckoutFieldDisplay {
+	return {
+		slug: field.slug,
+		label: field.label,
+		type: field.type,
+		required: field.required,
+		options: field.options,
+		free: field.free,
+		isPersonalData: field.isPersonalData
+	};
+}
+
+const addressSchema = z.object({
+	firstName: z.string().min(1),
+	lastName: z.string().min(1),
+	address: z.string().min(1),
+	city: z.string().min(1),
+	state: z.string().optional(),
+	zip: z.string().min(1),
+	country: z.enum([...COUNTRY_ALPHA2S] as [CountryAlpha2, ...CountryAlpha2[]]),
+	phone: z.string().optional(),
+	isCompany: z.boolean({ coerce: true }).default(false),
+	companyName: z.string().optional(),
+	vatNumber: z.string().optional()
+});
+
+const freeFormatRegex: Partial<Record<FreeInputFormat, RegExp>> = {
+	number: /^\d+$/,
+	alphanumeric: /^[a-z0-9]+$/i
+};
+
+export function collectCheckoutFieldValues(
+	fields: CheckoutFieldConfig[],
+	json: JsonObject
+): CollectedCheckoutField[] {
+	const textParsed = z.record(z.string()).safeParse(json.checkoutField);
+	const textValues = textParsed.success ? textParsed.data : {};
+	const addressParsed = z.record(z.unknown()).safeParse(json.checkoutFieldAddress);
+	const addressValues = addressParsed.success ? addressParsed.data : {};
+
+	return fields.flatMap((field): CollectedCheckoutField[] => {
+		const base = {
+			fieldId: field._id.toString(),
+			slug: field.slug,
+			name: field.name,
+			label: field.label,
+			type: field.type,
+			...(field.isPersonalData && { isPersonalData: true })
+		};
+
+		switch (field.type) {
+			case 'address': {
+				const submitted = addressValues[field.slug];
+				if (!submitted) {
+					if (field.required) {
+						throw error(400, `${field.label} is required`);
+					}
+					return [];
+				}
+				const parsed = addressSchema.safeParse(submitted);
+				if (!parsed.success) {
+					throw error(400, `${field.label} is invalid`);
+				}
+				const address = parsed.data;
+				if (address.isCompany) {
+					if (!address.companyName) {
+						throw error(400, `Company name is required for ${field.label}`);
+					}
+				} else {
+					delete address.companyName;
+					delete address.vatNumber;
+				}
+				return [{ ...base, address }];
+			}
+			case 'options': {
+				const value = (textValues[field.slug] ?? '').trim();
+				if (!value) {
+					if (field.required) {
+						throw error(400, `${field.label} is required`);
+					}
+					return [];
+				}
+				if (!field.options?.includes(value)) {
+					throw error(400, `Invalid option for ${field.label}`);
+				}
+				return [{ ...base, value }];
+			}
+			case 'free': {
+				const value = (textValues[field.slug] ?? '').trim();
+				if (!value) {
+					if (field.required) {
+						throw error(400, `${field.label} is required`);
+					}
+					return [];
+				}
+				if (field.free?.maxLength && value.length > field.free.maxLength) {
+					throw error(400, `${field.label} is too long`);
+				}
+				const regex = field.free?.format ? freeFormatRegex[field.free.format] : undefined;
+				if (regex && !regex.test(value)) {
+					throw error(400, `Invalid format for ${field.label}`);
+				}
+				return [{ ...base, value }];
+			}
+			default: {
+				const exhaustive: never = field.type;
+				throw error(500, `Unknown checkout field type: ${String(exhaustive)}`);
+			}
+		}
+	});
+}

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -52,6 +52,7 @@ import type { ScheduleEventBooked, Schedule } from '$lib/types/Schedule';
 import type { Leaderboard } from '$lib/types/Leaderboard';
 import type { OrderTab } from '$lib/types/OrderTab';
 import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
+import type { CheckoutFieldConfig } from '$lib/types/CheckoutFieldConfig';
 import type { PosSession } from '$lib/types/PosSession';
 import type { PendingZap } from '$lib/types/PendingZap';
 import type { AccountingLog } from '$lib/types/AccountingLog';
@@ -117,6 +118,7 @@ const genCollection = () => ({
 	schedules: db.collection<Schedule>('schedules'),
 	scheduleEvents: db.collection<ScheduleEventBooked>('schedule.events'),
 	posPaymentSubtypes: db.collection<PosPaymentSubtype>('posPaymentSubtypes'),
+	checkoutFieldConfigs: db.collection<CheckoutFieldConfig>('checkoutFieldConfigs'),
 	posSessions: db.collection<PosSession>('posSessions'),
 	pendingZaps: db.collection<PendingZap>('pendingZaps'),
 
@@ -232,6 +234,9 @@ const indexes: Array<[Collection<any>, IndexSpecification, CreateIndexesOptions?
 	[collections.posPaymentSubtypes, { slug: 1 }, { unique: true }],
 	[collections.posPaymentSubtypes, { sortOrder: 1 }],
 	[collections.posPaymentSubtypes, { disabled: 1 }],
+	[collections.checkoutFieldConfigs, { slug: 1 }, { unique: true }],
+	[collections.checkoutFieldConfigs, { sortOrder: 1 }],
+	[collections.checkoutFieldConfigs, { disabled: 1 }],
 	[collections.posSessions, { status: 1, openedAt: -1 }],
 	[collections.posSessions, { closedAt: -1 }],
 	[collections.orderTabs, { slug: 1 }, { unique: true }],

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -4,7 +4,8 @@ import {
 	type Order,
 	type OrderPayment,
 	type Price,
-	type OrderPaymentStatus
+	type OrderPaymentStatus,
+	type CollectedCheckoutField
 } from '$lib/types/Order';
 import { ClientSession, ObjectId, type WithId } from 'mongodb';
 import { collections, withTransaction } from './database';
@@ -566,7 +567,7 @@ export async function cancelPayment(
 export async function anonymizeOrderData(orderId: string): Promise<boolean> {
 	const order = await collections.orders.findOne(
 		{ _id: orderId, dataAnonymized: { $ne: true } },
-		{ projection: { shippingAddress: 1, billingAddress: 1 } }
+		{ projection: { shippingAddress: 1, billingAddress: 1, customCheckoutFields: 1 } }
 	);
 	if (!order) {
 		return false;
@@ -584,6 +585,27 @@ export async function anonymizeOrderData(orderId: string): Promise<boolean> {
 	}
 	if (order.billingAddress) {
 		$set.billingAddress = { country: order.billingAddress.country, zip: order.billingAddress.zip };
+	}
+	if (order.customCheckoutFields?.some((f) => f.isPersonalData)) {
+		$set.customCheckoutFields = order.customCheckoutFields.map((f) => {
+			if (!f.isPersonalData) {
+				return f;
+			}
+			const cleaned: Record<string, unknown> = {
+				fieldId: f.fieldId,
+				slug: f.slug,
+				name: f.name,
+				label: f.label,
+				type: f.type,
+				isPersonalData: true
+			};
+			if (f.address) {
+				cleaned.address = { country: f.address.country, zip: f.address.zip };
+			} else {
+				cleaned.value = '';
+			}
+			return cleaned;
+		});
 	}
 
 	const result = await collections.orders.updateOne(
@@ -703,6 +725,7 @@ export async function createOrder(
 		clientIp?: string;
 		note?: string;
 		receiptNote?: string;
+		customCheckoutFields?: CollectedCheckoutField[];
 		engagements?: {
 			acceptedTermsOfUse?: boolean;
 			acceptedIPCollect?: boolean;
@@ -1685,6 +1708,9 @@ export async function createOrder(
 					: [])
 			],
 			...(params.receiptNote && { receiptNote: params.receiptNote }),
+			...(params.customCheckoutFields?.length && {
+				customCheckoutFields: params.customCheckoutFields
+			}),
 			...(params.reasonOfferDeliveryFees && {
 				deliveryFeesFree: {
 					reason: params.reasonOfferDeliveryFees

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -113,6 +113,9 @@
 		}
 	},
 	"checkout": {
+		"additionalFields": {
+			"title": "Zusätzliche Informationen"
+		},
 		"agreeIpCollect": "Ich stimme der Erfassung meiner IP-Adresse zu (warum?)",
 		"agreeNullVatForeigner": "Ich verstehe, dass ich die Mehrwertsteuer bei Lieferung bezahlen muss (warum?)",
 		"agreeOnlyDeposit": "Ich stimme zu, dass ich den Restbetrag in der Zukunft bezahlen muss (warum?)",
@@ -503,6 +506,9 @@
 		"allowSellerContact": "Erlauben Sie uns, Ihnen kommerzielle Anfragen zu senden"
 	},
 	"order": {
+		"additionalFields": {
+			"title": "Zusätzliche Informationen"
+		},
 		"addPayment": {
 			"amount": "Zahlungsbetrag",
 			"cta": "Zahlungsaufforderung senden",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -131,6 +131,9 @@
 		"multiplePaymentMethods": "Use several payment methods",
 		"multiplePaymentMethodsHelpText": "You can set payment methods at the next step.",
 		"noDeliveryInCountry": "Delivery is not available in your country for some of the items of your cart.",
+		"additionalFields": {
+			"title": "Additional information"
+		},
 		"note": {
 			"label": "Leave a note for merchant",
 			"title": "Note"
@@ -514,6 +517,9 @@
 		"backToOrder": "<< Back to order",
 		"clickQR": "Click on the QR code to pay with your wallet",
 		"confirmCancel": "Are you sure ? If this is your only pending payment and there is no paid payment on the order, the order will be cancelled. In case of mistake, first create a payment, then delete this one.",
+		"additionalFields": {
+			"title": "Additional information"
+		},
 		"contactAddress": {
 			"title": "Contact address"
 		},

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -113,6 +113,9 @@
 		}
 	},
 	"checkout": {
+		"additionalFields": {
+			"title": "Información adicional"
+		},
 		"agreeIpCollect": "Acepto que mi dirección IP sea guardada (<0>¿por qué?</0>)",
 		"agreeNullVatForeigner": "Entiendo que tendré que pagar IVA al momento de la entrega (<0>¿por qué?</0>)",
 		"agreeOnlyDeposit": "Acepto la Responsabilidad de pagar el resto después (<0>¿por qué?</0>)",
@@ -503,6 +506,9 @@
 		"allowSellerContact": "Permitir nuestras solicitudes comerciales"
 	},
 	"order": {
+		"additionalFields": {
+			"title": "Información adicional"
+		},
 		"addPayment": {
 			"amount": "Monto del pago",
 			"cta": "Envíe una llamada para el pago",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -113,6 +113,9 @@
 		}
 	},
 	"checkout": {
+		"additionalFields": {
+			"title": "Informations complémentaires"
+		},
 		"agreeIpCollect": "J'accepte la collecte de mon adresse IP (<0>pourquoi?</0>)",
 		"agreeNullVatForeigner": "Je comprends que je devrai m'acquitter de la TVA lors de la livraison (<0>pourquoi ?</0>)",
 		"agreeOnlyDeposit": "Je comprends que je dois m'acquitter du solde hors-acompte (<0>pourquoi ?</0>)",
@@ -503,6 +506,9 @@
 		"allowSellerContact": "Nous autoriser à vous envoyer des sollicitations commerciales"
 	},
 	"order": {
+		"additionalFields": {
+			"title": "Informations complémentaires"
+		},
 		"addPayment": {
 			"amount": "Montant du paiement",
 			"cta": "Envoyer un appel pour le paiement",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -113,6 +113,9 @@
 		}
 	},
 	"checkout": {
+		"additionalFields": {
+			"title": "Informazioni aggiuntive"
+		},
 		"agreeIpCollect": "Acconsento alla raccolta del mio indirizzo IP(<0>why?</0>)",
 		"agreeNullVatForeigner": "Capisco che dovrò pagare l'IVA alla ricezione (<0>why?</0>)",
 		"agreeOnlyDeposit": "Accetto che dovrò pagare il resto in futuro (<0>why?</0>)",
@@ -503,6 +506,9 @@
 		"allowSellerContact": "Consentici di inviarti comunicazioni commerciali."
 	},
 	"order": {
+		"additionalFields": {
+			"title": "Informazioni aggiuntive"
+		},
 		"addPayment": {
 			"amount": "Somma del pagamento",
 			"cta": "Invia una chiamata per il pagamento",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -113,6 +113,9 @@
 		}
 	},
 	"checkout": {
+		"additionalFields": {
+			"title": "Aanvullende informatie"
+		},
 		"agreeIpCollect": "Ik ga akkoord met het verzamelen van mijn IP-adres (<0>waarom?</0>)",
 		"agreeNullVatForeigner": "Ik begrijp dat ik bij levering BTW moet betalen (<0>waarom?</0>)",
 		"agreeOnlyDeposit": "Ik ga ermee akkoord dat ik het restant in de toekomst moet betalen (<0>waarom?</0>)",
@@ -503,6 +506,9 @@
 		"allowSellerContact": "Sta ons toe u commerciële verzoeken te sturen"
 	},
 	"order": {
+		"additionalFields": {
+			"title": "Aanvullende informatie"
+		},
 		"addPayment": {
 			"amount": "Te betalen bedrag",
 			"cta": "Stuur een oproep voor betaling",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -113,6 +113,9 @@
 		}
 	},
 	"checkout": {
+		"additionalFields": {
+			"title": "Informações adicionais"
+		},
 		"agreeIpCollect": "Concordo com a recolha do meu endereço IP (porquê?)",
 		"agreeNullVatForeigner": "Compreendo que terei de pagar IVA no momento da entrega (porquê?)",
 		"agreeOnlyDeposit": "Concordo que preciso de pagar o restante no futuro (porquê?)",
@@ -503,6 +506,9 @@
 		"allowSellerContact": "Permitir que lhe enviemos solicitações comerciais"
 	},
 	"order": {
+		"additionalFields": {
+			"title": "Informações adicionais"
+		},
 		"addPayment": {
 			"amount": "Valor do pagamento",
 			"cta": "Enviar um pedido de pagamento",

--- a/src/lib/types/CheckoutFieldConfig.ts
+++ b/src/lib/types/CheckoutFieldConfig.ts
@@ -1,0 +1,32 @@
+import type { ObjectId } from 'mongodb';
+import type { Timestamps } from './Timestamps';
+
+export const CHECKOUT_FIELD_TYPES = ['options', 'free', 'address'] as const;
+export type CheckoutFieldType = (typeof CHECKOUT_FIELD_TYPES)[number];
+
+export const FREE_INPUT_FORMATS = ['text', 'number', 'alphanumeric'] as const;
+export type FreeInputFormat = (typeof FREE_INPUT_FORMATS)[number];
+
+export interface CheckoutFieldConfig extends Timestamps {
+	_id: ObjectId;
+	slug: string;
+	name: string;
+	label: string;
+	type: CheckoutFieldType;
+	options?: string[];
+	free?: { maxLength?: number; format?: FreeInputFormat };
+	required?: boolean;
+	disabled?: boolean;
+	isPersonalData?: boolean;
+	sortOrder: number;
+}
+
+export interface CheckoutFieldDisplay {
+	slug: string;
+	label: string;
+	type: CheckoutFieldType;
+	required?: boolean;
+	options?: string[];
+	free?: { maxLength?: number; format?: FreeInputFormat };
+	isPersonalData?: boolean;
+}

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -15,6 +15,7 @@ import type { OrderLabel } from './OrderLabel';
 import { toBitcoins } from '$lib/utils/toBitcoins';
 import type { ScheduleEventBooked } from './Schedule';
 import type { PickDeep } from 'type-fest';
+import type { CheckoutFieldType } from './CheckoutFieldConfig';
 
 export const ORDER_PAYMENT_STATUSES = ['pending', 'paid', 'expired', 'canceled', 'failed'] as const;
 export type OrderPaymentStatus = (typeof ORDER_PAYMENT_STATUSES)[number];
@@ -61,6 +62,17 @@ export interface Note {
 	role: string | null;
 	content: string;
 	createdAt: Date;
+}
+
+export interface CollectedCheckoutField {
+	fieldId: string;
+	slug: string;
+	name: string;
+	label: string;
+	type: CheckoutFieldType;
+	value?: string;
+	address?: OrderAddress;
+	isPersonalData?: boolean;
 }
 
 export interface OrderPayment {
@@ -338,6 +350,7 @@ export interface Order extends Timestamps {
 	clientIp?: string;
 	notes?: Note[];
 	receiptNote?: string;
+	customCheckoutFields?: CollectedCheckoutField[];
 	onLocation?: boolean;
 	engagements?: {
 		acceptedTermsOfUse?: boolean;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
@@ -265,6 +265,10 @@
 	</label>
 	<h2 class="text-2xl">Checkout</h2>
 
+	<a href="{data.adminPrefix}/config/checkout-fields" class="underline">
+		Set checkout additional fields
+	</a>
+
 	<label class="checkbox-label">
 		<input
 			type="checkbox"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/checkout-fields/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/checkout-fields/+page.server.ts
@@ -1,0 +1,204 @@
+import type { Actions } from './$types';
+import { collections } from '$lib/server/database';
+import { fail } from '@sveltejs/kit';
+import { ObjectId } from 'mongodb';
+import { z } from 'zod';
+import {
+	CHECKOUT_FIELD_TYPES,
+	FREE_INPUT_FORMATS,
+	type CheckoutFieldConfig
+} from '$lib/types/CheckoutFieldConfig';
+
+const fieldSchema = z.object({
+	slug: z
+		.string()
+		.min(1)
+		.regex(/^[a-z0-9-]+$/, 'Slug must be lowercase alphanumeric with hyphens'),
+	name: z.string().min(1),
+	label: z.string().min(1),
+	type: z.enum(CHECKOUT_FIELD_TYPES),
+	maxLength: z.coerce.number().int().positive().optional(),
+	format: z.enum(FREE_INPUT_FORMATS).optional(),
+	required: z.boolean({ coerce: true }).default(false),
+	disabled: z.boolean({ coerce: true }).default(false),
+	isPersonalData: z.boolean({ coerce: true }).default(false)
+});
+
+function parseForm(formData: FormData) {
+	const parsed = fieldSchema.safeParse({
+		slug: formData.get('slug'),
+		name: formData.get('name'),
+		label: formData.get('label'),
+		type: formData.get('type'),
+		maxLength: formData.get('maxLength') || undefined,
+		format: formData.get('format') || undefined,
+		required: formData.get('required') === 'true',
+		disabled: formData.get('disabled') === 'true',
+		isPersonalData: formData.get('isPersonalData') === 'true'
+	});
+
+	if (!parsed.success) {
+		return { error: parsed.error.message } as const;
+	}
+
+	const options =
+		parsed.data.type === 'options'
+			? String(formData.get('options') ?? '')
+					.split(/\r?\n/)
+					.map((line) => line.trim())
+					.filter(Boolean)
+			: undefined;
+
+	if (parsed.data.type === 'options' && !options?.length) {
+		return { error: 'Options list cannot be empty' } as const;
+	}
+
+	return { data: parsed.data, options } as const;
+}
+
+function fieldDocFields(parsed: z.infer<typeof fieldSchema>, options: string[] | undefined) {
+	const free =
+		parsed.type === 'free' && (parsed.maxLength !== undefined || parsed.format !== undefined)
+			? {
+					...(parsed.maxLength !== undefined && { maxLength: parsed.maxLength }),
+					...(parsed.format !== undefined && { format: parsed.format })
+			  }
+			: undefined;
+
+	return {
+		name: parsed.name,
+		label: parsed.label,
+		type: parsed.type,
+		...(options && { options }),
+		...(free && { free }),
+		required: parsed.required,
+		disabled: parsed.disabled,
+		isPersonalData: parsed.isPersonalData
+	};
+}
+
+export const load = async () => {
+	const fieldsRaw = await collections.checkoutFieldConfigs
+		.find({})
+		.sort({ sortOrder: 1 })
+		.toArray();
+
+	const fields = fieldsRaw.map((field) => ({
+		...field,
+		_id: field._id.toString(),
+		createdAt: field.createdAt.toISOString(),
+		updatedAt: field.updatedAt.toISOString()
+	}));
+
+	return { fields, fieldTypes: CHECKOUT_FIELD_TYPES, freeFormats: FREE_INPUT_FORMATS };
+};
+
+export const actions: Actions = {
+	create: async ({ request }) => {
+		const formData = await request.formData();
+		const result = parseForm(formData);
+		if ('error' in result) {
+			return fail(400, { error: result.error });
+		}
+
+		const existing = await collections.checkoutFieldConfigs.findOne({ slug: result.data.slug });
+		if (existing) {
+			return fail(400, { error: 'Field with this slug already exists' });
+		}
+
+		const [maxSortOrder] = await collections.checkoutFieldConfigs
+			.find({})
+			.sort({ sortOrder: -1 })
+			.limit(1)
+			.toArray();
+
+		const newField: CheckoutFieldConfig = {
+			_id: new ObjectId(),
+			slug: result.data.slug,
+			...fieldDocFields(result.data, result.options),
+			sortOrder: (maxSortOrder?.sortOrder ?? 0) + 1,
+			createdAt: new Date(),
+			updatedAt: new Date()
+		};
+
+		await collections.checkoutFieldConfigs.insertOne(newField);
+
+		return { success: true };
+	},
+
+	update: async ({ request }) => {
+		const formData = await request.formData();
+		const idParsed = z.object({ id: z.string().min(1) }).safeParse({ id: formData.get('id') });
+		if (!idParsed.success || !ObjectId.isValid(idParsed.data.id)) {
+			return fail(400, { error: 'Invalid ID' });
+		}
+
+		const result = parseForm(formData);
+		if ('error' in result) {
+			return fail(400, { error: result.error });
+		}
+
+		const updateResult = await collections.checkoutFieldConfigs.updateOne(
+			{ _id: new ObjectId(idParsed.data.id) },
+			{
+				$set: {
+					...fieldDocFields(result.data, result.options),
+					updatedAt: new Date()
+				},
+				$unset: {
+					...(result.data.type !== 'options' && { options: '' }),
+					...(result.data.type !== 'free' && { free: '' })
+				}
+			}
+		);
+
+		if (updateResult.matchedCount === 0) {
+			return fail(404, { error: 'Field not found' });
+		}
+
+		return { success: true };
+	},
+
+	saveSortOrder: async ({ request }) => {
+		const formData = await request.formData();
+		const idsParsed = z
+			.array(z.string().min(1))
+			.min(1)
+			.safeParse(formData.getAll('ids').map(String));
+		if (!idsParsed.success) {
+			return fail(400, { error: 'Invalid order' });
+		}
+		const validIds = idsParsed.data.filter((id) => ObjectId.isValid(id));
+		if (!validIds.length) {
+			return fail(400, { error: 'Invalid order' });
+		}
+
+		await collections.checkoutFieldConfigs.bulkWrite(
+			validIds.map((id, index) => ({
+				updateOne: {
+					filter: { _id: new ObjectId(id) },
+					update: { $set: { sortOrder: index, updatedAt: new Date() } }
+				}
+			}))
+		);
+
+		return { success: true };
+	},
+
+	delete: async ({ request }) => {
+		const formData = await request.formData();
+		const id = String(formData.get('id'));
+		if (!ObjectId.isValid(id)) {
+			return fail(400, { error: 'Invalid ID' });
+		}
+
+		const field = await collections.checkoutFieldConfigs.findOne({ _id: new ObjectId(id) });
+		if (!field) {
+			return fail(404, { error: 'Field not found' });
+		}
+
+		await collections.checkoutFieldConfigs.deleteOne({ _id: new ObjectId(id) });
+
+		return { success: true };
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/checkout-fields/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/checkout-fields/+page.svelte
@@ -1,0 +1,391 @@
+<script lang="ts">
+	import { applyAction, enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
+	import type { ActionData, PageData } from './$types';
+	import { generateId } from '$lib/utils/generateId';
+	import IconUpArrow from '~icons/ant-design/arrow-up-outlined';
+	import IconDownArrow from '~icons/ant-design/arrow-down-outlined';
+
+	export let data: PageData;
+	export let form: ActionData;
+
+	const TYPE_LABELS: Record<string, string> = {
+		options: 'Option list',
+		free: 'Free input',
+		address: 'Address'
+	};
+
+	let showCreateForm = false;
+	let editingField: (typeof data.fields)[0] | null = null;
+	let nameInput = '';
+	let slugInput = '';
+	let selectedType = '';
+	let optionsInput = '';
+	let maxLengthInput = '';
+	let selectedFormat = '';
+
+	$: if (!editingField && nameInput) {
+		slugInput = generateId(nameInput, false);
+	}
+
+	let sortedFields = [...data.fields];
+	let orderChanged = false;
+
+	$: {
+		sortedFields = [...data.fields];
+		orderChanged = false;
+	}
+
+	function moveUp(index: number) {
+		if (index === 0) {
+			return;
+		}
+		const arr = [...sortedFields];
+		[arr[index - 1], arr[index]] = [arr[index], arr[index - 1]];
+		sortedFields = arr;
+		orderChanged = true;
+	}
+
+	function moveDown(index: number) {
+		if (index >= sortedFields.length - 1) {
+			return;
+		}
+		const arr = [...sortedFields];
+		[arr[index], arr[index + 1]] = [arr[index + 1], arr[index]];
+		sortedFields = arr;
+		orderChanged = true;
+	}
+
+	function startEdit(field: (typeof data.fields)[0]) {
+		editingField = field;
+		showCreateForm = false;
+		nameInput = field.name;
+		selectedType = field.type;
+		optionsInput = field.options?.join('\n') ?? '';
+		maxLengthInput = field.free?.maxLength ? String(field.free.maxLength) : '';
+		selectedFormat = field.free?.format ?? '';
+	}
+
+	function resetForm() {
+		showCreateForm = false;
+		editingField = null;
+		nameInput = '';
+		slugInput = '';
+		selectedType = '';
+		optionsInput = '';
+		maxLengthInput = '';
+		selectedFormat = '';
+	}
+</script>
+
+<h1 class="text-3xl mb-4">Custom input for order processing</h1>
+
+<p class="text-gray-600 mb-6">
+	Define custom input fields shown to customers on the checkout page. Collected values are stored on
+	the order and visible on the order page.
+</p>
+
+{#if form?.error}
+	<div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+		{form.error}
+	</div>
+{/if}
+
+{#if form?.success}
+	<div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+		Operation successful!
+	</div>
+{/if}
+
+<div class="flex flex-col gap-6">
+	<section>
+		<h2 class="text-2xl mb-4">Existing Inputs</h2>
+
+		{#if sortedFields.length === 0}
+			<p class="text-gray-500">No custom inputs configured yet. Create your first one below!</p>
+		{:else}
+			<div class="flex flex-col gap-4">
+				{#each sortedFields as field, i (field._id)}
+					<div
+						class="border rounded-lg p-4 flex justify-between items-start {field.disabled
+							? 'bg-gray-50 opacity-60'
+							: ''}"
+					>
+						<div class="flex-1">
+							<div class="flex items-center gap-2">
+								<h3 class="font-bold text-lg">{field.name}</h3>
+								<span class="text-xs bg-blue-600 text-white px-2 py-1 rounded"
+									>{TYPE_LABELS[field.type] ?? field.type}</span
+								>
+								{#if field.required}
+									<span class="text-xs bg-amber-600 text-white px-2 py-1 rounded">Mandatory</span>
+								{/if}
+								{#if field.disabled}
+									<span class="text-xs bg-gray-500 text-white px-2 py-1 rounded">Disabled</span>
+								{/if}
+							</div>
+							<p class="text-sm text-gray-600">
+								Slug: <code class="bg-gray-100 px-1 rounded">{field.slug}</code>
+							</p>
+							<p class="text-sm mt-2">{field.label}</p>
+							{#if field.type === 'options' && field.options?.length}
+								<p class="text-sm text-gray-600 mt-1">Options: {field.options.join(', ')}</p>
+							{/if}
+							{#if field.type === 'free' && field.free}
+								<p class="text-sm text-gray-600 mt-1">
+									{#if field.free.maxLength}Max length: {field.free.maxLength}.{/if}
+									{#if field.free.format}Format: {field.free.format}.{/if}
+								</p>
+							{/if}
+						</div>
+
+						<div class="flex flex-col gap-2 ml-4">
+							<div class="flex gap-2">
+								<button type="button" class="btn btn-sm" on:click={() => startEdit(field)}>
+									Edit
+								</button>
+
+								<form
+									method="post"
+									action="?/delete"
+									use:enhance={() => {
+										return async ({ result }) => {
+											await applyAction(result);
+											if (result.type === 'success') {
+												await invalidateAll();
+											}
+										};
+									}}
+								>
+									<input type="hidden" name="id" value={field._id} />
+									<button
+										type="submit"
+										class="btn btn-sm btn-danger"
+										on:click={(e) => {
+											if (!confirm(`Delete "${field.name}"?\n\nThis action cannot be undone.`)) {
+												e.preventDefault();
+											}
+										}}
+									>
+										Delete
+									</button>
+								</form>
+							</div>
+
+							<div class="flex gap-2 justify-center">
+								<button
+									type="button"
+									class="btn btn-sm"
+									class:invisible={i === 0}
+									title="Move up"
+									on:click={() => moveUp(i)}
+								>
+									<IconUpArrow />
+								</button>
+								<button
+									type="button"
+									class="btn btn-sm"
+									class:invisible={i === sortedFields.length - 1}
+									title="Move down"
+									on:click={() => moveDown(i)}
+								>
+									<IconDownArrow />
+								</button>
+							</div>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</section>
+
+	{#if !showCreateForm && !editingField}
+		<div class="flex gap-2 self-start">
+			<button type="button" class="btn btn-black" on:click={() => (showCreateForm = true)}>
+				+ Create New Input
+			</button>
+			<form
+				method="post"
+				action="?/saveSortOrder"
+				use:enhance={() => {
+					return async ({ result }) => {
+						await applyAction(result);
+						if (result.type === 'success') {
+							await invalidateAll();
+						}
+					};
+				}}
+			>
+				{#each sortedFields as field}
+					<input type="hidden" name="ids" value={field._id} />
+				{/each}
+				<button type="submit" class="btn btn-black" disabled={!orderChanged}>
+					Save sorting order
+				</button>
+			</form>
+		</div>
+	{/if}
+
+	{#if showCreateForm || editingField}
+		<form
+			method="post"
+			action="?/{editingField ? 'update' : 'create'}"
+			class="border rounded-lg p-6 flex flex-col gap-4 bg-gray-50"
+			use:enhance={() => {
+				return async ({ result }) => {
+					await applyAction(result);
+					if (result.type === 'success') {
+						await invalidateAll();
+						resetForm();
+					}
+				};
+			}}
+		>
+			<h3 class="text-xl font-bold">
+				{editingField ? `Edit "${editingField.name}"` : 'Create New Input'}
+			</h3>
+
+			{#if editingField}
+				<input type="hidden" name="id" value={editingField._id} />
+				<input type="hidden" name="slug" value={editingField.slug} />
+			{/if}
+
+			<label class="form-label">
+				Input Name <span class="text-red-500">*</span>
+				<input
+					type="text"
+					name="name"
+					class="form-input"
+					bind:value={nameInput}
+					placeholder="e.g. Gift wrapper"
+					required
+				/>
+			</label>
+
+			{#if !editingField}
+				<label class="form-label">
+					Slug <span class="text-red-500">*</span>
+					<input
+						type="text"
+						name="slug"
+						class="form-input"
+						bind:value={slugInput}
+						placeholder="e.g. gift-wrapper"
+						pattern="[a-z0-9-]+"
+						title="Lowercase letters, numbers, and hyphens only"
+						required
+					/>
+					<p class="text-xs text-gray-500 mt-1">
+						Unique identifier (lowercase, alphanumeric, hyphens). Cannot be changed after creation.
+					</p>
+				</label>
+			{:else}
+				<div class="form-label">
+					Slug: <code class="bg-gray-200 px-2 py-1 rounded">{editingField.slug}</code>
+					<p class="text-xs text-gray-500">Cannot be changed</p>
+				</div>
+			{/if}
+
+			<label class="form-label">
+				Input message <span class="text-red-500">*</span>
+				<input
+					type="text"
+					name="label"
+					class="form-input"
+					value={editingField?.label ?? ''}
+					placeholder="e.g. Choose your gift wrapper:"
+					required
+				/>
+				<p class="text-xs text-gray-500 mt-1">Text shown to the customer on checkout.</p>
+			</label>
+
+			<label class="form-label">
+				Input type <span class="text-red-500">*</span>
+				<select name="type" class="form-input" bind:value={selectedType} required>
+					<option value="">--Select an option--</option>
+					{#each data.fieldTypes as fieldType}
+						<option value={fieldType}>{TYPE_LABELS[fieldType] ?? fieldType}</option>
+					{/each}
+				</select>
+			</label>
+
+			{#if selectedType === 'options'}
+				<label class="form-label">
+					Options list <span class="text-red-500">*</span>
+					<textarea
+						name="options"
+						class="form-input"
+						rows="5"
+						placeholder="One option per line"
+						bind:value={optionsInput}
+					/>
+					<p class="text-xs text-gray-500 mt-1">One option per line.</p>
+				</label>
+			{/if}
+
+			{#if selectedType === 'free'}
+				<label class="form-label">
+					Max length (optional)
+					<input
+						type="number"
+						name="maxLength"
+						class="form-input"
+						min="1"
+						bind:value={maxLengthInput}
+						placeholder="e.g. 100"
+					/>
+				</label>
+				<label class="form-label">
+					Format
+					<select name="format" class="form-input" bind:value={selectedFormat}>
+						<option value="">Text (any)</option>
+						{#each data.freeFormats as fmt}
+							<option value={fmt}>{fmt}</option>
+						{/each}
+					</select>
+				</label>
+			{/if}
+
+			<label class="checkbox-label flex items-center gap-2">
+				<input
+					type="checkbox"
+					name="required"
+					class="form-checkbox"
+					value="true"
+					checked={editingField?.required}
+				/>
+				<span>Make this input mandatory</span>
+			</label>
+
+			<label class="checkbox-label flex items-center gap-2">
+				<input
+					type="checkbox"
+					name="disabled"
+					class="form-checkbox"
+					value="true"
+					checked={editingField?.disabled}
+				/>
+				<span>Disable this input (hide from selection)</span>
+			</label>
+
+			<label class="checkbox-label flex items-center gap-2">
+				<input
+					type="checkbox"
+					name="isPersonalData"
+					class="form-checkbox"
+					value="true"
+					checked={editingField?.isPersonalData}
+				/>
+				<span>Contains personal data (subject to GDPR auto-cleanup)</span>
+			</label>
+
+			<div class="flex gap-2 mt-4">
+				<button type="submit" class="btn btn-black">
+					{editingField ? 'Update' : 'Create'}
+				</button>
+
+				<button type="button" class="btn" on:click={resetForm}> Cancel </button>
+			</div>
+		</form>
+	{/if}
+</div>

--- a/src/routes/(app)/checkout/+page.server.ts
+++ b/src/routes/(app)/checkout/+page.server.ts
@@ -25,6 +25,11 @@ import { omit } from '$lib/utils/omit.js';
 import { set } from '$lib/utils/set';
 import { ObjectId } from 'mongodb';
 import type { Tag } from '$lib/types/Tag';
+import {
+	collectCheckoutFieldValues,
+	loadEnabledCheckoutFields,
+	toDisplayDTO
+} from '$lib/server/checkoutFields';
 
 export async function load({ parent, locals }) {
 	const parentData = await parent();
@@ -174,6 +179,8 @@ export async function load({ parent, locals }) {
 				.toArray()
 		: [];
 
+	const checkoutFields = (await loadEnabledCheckoutFields()).map(toDisplayDTO);
+
 	return {
 		paymentMethods: methods,
 		discountByContext,
@@ -200,6 +207,7 @@ export async function load({ parent, locals }) {
 			slug: subtype.slug,
 			name: subtype.name
 		})),
+		checkoutFields,
 		...(cmsCheckoutTop && {
 			cmsCheckoutTop,
 			cmsCheckoutTopData: cmsFromContent(
@@ -552,6 +560,9 @@ export const actions = {
 				'You must acknowledge that you are only paying a deposit and will have to pay the rest later'
 			);
 		}
+		const enabledCheckoutFields = await loadEnabledCheckoutFields();
+		const customCheckoutFields = collectCheckoutFieldValues(enabledCheckoutFields, json);
+
 		rateLimit(locals.clientIp, 'email', 10, { minutes: 1 });
 		let orderId = '';
 		await withTransaction(async (session) => {
@@ -606,6 +617,7 @@ export const actions = {
 							}
 						}),
 					...(note && { note: note.noteContent }),
+					...(customCheckoutFields.length && { customCheckoutFields }),
 					...(agreements.allowCollectIP && { clientIp: locals.clientIp }),
 					...(locals.user?.hasPosOptions &&
 						runtimeConfig.deliveryFees.allowFreeForPOS &&

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import Picture from '$lib/components/Picture.svelte';
 	import PriceTag from '$lib/components/PriceTag.svelte';
+	import CheckoutFieldInput from '$lib/components/CheckoutFieldInput.svelte';
 	import { bech32 } from 'bech32';
 	import { typedValues } from '$lib/utils/typedValues';
 	import { typedInclude } from '$lib/utils/typedIncludes';
@@ -737,6 +738,20 @@
 					</article>
 				{/each}
 			</section>
+			{#if data.checkoutFields?.length}
+				<section class="gap-4 flex flex-col">
+					<article class="rounded border border-gray-300 overflow-hidden flex flex-col">
+						<div class="pl-4 py-2 body-mainPlan border-b border-gray-300 text-xl font-light">
+							{t('checkout.additionalFields.title')}
+						</div>
+						<div class="p-4 flex flex-col gap-4">
+							{#each data.checkoutFields as field (field.slug)}
+								<CheckoutFieldInput {field} />
+							{/each}
+						</div>
+					</article>
+				</section>
+			{/if}
 			<section class="gap-4 flex flex-col">
 				<article class="rounded border border-gray-300 overflow-hidden flex flex-col">
 					<div class="pl-4 py-2 body-mainPlan border-b border-gray-300 text-xl font-light">

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -417,6 +417,22 @@
 				</div>
 			{/if}
 
+			{#if data.order.customCheckoutFields?.length}
+				<div>
+					{t('order.additionalFields.title')}:
+					{#each data.order.customCheckoutFields as field}
+						<p class="body-secondaryText whitespace-pre-line">
+							<strong>{field.isPersonalData ? '🛡️ ' : ''}{field.label}:</strong>
+							{#if field.type === 'address' && field.address}
+								{textAddress(field.address)}
+							{:else}
+								{field.value ?? ''}
+							{/if}
+						</p>
+					{/each}
+				</div>
+			{/if}
+
 			<!-- ========== ADD PAYMENT SECTION (Staff Only) ========== -->
 			{#if data.order.status === 'pending' && remainingAmount && roleIsStaff}
 				<div class="border border-gray-300 rounded-xl p-4 add-payment-section">

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -231,6 +231,7 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 				alias: note.userAlias
 			})) || [],
 		receiptNote: order.receiptNote,
+		customCheckoutFields: order.customCheckoutFields,
 		user: {
 			npub: order.user.npub,
 			email: order.user.email,


### PR DESCRIPTION
Shop owners can now create custom questions on the checkout page to collect extra information for processing an order — for example a gift-wrapping choice, a free-text note, or an extra address. Fields are managed from a new admin page (Config → "Set checkout additional fields") that works just like the PoS Payments setup.

Three input types are available:
 - Option list — the customer picks one value from a list you define
 - Free input — free text, with optional length limit and format (text / numbers / letters+numbers)
 - Address — a full address form, with a personal/company toggle for the customer

Key points:
 - Each field can be marked mandatory and shown or hidden independently
 - Whatever the customer enters is saved on the order and shown on the order page
 - Answers are stored as a snapshot, so renaming or removing a field later never changes orders that were already placed
 - A field that's already used by orders can't be deleted — disable it instead

Closes #2212