### PR TITLE
🆕🤖 Search widget V1: dynamic facet engine for products (#1787)

### DIFF
--- a/src/lib/components/CmsDesign.svelte
+++ b/src/lib/components/CmsDesign.svelte
@@ -19,7 +19,8 @@
 		CmsCountdown,
 		CmsGallery,
 		CmsLeaderboard,
-		CmsSchedule
+		CmsSchedule,
+		CmsSearchlist
 	} from '$lib/server/cms';
 	import SpecificationWidget from './SpecificationWidget.svelte';
 	import ContactForm from './ContactForm.svelte';
@@ -30,6 +31,7 @@
 	import LeaderBoardWidget from './LeaderBoardWidget.svelte';
 	import CurrencyCalculator from './CurrencyCalculator.svelte';
 	import ScheduleWidget from './ScheduleWidget.svelte';
+	import Searchlist from './Searchlist.svelte';
 	import { groupBy } from '$lib/utils/group-by';
 	import { get } from '$lib/utils/get';
 
@@ -57,6 +59,7 @@
 	export let galleries: CmsGallery[];
 	export let leaderboards: CmsLeaderboard[];
 	export let schedules: CmsSchedule[];
+	export let searchlists: CmsSearchlist[] = [];
 
 	let classNames = '';
 	export { classNames as class };
@@ -86,6 +89,7 @@
 	$: sliderById = Object.fromEntries(sliders.map((slider) => [slider._id, slider]));
 	$: tagById = Object.fromEntries(tags.map((tag) => [tag._id, tag]));
 	$: scheduleById = Object.fromEntries(schedules.map((schedule) => [schedule._id, schedule]));
+	$: searchlistById = Object.fromEntries(searchlists.map((s) => [s._id, s]));
 
 	$: picturesByTag = groupBy(
 		pictures.filter((picture): picture is SetRequired<Picture, 'tag'> => !!picture.tag),
@@ -268,6 +272,22 @@
 					pictures={picturesBySchedule[token.slug] ?? []}
 					displayOption={token.display}
 					class="not-prose my-5"
+				/>
+			{:else if token.type === 'searchlistWidget' && searchlistById[token.slug]}
+				<Searchlist
+					class="not-prose my-5"
+					searchlist={searchlistById[token.slug]}
+					state={searchlistById[token.slug].state}
+					products={searchlistById[token.slug].products}
+					picturesByProductId={searchlistById[token.slug].picturesByProductId}
+					digitalFilesByProductId={searchlistById[token.slug].digitalFilesByProductId}
+					hasPosOptions={!!hasPosOptions}
+					total={searchlistById[token.slug].total}
+					totalPages={searchlistById[token.slug].totalPages}
+					basePath={searchlistById[token.slug].basePath}
+					allowedTags={searchlistById[token.slug].allowedTags}
+					displayVatIncluded={searchlistById[token.slug].displayVatIncluded}
+					embedded={true}
 				/>
 			{:else if token.type === 'html'}
 				<div class="my-5">

--- a/src/lib/components/CmsPage.svelte
+++ b/src/lib/components/CmsPage.svelte
@@ -14,7 +14,8 @@
 		CmsCountdown,
 		CmsGallery,
 		CmsLeaderboard,
-		CmsSchedule
+		CmsSchedule,
+		CmsSearchlist
 	} from '$lib/server/cms';
 	import CmsDesign from './CmsDesign.svelte';
 
@@ -54,6 +55,7 @@
 	export let galleries: CmsGallery[];
 	export let leaderboards: CmsLeaderboard[];
 	export let schedules: CmsSchedule[];
+	export let searchlists: CmsSearchlist[] = [];
 
 	const { t } = useI18n();
 </script>
@@ -90,6 +92,7 @@
 		{countdowns}
 		{galleries}
 		{leaderboards}
+		{searchlists}
 		{schedules}
 		class={cmsPage.displayRawContent ? '' : 'prose max-w-full body body-mainPlan'}
 	/>
@@ -119,6 +122,7 @@
 			{countdowns}
 			{galleries}
 			{leaderboards}
+			{searchlists}
 			{schedules}
 			class={cmsPage.displayRawContent ? '' : 'prose max-w-full body'}
 		/>

--- a/src/lib/components/Searchlist.svelte
+++ b/src/lib/components/Searchlist.svelte
@@ -1,0 +1,369 @@
+<script lang="ts">
+	import { useI18n } from '$lib/i18n';
+	import { goto } from '$app/navigation';
+	import ProductWidget from './ProductWidget.svelte';
+	import SearchlistGridTile from './SearchlistGridTile.svelte';
+	import type { Picture } from '$lib/types/Picture';
+	import type { ProductWidgetProduct } from './ProductWidget/ProductWidgetProduct';
+	import type { Searchlist } from '$lib/types/Searchlist';
+	import { SORT_KEYS, VIEW_MODES, type SortKey, type ViewMode } from '$lib/types/Searchlist';
+	import type { SearchlistUrlState } from '$lib/server/searchlist';
+	import { currencies } from '$lib/stores/currencies';
+	import { CURRENCY_UNIT } from '$lib/types/Currency';
+
+	export let searchlist: Searchlist;
+	export let state: SearchlistUrlState;
+	export let products: ProductWidgetProduct[];
+	export let picturesByProductId: Record<string, Picture[]>;
+	export let digitalFilesByProductId: Record<string, boolean>;
+	export let hasPosOptions: boolean;
+	export let total: number;
+	export let totalPages: number;
+	export let basePath: string;
+	export let allowedTags: Array<{ _id: string; name: string }> = [];
+	export let displayVatIncluded = false;
+	export let embedded = false;
+
+	let className = '';
+	export { className as class };
+
+	$: priceUnitLabel = displayVatIncluded ? `${$currencies.main} TTC` : $currencies.main;
+
+	const { t } = useI18n();
+
+	let qInput = state.q;
+	let pmin = state.pmin ?? '';
+	let pmax = state.pmax ?? '';
+	let stockChecked = state.stock;
+	let tagChoice = state.tag ?? '';
+	let sortChoice: SortKey = state.sort;
+	let viewChoice: ViewMode = state.view;
+
+	$: showResults = total > 0;
+	$: hasMorePages = state.page < totalPages;
+	// V1: infinite scroll disabled (flaky); fall back to loadMore for existing configs.
+	$: effectivePaginationMode =
+		searchlist.pagination.mode === 'infinite' ? 'loadMore' : searchlist.pagination.mode;
+	$: visibleSortOptions = SORT_KEYS.filter((k) => searchlist.sort.options.includes(k));
+	$: hasInteractiveControls =
+		!embedded &&
+		(!searchlist.hideSearchbar ||
+			searchlist.filters.price.enabled ||
+			searchlist.filters.stock.enabled ||
+			(searchlist.filters.tags?.enabled && allowedTags.length > 0) ||
+			(searchlist.sort.displayed && visibleSortOptions.length > 0));
+
+	function applyState(
+		overrides: Partial<{
+			q: string;
+			pmin: string | number;
+			pmax: string | number;
+			stock: boolean;
+			tag: string;
+			sort: SortKey;
+			view: ViewMode;
+			page: number;
+		}>
+	) {
+		const params = new URLSearchParams();
+		const next = {
+			q: overrides.q !== undefined ? overrides.q : qInput,
+			pmin: overrides.pmin !== undefined ? overrides.pmin : pmin,
+			pmax: overrides.pmax !== undefined ? overrides.pmax : pmax,
+			stock: overrides.stock !== undefined ? overrides.stock : stockChecked,
+			tag: overrides.tag !== undefined ? overrides.tag : tagChoice,
+			sort: overrides.sort !== undefined ? overrides.sort : sortChoice,
+			view: overrides.view !== undefined ? overrides.view : viewChoice,
+			page: overrides.page !== undefined ? overrides.page : 1
+		};
+		if (next.q) {
+			params.set('q', String(next.q));
+		}
+		if (searchlist.filters.price.enabled) {
+			if (next.pmin !== '' && next.pmin !== undefined) {
+				params.set('pmin', String(next.pmin));
+			}
+			if (next.pmax !== '' && next.pmax !== undefined) {
+				params.set('pmax', String(next.pmax));
+			}
+		}
+		if (searchlist.filters.stock.enabled && next.stock) {
+			params.set('stock', '1');
+		}
+		if (searchlist.filters.tags?.enabled && next.tag) {
+			params.set('tag', String(next.tag));
+		}
+		if (searchlist.sort.displayed && next.sort !== searchlist.sort.default) {
+			params.set('sort', next.sort);
+		}
+		if (!searchlist.view.hideToggle && next.view !== searchlist.view.default) {
+			params.set('view', next.view);
+		}
+		if (next.page && next.page > 1) {
+			params.set('page', String(next.page));
+		}
+		const qs = params.toString();
+		goto(qs ? `${basePath}?${qs}` : basePath, { keepFocus: true, noScroll: true });
+	}
+
+	function onSubmit(ev: SubmitEvent) {
+		ev.preventDefault();
+		applyState({ q: qInput, page: 1 });
+	}
+
+	function onReset() {
+		qInput = searchlist.prefillSearchterm ? searchlist.initialSearchterm ?? '' : '';
+		pmin = searchlist.filters.price.defaultMin ?? '';
+		pmax = searchlist.filters.price.defaultMax ?? '';
+		stockChecked = !!searchlist.filters.stock.defaultChecked;
+		tagChoice = '';
+		sortChoice = searchlist.sort.default;
+		viewChoice = searchlist.view.default;
+		goto(basePath, { keepFocus: true, noScroll: true });
+	}
+
+	function onSortChange() {
+		applyState({ sort: sortChoice, page: 1 });
+	}
+
+	function onViewChange(v: ViewMode) {
+		viewChoice = v;
+		applyState({ view: v, page: 1 });
+	}
+
+	$: priceStep = CURRENCY_UNIT[$currencies.main];
+
+	function clampToDisplayPrecision(raw: string | number): string | number {
+		if (raw === '' || raw === undefined || raw === null) {
+			return '';
+		}
+		const n = typeof raw === 'number' ? raw : Number(raw);
+		if (!Number.isFinite(n)) {
+			return '';
+		}
+		const factor = 1 / priceStep;
+		return Math.round(n * factor) / factor;
+	}
+
+	function onFiltersApply() {
+		pmin = clampToDisplayPrecision(pmin);
+		pmax = clampToDisplayPrecision(pmax);
+		applyState({ pmin, pmax, stock: stockChecked, page: 1 });
+	}
+
+	function onTagChange() {
+		applyState({ tag: tagChoice, page: 1 });
+	}
+
+	function gotoPage(p: number) {
+		applyState({ page: p });
+	}
+
+	function canBuyOf(p: ProductWidgetProduct): boolean {
+		return hasPosOptions
+			? p.actionSettings.retail.canBeAddedToBasket
+			: p.actionSettings.eShop.canBeAddedToBasket;
+	}
+
+	// infinite-scroll helpers removed alongside the disabled mode (see effectivePaginationMode).
+</script>
+
+<div class="searchlist flex flex-col gap-4 {className}">
+	{#if searchlist.disabled}
+		<div class="rounded border border-amber-400 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+			{t('searchlist.disabledNotice')}
+		</div>
+	{/if}
+	{#if hasInteractiveControls}
+		<form on:submit={onSubmit} class="flex flex-col gap-2">
+			{#if !searchlist.hideSearchbar}
+				<label class="form-label">
+					{t('searchlist.searchbar.label')}
+					<div class="flex gap-2 items-stretch">
+						<input
+							type="text"
+							class="form-input flex-grow"
+							name="q"
+							bind:value={qInput}
+							placeholder={t('searchlist.searchbar.placeholder')}
+						/>
+						<button
+							type="submit"
+							class="btn body-mainCTA px-3"
+							aria-label={t('searchlist.searchbar.submit')}
+						>
+							🔍
+						</button>
+						<button
+							type="button"
+							class="btn body-secondaryCTA px-3"
+							aria-label={t('searchlist.searchbar.reset')}
+							on:click={onReset}
+						>
+							🧹
+						</button>
+					</div>
+				</label>
+			{:else}
+				<div class="flex gap-2 items-stretch">
+					<button
+						type="submit"
+						class="btn body-mainCTA px-3"
+						aria-label={t('searchlist.searchbar.submit')}
+					>
+						🔍
+					</button>
+					<button
+						type="button"
+						class="btn body-secondaryCTA px-3"
+						aria-label={t('searchlist.searchbar.reset')}
+						on:click={onReset}
+					>
+						🧹
+					</button>
+				</div>
+			{/if}
+		</form>
+	{/if}
+
+	{#if !embedded && searchlist.sort.displayed && visibleSortOptions.length > 0}
+		<label class="form-label">
+			{t('searchlist.sort.label')}
+			<select class="form-input" bind:value={sortChoice} on:change={onSortChange}>
+				{#each visibleSortOptions as opt}
+					<option value={opt}>{t(`searchlist.sort.options.${opt}`)}</option>
+				{/each}
+			</select>
+		</label>
+	{/if}
+
+	{#if !embedded && searchlist.filters.tags?.enabled && allowedTags.length > 0}
+		<label class="form-label">
+			{t('searchlist.filters.tag.label')}
+			<select class="form-input" bind:value={tagChoice} on:change={onTagChange}>
+				<option value="">—</option>
+				{#each allowedTags as tag}
+					<option value={tag._id}>{tag.name}</option>
+				{/each}
+			</select>
+		</label>
+	{/if}
+
+	{#if !embedded && searchlist.filters.price.enabled}
+		<div class="flex flex-wrap gap-4 items-end">
+			<label class="form-label">
+				{t('searchlist.filters.price.minLabel')} ({priceUnitLabel})
+				<input
+					type="number"
+					class="form-input"
+					bind:value={pmin}
+					on:change={onFiltersApply}
+					on:wheel|preventDefault
+					min="0"
+					step={priceStep}
+				/>
+			</label>
+			<label class="form-label">
+				{t('searchlist.filters.price.maxLabel')} ({priceUnitLabel})
+				<input
+					type="number"
+					class="form-input"
+					bind:value={pmax}
+					on:change={onFiltersApply}
+					on:wheel|preventDefault
+					min="0"
+					step={priceStep}
+				/>
+			</label>
+		</div>
+	{/if}
+	{#if !embedded && searchlist.filters.stock.enabled}
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				bind:checked={stockChecked}
+				on:change={onFiltersApply}
+			/>
+			{t('searchlist.filters.stock.label')}
+		</label>
+	{/if}
+
+	{#if !embedded && !searchlist.view.hideToggle}
+		<div class="flex gap-3">
+			{#each VIEW_MODES as v}
+				<label class="checkbox-label">
+					<input
+						type="radio"
+						class="form-radio"
+						name="view"
+						value={v}
+						checked={viewChoice === v}
+						on:change={() => onViewChange(v)}
+					/>
+					{t(`searchlist.view.${v}`)}
+				</label>
+			{/each}
+		</div>
+	{/if}
+
+	{#if showResults}
+		{#if viewChoice === 'grid'}
+			<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+				{#each products as product}
+					<SearchlistGridTile {product} picture={picturesByProductId[product._id]?.[0]} />
+				{/each}
+			</div>
+		{:else}
+			<div class="flex flex-col gap-4">
+				{#each products as product}
+					<ProductWidget
+						{product}
+						pictures={picturesByProductId[product._id] ?? []}
+						hasDigitalFiles={digitalFilesByProductId[product._id] === true}
+						canBuy={canBuyOf(product)}
+						displayOption="img-3"
+						class="not-prose"
+					/>
+				{/each}
+			</div>
+		{/if}
+
+		{#if embedded}
+			<!-- caller embeds the widget (e.g. CMS page): pagination off -->
+		{:else if effectivePaginationMode === 'classic' && totalPages > 1}
+			<div class="flex justify-between items-center mt-4">
+				<button
+					type="button"
+					class="btn body-secondaryCTA"
+					disabled={state.page <= 1}
+					on:click={() => gotoPage(state.page - 1)}
+				>
+					{t('searchlist.pagination.prev')}
+				</button>
+				<span>{state.page} / {totalPages}</span>
+				<button
+					type="button"
+					class="btn body-secondaryCTA"
+					disabled={state.page >= totalPages}
+					on:click={() => gotoPage(state.page + 1)}
+				>
+					{t('searchlist.pagination.next')}
+				</button>
+			</div>
+		{:else if effectivePaginationMode === 'loadMore' && hasMorePages}
+			<div class="flex justify-center mt-4">
+				<button type="button" class="btn body-mainCTA" on:click={() => gotoPage(state.page + 1)}>
+					{t('searchlist.pagination.loadMore')}
+				</button>
+			</div>
+		{/if}
+	{:else}
+		<div class="flex flex-col gap-2 items-center py-6">
+			<p>{t('searchlist.empty.title')}</p>
+			<button type="button" class="btn body-secondaryCTA" on:click={onReset}>
+				{t('searchlist.empty.reset')}
+			</button>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/SearchlistGridTile.svelte
+++ b/src/lib/components/SearchlistGridTile.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import PictureComponent from '$lib/components/Picture.svelte';
+	import PriceTag from '$lib/components/PriceTag.svelte';
+	import type { Picture } from '$lib/types/Picture';
+	import type { Product } from '$lib/types/Product';
+
+	export let picture: Picture | undefined;
+	export let product: Pick<Product, '_id' | 'price' | 'name'>;
+</script>
+
+<a href="/product/{product._id}" class="rounded-xl w-full items-center mx-auto">
+	<div class="relative w-full h-40">
+		<PictureComponent {picture} class="object-cover w-full h-full rounded-xl shadow-md" />
+		<span class="absolute top-2 right-2 bg-white text-black px-2 rounded-lg">
+			<PriceTag amount={product.price.amount} currency={product.price.currency} main />
+		</span>
+	</div>
+	<p class="mt-4 text-center px-1 text-xs break-words break-all">
+		{product.name.toUpperCase()}
+	</p>
+</a>

--- a/src/lib/server/cms.ts
+++ b/src/lib/server/cms.ts
@@ -2,6 +2,7 @@ import type { Challenge } from '$lib/types/Challenge';
 import type { DigitalFile } from '$lib/types/DigitalFile';
 import type { Product } from '$lib/types/Product';
 import type { Picture } from '$lib/types/Picture';
+import { CUSTOMER_ROLE_ID } from '$lib/types/User';
 import type { Currency } from '$lib/types/Currency';
 import { trimPrefix } from '$lib/utils/trimPrefix';
 import { trimSuffix } from '$lib/utils/trimSuffix';
@@ -9,7 +10,6 @@ import { JSDOM } from 'jsdom';
 import DOMPurify from 'dompurify';
 import { collections } from './database';
 import { ALLOW_JS_INJECTION } from '$lib/server/env-config';
-import type { PickDeep } from 'type-fest';
 import type { Specification } from '$lib/types/Specification';
 import type { Tag } from '$lib/types/Tag';
 import type { ContactForm } from '$lib/types/ContactForm';
@@ -21,6 +21,9 @@ import { groupBy } from '$lib/utils/group-by';
 import { subMinutes } from 'date-fns';
 import { z } from 'zod';
 import type { ProductWidgetProduct } from '$lib/components/ProductWidget/ProductWidgetProduct';
+import { readUrlState, searchProducts, type VatContext } from './searchlist';
+import { runtimeConfig } from './runtime-config';
+import type { VatProfile } from '$lib/types/VatProfile';
 export type ExternalProductData = ProductWidgetProduct & {
 	externalUrl: string;
 	pictures: Picture[];
@@ -222,6 +225,11 @@ type TokenObject =
 			slug: string;
 			display: string | undefined;
 			raw: string;
+	  }
+	| {
+			type: 'searchlistWidget';
+			slug: string;
+			raw: string;
 	  };
 
 export async function cmsFromContent(
@@ -238,7 +246,7 @@ export async function cmsFromContent(
 		forceContentVersion?: 'desktop' | 'mobile' | 'employee';
 		forceUnsanitizedContent?: boolean;
 	},
-	locals: Partial<PickDeep<App.Locals, 'user.hasPosOptions' | 'language' | 'email' | 'sso'>>
+	locals: App.Locals
 ) {
 	/**
 	 * Matches product widget syntax in CMS content:
@@ -273,6 +281,7 @@ export async function cmsFromContent(
 	const CURRENCY_CALCULATOR_WIDGET_REGEX = /\[CurrencyCalculator=(?<slug>[a-z0-9-]+)\]/giu;
 	const SCHEDULE_WIDGET_REGEX =
 		/\[Schedule=(?<slug>[\p{L}\d_:-]+)(?:[?\s]display=(?<display>(main|main-light|list|calendar)))?\]/giu;
+	const SEARCHLIST_WIDGET_REGEX = /\[Searchlist=(?<slug>[a-z0-9-]+)\]/giu;
 
 	const productSlugs = new Set<string>();
 	const externalProductUrls = new Set<string>();
@@ -289,6 +298,7 @@ export async function cmsFromContent(
 	const qrCodeSlugs = new Set<string>();
 	const currencyCalculatorSlugs = new Set<string>();
 	const scheduleSlugs = new Set<string>();
+	const searchlistSlugs = new Set<string>();
 
 	function matchAndSort(content: string, regex: RegExp, type: string) {
 		const regexMatches = [...content.matchAll(regex)];
@@ -314,7 +324,8 @@ export async function cmsFromContent(
 			...matchAndSort(content, LEADERBOARD_WIDGET_REGEX, 'leaderboardWidget'),
 			...matchAndSort(content, QRCODE_REGEX, 'qrCode'),
 			...matchAndSort(content, CURRENCY_CALCULATOR_WIDGET_REGEX, 'currencyCalculatorWidget'),
-			...matchAndSort(content, SCHEDULE_WIDGET_REGEX, 'scheduleWidget')
+			...matchAndSort(content, SCHEDULE_WIDGET_REGEX, 'scheduleWidget'),
+			...matchAndSort(content, SEARCHLIST_WIDGET_REGEX, 'searchlistWidget')
 		].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
 		for (const match of matches) {
 			const html = trimPrefix(trimSuffix(content.slice(index, match.index), '<p>'), '</p>');
@@ -483,6 +494,14 @@ export async function cmsFromContent(
 							raw: match[0]
 						});
 						break;
+					case 'searchlistWidget':
+						searchlistSlugs.add(match.groups.slug);
+						token.push({
+							type: 'searchlistWidget',
+							slug: match.groups.slug,
+							raw: match[0]
+						});
+						break;
 				}
 			}
 			index = match.index + match[0].length;
@@ -556,7 +575,8 @@ export async function cmsFromContent(
 		contactForms,
 		countdowns,
 		galleries,
-		schedules
+		schedules,
+		searchlists
 	] = await Promise.all([
 		tagProductsSlugs.size > 0 || productSlugs.size > 0 || allProductsLead.length > 0
 			? collections.products
@@ -734,7 +754,8 @@ export async function cmsFromContent(
 						_id: { $in: [...scheduleSlugs] }
 					})
 					.toArray()
-			: []
+			: [],
+		buildSearchlistViews([...searchlistSlugs], locals)
 	]);
 
 	const pictureConditions = {
@@ -796,6 +817,7 @@ export async function cmsFromContent(
 		countdowns,
 		galleries,
 		leaderboards,
+		searchlists,
 		schedules: schedules.map((schedule) => ({
 			...schedule,
 			events: [...schedule.events, ...(scheduleEventsById[schedule._id] ?? [])].filter((event) =>
@@ -810,6 +832,92 @@ export async function cmsFromContent(
 	};
 }
 
+async function buildSearchlistViews(searchlistSlugs: string[], locals: App.Locals) {
+	if (searchlistSlugs.length === 0) {
+		return [];
+	}
+
+	const isEmployee = locals.user?.roleId !== undefined && locals.user.roleId !== CUSTOMER_ROLE_ID;
+	const visibilityFilter = isEmployee ? {} : { disabled: { $ne: true } };
+
+	const [searchlists, vatProfiles] = await Promise.all([
+		collections.searchlists.find({ _id: { $in: searchlistSlugs }, ...visibilityFilter }).toArray(),
+		collections.vatProfiles
+			.find({})
+			.project<Pick<VatProfile, '_id' | 'rates'>>({ _id: 1, rates: 1 })
+			.map((p) => ({ _id: p._id.toString(), rates: p.rates }))
+			.toArray()
+	]);
+
+	const vatContext: VatContext = {
+		vatProfiles,
+		bebopCountry: runtimeConfig.vatCountry,
+		userCountry: locals.countryCode,
+		vatSingleCountry: runtimeConfig.vatSingleCountry,
+		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
+	};
+
+	return Promise.all(
+		searchlists.map(async (sl) => {
+			const state = readUrlState(new URL('http://x/'), sl);
+			state.page = 1;
+			const { products, total, totalPages } = await searchProducts(sl, state, locals, vatContext);
+
+			const productIds = products.map((p) => p._id);
+			const [slPictures, slDigitalFiles, slAllowedTags] = await Promise.all([
+				productIds.length > 0
+					? collections.pictures
+							.find({ productId: { $in: productIds } })
+							.sort({ order: 1, createdAt: 1 })
+							.toArray()
+					: Promise.resolve([] as Picture[]),
+				productIds.length > 0
+					? collections.digitalFiles
+							.find({ productId: { $in: productIds } })
+							.project<{ productId: string }>({ productId: 1, _id: 0 })
+							.toArray()
+					: Promise.resolve([] as Array<{ productId: string }>),
+				sl.filters.tags?.enabled && (sl.filters.tags.allowedTagIds?.length ?? 0) > 0
+					? collections.tags
+							.find({ _id: { $in: sl.filters.tags.allowedTagIds } })
+							.project<Pick<Tag, '_id' | 'name'>>({
+								_id: 1,
+								name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] }
+							})
+							.toArray()
+					: Promise.resolve([] as Array<Pick<Tag, '_id' | 'name'>>)
+			]);
+
+			const picturesByProductId: Record<string, Picture[]> = {};
+			for (const pic of slPictures) {
+				if (!pic.productId) {
+					continue;
+				}
+				(picturesByProductId[pic.productId] ||= []).push(pic);
+			}
+			const digitalFilesByProductId: Record<string, boolean> = {};
+			for (const df of slDigitalFiles) {
+				if (df.productId) {
+					digitalFilesByProductId[df.productId] = true;
+				}
+			}
+
+			return {
+				...sl,
+				state,
+				products,
+				picturesByProductId,
+				digitalFilesByProductId,
+				total,
+				totalPages,
+				allowedTags: slAllowedTags,
+				basePath: `/searchlist/${sl._id}`,
+				displayVatIncluded: vatContext.displayVatIncluded
+			};
+		})
+	);
+}
+
 export type CmsTokens = Awaited<ReturnType<typeof cmsFromContent>>['tokens'];
 export type CmsProduct = Awaited<ReturnType<typeof cmsFromContent>>['products'][number];
 export type CmsChallenge = Awaited<ReturnType<typeof cmsFromContent>>['challenges'][number];
@@ -817,6 +925,7 @@ export type CmsSlider = Awaited<ReturnType<typeof cmsFromContent>>['sliders'][nu
 export type CmsTag = Awaited<ReturnType<typeof cmsFromContent>>['tags'][number];
 export type CmsPicture = Awaited<ReturnType<typeof cmsFromContent>>['pictures'][number];
 export type CmsDigitalFile = Awaited<ReturnType<typeof cmsFromContent>>['digitalFiles'][number];
+export type CmsSearchlist = Awaited<ReturnType<typeof cmsFromContent>>['searchlists'][number];
 export type CmsSpecification = Awaited<ReturnType<typeof cmsFromContent>>['specifications'][number];
 export type CmsContactForm = Awaited<ReturnType<typeof cmsFromContent>>['contactForms'][number];
 export type CmsCountdown = Awaited<ReturnType<typeof cmsFromContent>>['countdowns'][number];

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -45,6 +45,7 @@ import type { Specification } from '$lib/types/Specification';
 import type { ContactForm } from '$lib/types/ContactForm';
 import type { Countdown } from '$lib/types/Countdown';
 import type { Gallery } from '$lib/types/Gallery';
+import type { Searchlist } from '$lib/types/Searchlist';
 import type { VatProfile } from '$lib/types/VatProfile';
 import type { Ticket } from '$lib/types/Ticket';
 import type { OrderLabel } from '$lib/types/OrderLabel';
@@ -112,6 +113,7 @@ const genCollection = () => ({
 	contactForms: db.collection<ContactForm>('contactForms'),
 	countdowns: db.collection<Countdown>('countdowns'),
 	galleries: db.collection<Gallery>('galleries'),
+	searchlists: db.collection<Searchlist>('searchlists'),
 	vatProfiles: db.collection<VatProfile>('vatProfiles'),
 	tickets: db.collection<Ticket>('tickets'),
 	labels: db.collection<OrderLabel>('labels'),

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -8,6 +8,92 @@ import { ORIGIN } from '$lib/server/env-config';
 import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
 import { CURRENCIES, FRACTION_DIGITS_PER_CURRENCY } from '$lib/types/Currency';
 
+async function ensureDefaultSearchlist(session?: ClientSession): Promise<void> {
+	const existing = await collections.searchlists.findOne({ _id: 'default' }, { session });
+	if (existing) {
+		return;
+	}
+	const now = new Date();
+	await collections.searchlists.insertOne(
+		{
+			_id: 'default',
+			name: 'default',
+			displayWidgetName: false,
+			hideSearchbar: true,
+			prefillSearchterm: false,
+			hideSearchterm: false,
+			searchTargets: {
+				title: true,
+				shortDescription: true,
+				longDescription: true,
+				productTags: false,
+				productVariation: false,
+				productCustomCta: false,
+				productCmsBefore: false,
+				productCmsAfter: false
+			},
+			filters: {
+				price: { enabled: false },
+				stock: { enabled: false, defaultChecked: false },
+				tags: { enabled: false, allowedTagIds: [] }
+			},
+			sort: {
+				displayed: false,
+				options: ['alphaAsc', 'alphaDesc', 'priceAsc', 'priceDesc', 'createdAsc', 'createdDesc'],
+				default: 'alphaAsc'
+			},
+			view: { default: 'grid', hideToggle: true },
+			pagination: { mode: 'loadMore', perPage: 12 },
+			createdAt: now,
+			updatedAt: now
+		},
+		{ session }
+	);
+}
+
+async function ensureSearchSearchlist(session?: ClientSession): Promise<void> {
+	const existing = await collections.searchlists.findOne({ _id: 'search' }, { session });
+	if (existing) {
+		return;
+	}
+	const now = new Date();
+	await collections.searchlists.insertOne(
+		{
+			_id: 'search',
+			name: 'Recherche',
+			displayWidgetName: false,
+			hideSearchbar: false,
+			prefillSearchterm: false,
+			hideSearchterm: false,
+			searchTargets: {
+				title: true,
+				shortDescription: true,
+				longDescription: true,
+				productTags: false,
+				productVariation: false,
+				productCustomCta: false,
+				productCmsBefore: false,
+				productCmsAfter: false
+			},
+			filters: {
+				price: { enabled: true },
+				stock: { enabled: true, defaultChecked: false },
+				tags: { enabled: false, allowedTagIds: [] }
+			},
+			sort: {
+				displayed: true,
+				options: ['alphaAsc', 'alphaDesc', 'priceAsc', 'priceDesc', 'createdAsc', 'createdDesc'],
+				default: 'alphaAsc'
+			},
+			view: { default: 'grid', hideToggle: false },
+			pagination: { mode: 'loadMore', perPage: 12 },
+			createdAt: now,
+			updatedAt: now
+		},
+		{ session }
+	);
+}
+
 const migrations = [
 	{
 		_id: new ObjectId('65281201e92e590e858af6cb'),
@@ -697,6 +783,52 @@ const migrations = [
 				{ session }
 			);
 		}
+	},
+	{
+		_id: new ObjectId('660d1e8a2f1e0c0001787001'),
+		name: 'Seed default searchlist (issue #1787)',
+		run: async (session: ClientSession) => {
+			await ensureDefaultSearchlist(session);
+		}
+	},
+	{
+		_id: new ObjectId('660d1e8a2f1e0c0001787002'),
+		name: 'Backfill displayWidgetName + hideSearchbar on default searchlist (issue #1787)',
+		run: async (session: ClientSession) => {
+			await collections.searchlists.updateMany(
+				{ displayWidgetName: { $exists: false } },
+				{ $set: { displayWidgetName: false, updatedAt: new Date() } },
+				{ session }
+			);
+			await collections.searchlists.updateOne(
+				{ _id: 'default' },
+				{ $set: { hideSearchbar: true, updatedAt: new Date() } },
+				{ session }
+			);
+		}
+	},
+	{
+		_id: new ObjectId('660d1e8a2f1e0c0001787003'),
+		name: 'Backfill filters.tags on searchlists (issue #1787)',
+		run: async (session: ClientSession) => {
+			await collections.searchlists.updateMany(
+				{ 'filters.tags': { $exists: false } },
+				{
+					$set: {
+						'filters.tags': { enabled: false, allowedTagIds: [] },
+						updatedAt: new Date()
+					}
+				},
+				{ session }
+			);
+		}
+	},
+	{
+		_id: new ObjectId('660d1e8a2f1e0c0001787004'),
+		name: 'Seed search searchlist (issue #1787)',
+		run: async (session: ClientSession) => {
+			await ensureSearchSearchlist(session);
+		}
 	}
 ];
 
@@ -754,4 +886,10 @@ export async function runMigrations() {
 	while ((await collections.migrations.countDocuments()) < migrations.length) {
 		await new Promise((resolve) => setTimeout(resolve, 1000));
 	}
+
+	// Idempotent on every startup: ensure the built-in searchlists exist.
+	// Re-creates them if they were deleted (the admin UI blocks deletion,
+	// but a manual Mongo delete still happens).
+	await ensureDefaultSearchlist();
+	await ensureSearchSearchlist();
 }

--- a/src/lib/server/searchlist.test.ts
+++ b/src/lib/server/searchlist.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { runtimeConfig } from './runtime-config';
+import {
+	buildSearchOrClauses,
+	extractTagsFromTerm,
+	mainPerCurrency,
+	readUrlState
+} from './searchlist';
+import { DEFAULT_SEARCH_TARGETS, type Searchlist } from '$lib/types/Searchlist';
+
+function makeSearchlist(overrides: Partial<Searchlist> = {}): Searchlist {
+	return {
+		_id: 'test',
+		name: 'Test',
+		displayWidgetName: false,
+		hideSearchbar: false,
+		prefillSearchterm: false,
+		initialSearchterm: '',
+		hideSearchterm: false,
+		searchTargets: { ...DEFAULT_SEARCH_TARGETS },
+		filters: {
+			price: { enabled: true, defaultMin: undefined, defaultMax: undefined },
+			stock: { enabled: true, defaultChecked: false },
+			tags: { enabled: true, allowedTagIds: [] }
+		},
+		sort: { displayed: true, options: ['createdDesc'], default: 'createdDesc' },
+		view: { default: 'grid', hideToggle: false },
+		pagination: { mode: 'classic', perPage: 20 },
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides
+	};
+}
+
+describe('extractTagsFromTerm', () => {
+	it('returns the term untouched when no tag: prefix is present', () => {
+		expect(extractTagsFromTerm('red shoes')).toEqual({ tagIds: [], remaining: 'red shoes' });
+	});
+
+	it('extracts a single tag and trims the remaining term', () => {
+		expect(extractTagsFromTerm('tag:sale red shoes')).toEqual({
+			tagIds: ['sale'],
+			remaining: 'red shoes'
+		});
+	});
+
+	it('extracts multiple tags from the same query', () => {
+		const result = extractTagsFromTerm('tag:sale red tag:winter shoes');
+		expect(result.tagIds).toEqual(['sale', 'winter']);
+		expect(result.remaining).toBe('red shoes');
+	});
+
+	it('is case-insensitive on the tag: prefix', () => {
+		expect(extractTagsFromTerm('TAG:promo deal')).toEqual({
+			tagIds: ['promo'],
+			remaining: 'deal'
+		});
+	});
+
+	it('returns an empty remaining when only tags are provided', () => {
+		expect(extractTagsFromTerm('tag:sale tag:winter')).toEqual({
+			tagIds: ['sale', 'winter'],
+			remaining: ''
+		});
+	});
+});
+
+describe('readUrlState', () => {
+	const searchlist = makeSearchlist();
+
+	it('falls back to defaults when query params are missing', () => {
+		const state = readUrlState(new URL('https://shop.test/searchlist/x'), searchlist);
+		expect(state).toMatchObject({
+			q: '',
+			sort: 'createdDesc',
+			view: 'grid',
+			page: 1,
+			stock: false
+		});
+	});
+
+	it('clamps page to 1 when the param is invalid', () => {
+		const state = readUrlState(new URL('https://shop.test/searchlist/x?page=-3'), searchlist);
+		expect(state.page).toBe(1);
+	});
+
+	it('ignores invalid sort/view and keeps the searchlist defaults', () => {
+		const state = readUrlState(
+			new URL('https://shop.test/searchlist/x?sort=nope&view=bogus'),
+			searchlist
+		);
+		expect(state.sort).toBe('createdDesc');
+		expect(state.view).toBe('grid');
+	});
+
+	it('uses initialSearchterm only when prefillSearchterm is on', () => {
+		const sl = makeSearchlist({ prefillSearchterm: true, initialSearchterm: 'hello' });
+		expect(readUrlState(new URL('https://shop.test/searchlist/x'), sl).q).toBe('hello');
+		const slOff = makeSearchlist({ prefillSearchterm: false, initialSearchterm: 'hello' });
+		expect(readUrlState(new URL('https://shop.test/searchlist/x'), slOff).q).toBe('');
+	});
+
+	it('parses pmin/pmax, ignoring non-numeric values', () => {
+		const state = readUrlState(
+			new URL('https://shop.test/searchlist/x?pmin=10&pmax=foo'),
+			searchlist
+		);
+		expect(state.pmin).toBe(10);
+		expect(state.pmax).toBeUndefined();
+	});
+});
+
+describe('buildSearchOrClauses', () => {
+	it('escapes regex special characters in the term', () => {
+		const clauses = buildSearchOrClauses(
+			'a+b.c*',
+			{ ...DEFAULT_SEARCH_TARGETS, title: true },
+			'en'
+		);
+		const fieldClause = clauses.find((c) => 'name' in c) as { name: { $regex: string } };
+		expect(fieldClause.name.$regex).toBe('a\\+b\\.c\\*');
+	});
+
+	it('emits a clause for the translated field next to the canonical one', () => {
+		const clauses = buildSearchOrClauses('shoes', { ...DEFAULT_SEARCH_TARGETS, title: true }, 'fr');
+		expect(clauses.some((c) => 'name' in c)).toBe(true);
+		expect(clauses.some((c) => 'translations.fr.name' in c)).toBe(true);
+	});
+
+	it('returns no clauses when every target is disabled', () => {
+		const allOff = Object.fromEntries(
+			Object.keys(DEFAULT_SEARCH_TARGETS).map((k) => [k, false])
+		) as typeof DEFAULT_SEARCH_TARGETS;
+		expect(buildSearchOrClauses('anything', allOff, 'en')).toEqual([]);
+	});
+});
+
+describe('mainPerCurrency', () => {
+	const savedRates = { ...runtimeConfig.exchangeRate };
+
+	beforeAll(() => {
+		runtimeConfig.exchangeRate.EUR = 50_000; // 1 BTC = 50k EUR
+		runtimeConfig.exchangeRate.USD = 60_000; // 1 BTC = 60k USD
+	});
+
+	afterAll(() => {
+		Object.assign(runtimeConfig.exchangeRate, savedRates);
+	});
+
+	it('returns 1 when from === main', () => {
+		expect(mainPerCurrency('EUR', 'EUR')).toBe(1);
+		expect(mainPerCurrency('BTC', 'BTC')).toBe(1);
+	});
+
+	it('converts via BTC pivot when both rates are present', () => {
+		// 1 EUR = (60000 / 50000) USD = 1.2 (mainRate / fromRate)
+		expect(mainPerCurrency('EUR', 'USD')).toBeCloseTo(60_000 / 50_000, 6);
+	});
+
+	it('falls back to 1 when a rate is missing', () => {
+		delete runtimeConfig.exchangeRate.EUR;
+		expect(mainPerCurrency('EUR', 'USD')).toBe(1);
+		runtimeConfig.exchangeRate.EUR = 50_000;
+	});
+});

--- a/src/lib/server/searchlist.ts
+++ b/src/lib/server/searchlist.ts
@@ -1,0 +1,399 @@
+import { ObjectId, type Document, type Filter } from 'mongodb';
+import { collections } from './database';
+import type {
+	Searchlist,
+	SearchTargetKey,
+	SortKey,
+	ViewMode,
+	PaginationMode
+} from '$lib/types/Searchlist';
+import { SORT_KEYS, VIEW_MODES, PAGINATION_MODES } from '$lib/types/Searchlist';
+import type { Product } from '$lib/types/Product';
+import { CUSTOMER_ROLE_ID } from '$lib/types/User';
+import { runtimeConfig } from './runtime-config';
+import { CURRENCIES, CURRENCY_UNIT, type Currency } from '$lib/types/Currency';
+import type { CountryAlpha2 } from '$lib/types/Country';
+import { computeVatRate } from '$lib/utils/vat';
+
+export const MAX_SEARCH_TERM_LENGTH = 64;
+export const MAX_CUMULATIVE_PAGES = 100;
+
+// 1 unit of `from` equals X units of `main`. Uses raw rates to avoid the
+// display-precision rounding that toCurrency applies (which would zero out
+// small ratios like 1 SAT → EUR).
+export function mainPerCurrency(from: Currency, main: Currency): number {
+	const rates = runtimeConfig.exchangeRate;
+	const fromRate = from === 'BTC' ? 1 : rates[from];
+	const mainRate = main === 'BTC' ? 1 : rates[main];
+	if (fromRate === undefined || mainRate === undefined) {
+		console.warn(
+			`[searchlist] missing exchange rate (from=${from}, main=${main}); falling back to 1:1`
+		);
+		return 1;
+	}
+	return mainRate / fromRate;
+}
+
+export type SearchlistUrlState = {
+	q: string;
+	pmin?: number;
+	pmax?: number;
+	stock: boolean;
+	tag?: string;
+	sort: SortKey;
+	view: ViewMode;
+	page: number;
+};
+
+const TAG_PATTERN_GLOBAL = /(?:^|\s)tag:([a-z0-9-]+)/gi;
+
+export function extractTagsFromTerm(term: string): { tagIds: string[]; remaining: string } {
+	const tagIds: string[] = [];
+	const remaining = term
+		.replace(TAG_PATTERN_GLOBAL, (_match, tagId) => {
+			tagIds.push(String(tagId));
+			return ' ';
+		})
+		.replace(/\s+/g, ' ')
+		.trim();
+	return { tagIds, remaining };
+}
+
+export function readUrlState(
+	url: URL,
+	searchlist: Pick<
+		Searchlist,
+		'filters' | 'sort' | 'view' | 'prefillSearchterm' | 'initialSearchterm'
+	>
+): SearchlistUrlState {
+	const q = url.searchParams.get('q');
+	const initial = searchlist.prefillSearchterm ? searchlist.initialSearchterm ?? '' : '';
+
+	const sortParam = url.searchParams.get('sort');
+	const sort: SortKey = SORT_KEYS.includes(sortParam as SortKey)
+		? (sortParam as SortKey)
+		: searchlist.sort.default;
+
+	const viewParam = url.searchParams.get('view');
+	const view: ViewMode = VIEW_MODES.includes(viewParam as ViewMode)
+		? (viewParam as ViewMode)
+		: searchlist.view.default;
+
+	const pmin = parseOptionalNumber(
+		url.searchParams.get('pmin'),
+		searchlist.filters.price.defaultMin
+	);
+	const pmax = parseOptionalNumber(
+		url.searchParams.get('pmax'),
+		searchlist.filters.price.defaultMax
+	);
+
+	const stockParam = url.searchParams.get('stock');
+	const stock =
+		stockParam !== null ? stockParam === '1' : !!searchlist.filters.stock.defaultChecked;
+
+	const tag = url.searchParams.get('tag') || undefined;
+
+	const page = parsePositiveInt(url.searchParams.get('page'), 1);
+
+	return {
+		q: q ?? initial,
+		pmin,
+		pmax,
+		stock,
+		tag,
+		sort,
+		view,
+		page
+	};
+}
+
+function parseOptionalNumber(raw: string | null, fallback: number | undefined): number | undefined {
+	if (raw === null || raw === '') {
+		return fallback;
+	}
+	const n = Number(raw);
+	return Number.isFinite(n) ? n : fallback;
+}
+
+function parsePositiveInt(raw: string | null, fallback: number): number {
+	if (raw === null) {
+		return fallback;
+	}
+	const n = parseInt(raw, 10);
+	return Number.isFinite(n) && n >= 1 ? n : fallback;
+}
+
+// productTags + productVariation: admin can toggle the option in V1 but the search
+// logic does not honor them yet (extra tag lookup + dynamic variationLabels paths).
+const TARGET_TO_FIELDS: Record<SearchTargetKey, string[]> = {
+	title: ['name'],
+	shortDescription: ['shortDescription'],
+	longDescription: ['description'],
+	productTags: [],
+	productVariation: [],
+	productCustomCta: ['cta.label'],
+	productCmsBefore: ['contentBefore'],
+	productCmsAfter: ['contentAfter']
+};
+
+/**
+ * Builds the $or clauses for the search term. The regex is escaped, but it is
+ * NOT anchored and uses case-insensitive matching, which forces a collection
+ * scan in Mongo. Acceptable on small product catalogs; for scale, replace with
+ * a $text index or a dedicated search engine (Meilisearch / Atlas Search).
+ */
+export function buildSearchOrClauses(
+	term: string,
+	targets: Record<SearchTargetKey, boolean>,
+	language: string
+): Filter<Product>[] {
+	const safe = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const regex = { $regex: safe, $options: 'i' };
+	const clauses: Filter<Product>[] = [];
+	for (const target of Object.keys(targets) as SearchTargetKey[]) {
+		if (!targets[target]) {
+			continue;
+		}
+		for (const field of TARGET_TO_FIELDS[target]) {
+			clauses.push({ [field]: regex } as Filter<Product>);
+			clauses.push({ [`translations.${language}.${field}`]: regex } as Filter<Product>);
+		}
+	}
+	return clauses;
+}
+
+export type SearchResult = {
+	products: Pick<
+		Product,
+		| '_id'
+		| 'name'
+		| 'shortDescription'
+		| 'price'
+		| 'shipping'
+		| 'preorder'
+		| 'availableDate'
+		| 'standalone'
+		| 'tagIds'
+		| 'stock'
+		| 'actionSettings'
+		| 'type'
+		| 'free'
+		| 'isTicket'
+		| 'payWhatYouWant'
+		| 'maxQuantityPerOrder'
+		| 'mobile'
+	>[];
+	total: number;
+	totalPages: number;
+};
+
+export type VatContext = {
+	vatProfiles: Array<{ _id: string; rates: Partial<Record<CountryAlpha2, number>> }>;
+	bebopCountry: CountryAlpha2 | undefined;
+	userCountry: CountryAlpha2 | undefined;
+	vatSingleCountry: boolean;
+	displayVatIncluded: boolean;
+};
+
+export async function searchProducts(
+	searchlist: Searchlist,
+	state: SearchlistUrlState,
+	locals: App.Locals,
+	vat: VatContext
+): Promise<SearchResult> {
+	const isEmployee = locals.user?.roleId !== undefined && locals.user.roleId !== CUSTOMER_ROLE_ID;
+
+	const baseFilter: Filter<Product> = {};
+
+	if (!isEmployee) {
+		baseFilter['actionSettings.eShop.visible'] = true;
+	}
+
+	const cappedTerm = state.q.slice(0, MAX_SEARCH_TERM_LENGTH);
+	const { tagIds: extractedTagIds, remaining: remainingTerm } = extractTagsFromTerm(cappedTerm);
+
+	if (remainingTerm.trim()) {
+		const clauses = buildSearchOrClauses(
+			remainingTerm.trim(),
+			searchlist.searchTargets,
+			locals.language
+		);
+		if (clauses.length > 0) {
+			baseFilter.$or = clauses;
+		}
+	}
+
+	if (searchlist.filters.tags?.enabled) {
+		const allowed = new Set(searchlist.filters.tags.allowedTagIds ?? []);
+		const tagFromDropdown = state.tag && allowed.has(state.tag) ? [state.tag] : [];
+		const finalTagIds = [...new Set([...extractedTagIds, ...tagFromDropdown])];
+		if (finalTagIds.length > 0) {
+			baseFilter.tagIds = { $all: finalTagIds };
+		}
+	}
+
+	if (searchlist.filters.stock.enabled && state.stock) {
+		baseFilter.$and = [
+			...((baseFilter.$and as Filter<Product>[]) ?? []),
+			{ $or: [{ stock: { $exists: false } }, { 'stock.available': { $gt: 0 } }] }
+		];
+	}
+
+	const main = runtimeConfig.mainCurrency;
+	const factorBranches = CURRENCIES.map((c) => ({
+		case: { $eq: ['$price.currency', c] },
+		then: mainPerCurrency(c, main)
+	}));
+	// _factor defaults to 0 for any currency outside CURRENCIES (data corruption /
+	// outdated CURRENCIES list); products in those would silently get _priceInMain=0.
+	// Surface it so a dev notices when adding/removing a supported currency.
+
+	const vatMultExpr: Document = vat.displayVatIncluded
+		? (() => {
+				const defaultRate = computeVatRate({
+					productVatProfileId: undefined,
+					vatProfiles: vat.vatProfiles,
+					bebopCountry: vat.bebopCountry,
+					userCountry: vat.userCountry,
+					vatSingleCountry: vat.vatSingleCountry
+				});
+				const branches = vat.vatProfiles.map((vp) => ({
+					case: { $eq: ['$vatProfileId', new ObjectId(vp._id)] },
+					then:
+						1 +
+						computeVatRate({
+							productVatProfileId: vp._id,
+							vatProfiles: vat.vatProfiles,
+							bebopCountry: vat.bebopCountry,
+							userCountry: vat.userCountry,
+							vatSingleCountry: vat.vatSingleCountry
+						}) /
+							100
+				}));
+				return branches.length > 0
+					? { $switch: { branches, default: 1 + defaultRate / 100 } }
+					: { $literal: 1 + defaultRate / 100 };
+		  })()
+		: { $literal: 1 };
+
+	// pmin/pmax are in mainCurrency, TTC when displayVatIncluded matches the
+	// displayed unit. Half-display-unit tolerance so a product whose displayed
+	// price rounds to the bound (e.g. 2.9213 → 2.92 EUR) is included.
+	const halfDisplayUnit = CURRENCY_UNIT[main] / 2;
+	const boundsMatch: Record<string, number> = {};
+	if (searchlist.filters.price.enabled) {
+		if (typeof state.pmin === 'number') {
+			boundsMatch.$gte = state.pmin - halfDisplayUnit;
+		}
+		if (typeof state.pmax === 'number') {
+			boundsMatch.$lte = state.pmax + halfDisplayUnit;
+		}
+	}
+
+	const perPage = searchlist.pagination.perPage;
+	// V1 known cost: loadMore/infinite re-queries cumulatively (limit = perPage * page),
+	// so listing N pages is O(perPage * page) — quadratic in scroll depth. We clamp the
+	// page to MAX_CUMULATIVE_PAGES to keep the worst case bounded. Switch to a cursor
+	// strategy in a follow-up if catalog grows.
+	const effectiveMode =
+		searchlist.pagination.mode === 'infinite' ? 'loadMore' : searchlist.pagination.mode;
+	const clampedPage =
+		effectiveMode === 'classic' ? state.page : Math.min(state.page, MAX_CUMULATIVE_PAGES);
+	const limit = effectiveMode === 'classic' ? perPage : perPage * clampedPage;
+	const skip = effectiveMode === 'classic' ? (clampedPage - 1) * perPage : 0;
+
+	const sortSpec: Record<string, 1 | -1> =
+		state.sort === 'priceAsc'
+			? { _priceInMain: 1, _id: 1 }
+			: state.sort === 'priceDesc'
+			? { _priceInMain: -1, _id: -1 }
+			: state.sort === 'alphaAsc'
+			? { name: 1, _id: 1 }
+			: state.sort === 'alphaDesc'
+			? { name: -1, _id: -1 }
+			: state.sort === 'createdAsc'
+			? { createdAt: 1, _id: 1 }
+			: { createdAt: -1, _id: -1 };
+
+	const priceProjection: Document = vat.displayVatIncluded
+		? { amount: { $multiply: ['$price.amount', '$_vatMult'] }, currency: '$price.currency' }
+		: { amount: '$price.amount', currency: '$price.currency' };
+
+	const projection: Document = {
+		_id: 1,
+		name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] },
+		shortDescription: {
+			$ifNull: [`$translations.${locals.language}.shortDescription`, '$shortDescription']
+		},
+		price: priceProjection,
+		shipping: 1,
+		preorder: 1,
+		availableDate: 1,
+		standalone: 1,
+		tagIds: 1,
+		stock: 1,
+		actionSettings: 1,
+		type: 1,
+		free: 1,
+		isTicket: 1,
+		payWhatYouWant: 1,
+		maxQuantityPerOrder: 1,
+		mobile: 1
+	};
+
+	const pipeline: Document[] = [
+		{ $match: baseFilter },
+		{
+			$addFields: {
+				_factor: { $switch: { branches: factorBranches, default: 0 } },
+				_vatMult: vatMultExpr
+			}
+		},
+		{
+			$addFields: {
+				_priceInMain: { $multiply: ['$price.amount', '$_factor', '$_vatMult'] }
+			}
+		}
+	];
+	if (Object.keys(boundsMatch).length > 0) {
+		pipeline.push({ $match: { _priceInMain: boundsMatch } });
+	}
+	pipeline.push({
+		$facet: {
+			products: [{ $sort: sortSpec }, { $skip: skip }, { $limit: limit }, { $project: projection }],
+			count: [{ $count: 'total' }],
+			unknownCurrency: [
+				{ $match: { 'price.currency': { $nin: [...CURRENCIES] } } },
+				{ $count: 'n' }
+			]
+		}
+	});
+
+	type ProductHit = SearchResult['products'][number];
+	type FacetResult = {
+		products: ProductHit[];
+		count: Array<{ total: number }>;
+		unknownCurrency: Array<{ n: number }>;
+	};
+
+	const [facet] = await collections.products.aggregate<FacetResult>(pipeline).toArray();
+	const products = facet?.products ?? [];
+	const total = facet?.count[0]?.total ?? 0;
+	const unknownCurrencyCount = facet?.unknownCurrency[0]?.n ?? 0;
+	if (unknownCurrencyCount > 0) {
+		console.warn(
+			`[searchlist] ${unknownCurrencyCount} product(s) have a currency outside CURRENCIES; _factor=0 applied`
+		);
+	}
+
+	return {
+		products,
+		total,
+		totalPages: Math.max(1, Math.ceil(total / perPage))
+	};
+}
+
+export function isPaginationMode(value: string): value is PaginationMode {
+	return PAGINATION_MODES.includes(value as PaginationMode);
+}

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -946,6 +946,51 @@
 		"subscribeCTA": "Abonnieren",
 		"uniqueDateText": " - ab {beginTime}"
 	},
+	"searchlist": {
+		"searchbar": {
+			"label": "Suche",
+			"placeholder": "Produkt nach Namen suchen",
+			"submit": "Suchen",
+			"reset": "Zurücksetzen"
+		},
+		"sort": {
+			"label": "Sortieren nach",
+			"options": {
+				"alphaAsc": "Alphabetisch (A → Z)",
+				"alphaDesc": "Alphabetisch (Z → A)",
+				"priceAsc": "Preis (aufsteigend)",
+				"priceDesc": "Preis (absteigend)",
+				"createdAsc": "Älteste zuerst",
+				"createdDesc": "Neueste zuerst"
+			}
+		},
+		"filters": {
+			"price": {
+				"minLabel": "Mindestpreis",
+				"maxLabel": "Höchstpreis"
+			},
+			"stock": {
+				"label": "Nur auf Lager"
+			},
+			"tag": {
+				"label": "Tag"
+			}
+		},
+		"view": {
+			"grid": "Rasteransicht",
+			"list": "Listenansicht"
+		},
+		"pagination": {
+			"loadMore": "Mehr laden",
+			"prev": "Zurück",
+			"next": "Weiter"
+		},
+		"empty": {
+			"title": "Keine Produkte entsprechen Ihrer Suche.",
+			"reset": "Zurücksetzen"
+		},
+		"disabledNotice": "Diese Suchliste ist deaktiviert und für die Öffentlichkeit nicht sichtbar."
+	},
 	"subscription": {
 		"associated": {
 			"title": "Verknüpft mit:",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -948,6 +948,51 @@
 		"subscribeCTA": "Subscribe",
 		"uniqueDateText": " - from {beginTime}"
 	},
+	"searchlist": {
+		"searchbar": {
+			"label": "Search",
+			"placeholder": "Search product by name",
+			"submit": "Search",
+			"reset": "Reset"
+		},
+		"sort": {
+			"label": "Sort by",
+			"options": {
+				"alphaAsc": "Alphabetical (A → Z)",
+				"alphaDesc": "Alphabetical (Z → A)",
+				"priceAsc": "Price (low → high)",
+				"priceDesc": "Price (high → low)",
+				"createdAsc": "Oldest first",
+				"createdDesc": "Newest first"
+			}
+		},
+		"filters": {
+			"price": {
+				"minLabel": "Min price",
+				"maxLabel": "Max price"
+			},
+			"stock": {
+				"label": "In stock only"
+			},
+			"tag": {
+				"label": "Tag"
+			}
+		},
+		"view": {
+			"grid": "Grid view",
+			"list": "List view"
+		},
+		"pagination": {
+			"loadMore": "Load more",
+			"prev": "Previous",
+			"next": "Next"
+		},
+		"empty": {
+			"title": "No products match your search.",
+			"reset": "Reset"
+		},
+		"disabledNotice": "This searchlist is disabled and not visible to the public."
+	},
 	"subscription": {
 		"associated": {
 			"title": "Associated to:",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -946,6 +946,51 @@
 		"subscribeCTA": "Suscribir",
 		"uniqueDateText": "- De {beginTime}"
 	},
+	"searchlist": {
+		"searchbar": {
+			"label": "Búsqueda",
+			"placeholder": "Buscar producto por nombre",
+			"submit": "Buscar",
+			"reset": "Reiniciar"
+		},
+		"sort": {
+			"label": "Ordenar por",
+			"options": {
+				"alphaAsc": "Alfabético (A → Z)",
+				"alphaDesc": "Alfabético (Z → A)",
+				"priceAsc": "Precio (ascendente)",
+				"priceDesc": "Precio (descendente)",
+				"createdAsc": "Más antiguos primero",
+				"createdDesc": "Más recientes primero"
+			}
+		},
+		"filters": {
+			"price": {
+				"minLabel": "Precio mínimo",
+				"maxLabel": "Precio máximo"
+			},
+			"stock": {
+				"label": "Solo en stock"
+			},
+			"tag": {
+				"label": "Tag"
+			}
+		},
+		"view": {
+			"grid": "Vista cuadrícula",
+			"list": "Vista lista"
+		},
+		"pagination": {
+			"loadMore": "Cargar más",
+			"prev": "Anterior",
+			"next": "Siguiente"
+		},
+		"empty": {
+			"title": "Ningún producto coincide con tu búsqueda.",
+			"reset": "Reiniciar"
+		},
+		"disabledNotice": "Esta searchlist está desactivada y no es visible para el público."
+	},
 	"subscription": {
 		"associated": {
 			"npub": "Asociado a la npub: {npub}",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -946,6 +946,51 @@
 		"subscribeCTA": "S'abonner",
 		"uniqueDateText": "- Dés {beginTime}"
 	},
+	"searchlist": {
+		"searchbar": {
+			"label": "Recherche",
+			"placeholder": "Rechercher un produit par nom",
+			"submit": "Rechercher",
+			"reset": "Réinitialiser"
+		},
+		"sort": {
+			"label": "Trier par",
+			"options": {
+				"alphaAsc": "Alphabétique (A → Z)",
+				"alphaDesc": "Alphabétique (Z → A)",
+				"priceAsc": "Prix (croissant)",
+				"priceDesc": "Prix (décroissant)",
+				"createdAsc": "Plus anciens",
+				"createdDesc": "Plus récents"
+			}
+		},
+		"filters": {
+			"price": {
+				"minLabel": "Prix minimum",
+				"maxLabel": "Prix maximum"
+			},
+			"stock": {
+				"label": "En stock uniquement"
+			},
+			"tag": {
+				"label": "Tag"
+			}
+		},
+		"view": {
+			"grid": "Vue grille",
+			"list": "Vue liste"
+		},
+		"pagination": {
+			"loadMore": "Voir plus",
+			"prev": "Précédent",
+			"next": "Suivant"
+		},
+		"empty": {
+			"title": "Aucun produit ne correspond à votre recherche.",
+			"reset": "Réinitialiser"
+		},
+		"disabledNotice": "Cette searchlist est désactivée et non visible par le grand public."
+	},
 	"subscription": {
 		"associated": {
 			"npub": "Associé à npub : {npub}",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -946,6 +946,51 @@
 		"subscribeCTA": "Iscriviti",
 		"uniqueDateText": "- Da {beginTime}"
 	},
+	"searchlist": {
+		"searchbar": {
+			"label": "Ricerca",
+			"placeholder": "Cerca un prodotto per nome",
+			"submit": "Cerca",
+			"reset": "Reimposta"
+		},
+		"sort": {
+			"label": "Ordina per",
+			"options": {
+				"alphaAsc": "Alfabetico (A → Z)",
+				"alphaDesc": "Alfabetico (Z → A)",
+				"priceAsc": "Prezzo (crescente)",
+				"priceDesc": "Prezzo (decrescente)",
+				"createdAsc": "Meno recenti prima",
+				"createdDesc": "Più recenti prima"
+			}
+		},
+		"filters": {
+			"price": {
+				"minLabel": "Prezzo minimo",
+				"maxLabel": "Prezzo massimo"
+			},
+			"stock": {
+				"label": "Solo disponibili"
+			},
+			"tag": {
+				"label": "Tag"
+			}
+		},
+		"view": {
+			"grid": "Vista a griglia",
+			"list": "Vista a lista"
+		},
+		"pagination": {
+			"loadMore": "Carica altro",
+			"prev": "Precedente",
+			"next": "Successivo"
+		},
+		"empty": {
+			"title": "Nessun prodotto corrisponde alla tua ricerca.",
+			"reset": "Reimposta"
+		},
+		"disabledNotice": "Questa searchlist è disattivata e non è visibile al pubblico."
+	},
 	"subscription": {
 		"associated": {
 			"npub": "Associato a npub: {npub}",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -946,6 +946,51 @@
 		"subscribeCTA": "Abonneren",
 		"uniqueDateText": "- van {beginTime}"
 	},
+	"searchlist": {
+		"searchbar": {
+			"label": "Zoeken",
+			"placeholder": "Zoek een product op naam",
+			"submit": "Zoeken",
+			"reset": "Resetten"
+		},
+		"sort": {
+			"label": "Sorteren op",
+			"options": {
+				"alphaAsc": "Alfabetisch (A → Z)",
+				"alphaDesc": "Alfabetisch (Z → A)",
+				"priceAsc": "Prijs (oplopend)",
+				"priceDesc": "Prijs (aflopend)",
+				"createdAsc": "Oudste eerst",
+				"createdDesc": "Nieuwste eerst"
+			}
+		},
+		"filters": {
+			"price": {
+				"minLabel": "Minimumprijs",
+				"maxLabel": "Maximumprijs"
+			},
+			"stock": {
+				"label": "Alleen op voorraad"
+			},
+			"tag": {
+				"label": "Tag"
+			}
+		},
+		"view": {
+			"grid": "Rasterweergave",
+			"list": "Lijstweergave"
+		},
+		"pagination": {
+			"loadMore": "Meer laden",
+			"prev": "Vorige",
+			"next": "Volgende"
+		},
+		"empty": {
+			"title": "Geen producten komen overeen met uw zoekopdracht.",
+			"reset": "Resetten"
+		},
+		"disabledNotice": "Deze searchlist is uitgeschakeld en niet zichtbaar voor het publiek."
+	},
 	"subscription": {
 		"associated": {
 			"npub": "Geassocieerd met npub: {npub}",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -946,6 +946,51 @@
 		"subscribeCTA": "Subscrever",
 		"uniqueDateText": " - a partir das {beginTime}"
 	},
+	"searchlist": {
+		"searchbar": {
+			"label": "Pesquisa",
+			"placeholder": "Pesquisar produto por nome",
+			"submit": "Pesquisar",
+			"reset": "Repor"
+		},
+		"sort": {
+			"label": "Ordenar por",
+			"options": {
+				"alphaAsc": "Alfabético (A → Z)",
+				"alphaDesc": "Alfabético (Z → A)",
+				"priceAsc": "Preço (crescente)",
+				"priceDesc": "Preço (decrescente)",
+				"createdAsc": "Mais antigos primeiro",
+				"createdDesc": "Mais recentes primeiro"
+			}
+		},
+		"filters": {
+			"price": {
+				"minLabel": "Preço mínimo",
+				"maxLabel": "Preço máximo"
+			},
+			"stock": {
+				"label": "Apenas em stock"
+			},
+			"tag": {
+				"label": "Tag"
+			}
+		},
+		"view": {
+			"grid": "Vista em grelha",
+			"list": "Vista em lista"
+		},
+		"pagination": {
+			"loadMore": "Carregar mais",
+			"prev": "Anterior",
+			"next": "Seguinte"
+		},
+		"empty": {
+			"title": "Nenhum produto corresponde à sua pesquisa.",
+			"reset": "Repor"
+		},
+		"disabledNotice": "Esta searchlist está desativada e não é visível para o público."
+	},
 	"subscription": {
 		"associated": {
 			"title": "Associado a:",

--- a/src/lib/types/Searchlist.ts
+++ b/src/lib/types/Searchlist.ts
@@ -1,0 +1,91 @@
+import type { Timestamps } from './Timestamps';
+
+export const SORT_KEYS = [
+	'alphaAsc',
+	'alphaDesc',
+	'priceAsc',
+	'priceDesc',
+	'createdAsc',
+	'createdDesc'
+] as const;
+export type SortKey = (typeof SORT_KEYS)[number];
+
+export const SEARCH_TARGET_KEYS = [
+	'title',
+	'shortDescription',
+	'longDescription',
+	'productTags',
+	'productVariation',
+	'productCustomCta',
+	'productCmsBefore',
+	'productCmsAfter'
+] as const;
+export type SearchTargetKey = (typeof SEARCH_TARGET_KEYS)[number];
+
+export const PAGINATION_MODES = ['classic', 'loadMore', 'infinite'] as const;
+export type PaginationMode = (typeof PAGINATION_MODES)[number];
+
+export const VIEW_MODES = ['grid', 'list'] as const;
+export type ViewMode = (typeof VIEW_MODES)[number];
+
+export type Searchlist = Timestamps & {
+	_id: string;
+	name: string;
+
+	/**
+	 * When true, /searchlist/{slug} returns 404 to the public and CMS embeds
+	 * skip the widget. Employees still see both with a "disabled" banner.
+	 */
+	disabled?: boolean;
+
+	displayWidgetName: boolean;
+	hideSearchbar: boolean;
+	prefillSearchterm: boolean;
+	initialSearchterm?: string;
+	hideSearchterm: boolean;
+
+	searchTargets: Record<SearchTargetKey, boolean>;
+
+	filters: {
+		price: {
+			enabled: boolean;
+			defaultMin?: number;
+			defaultMax?: number;
+		};
+		stock: {
+			enabled: boolean;
+			defaultChecked: boolean;
+		};
+		tags: {
+			enabled: boolean;
+			allowedTagIds: string[];
+		};
+	};
+
+	sort: {
+		displayed: boolean;
+		options: SortKey[];
+		default: SortKey;
+	};
+
+	view: {
+		default: ViewMode;
+		hideToggle: boolean;
+	};
+
+	pagination: {
+		mode: PaginationMode;
+		perPage: number;
+	};
+};
+
+export const DEFAULT_SEARCH_TARGETS: Record<SearchTargetKey, boolean> = {
+	title: true,
+	shortDescription: true,
+	longDescription: true,
+	productTags: false,
+	productVariation: false,
+	productCustomCta: false,
+	productCmsBefore: false,
+	productCmsAfter: false
+};

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -25,6 +25,7 @@
 		countdowns={data.cmsData.countdowns}
 		galleries={data.cmsData.galleries}
 		leaderboards={data.cmsData.leaderboards}
+		searchlists={data.cmsData.searchlists}
 		schedules={data.cmsData.schedules}
 	/>
 {:else}

--- a/src/routes/(app)/[slug]/+page.svelte
+++ b/src/routes/(app)/[slug]/+page.svelte
@@ -23,5 +23,6 @@
 	countdowns={data.cmsData.countdowns}
 	galleries={data.cmsData.galleries}
 	leaderboards={data.cmsData.leaderboards}
+	searchlists={data.cmsData.searchlists}
 	schedules={data.cmsData.schedules}
 />

--- a/src/routes/(app)/[slug]/[sub]/[...catchall]/+page.svelte
+++ b/src/routes/(app)/[slug]/[sub]/[...catchall]/+page.svelte
@@ -23,5 +23,6 @@
 	countdowns={data.cmsData.countdowns}
 	galleries={data.cmsData.galleries}
 	leaderboards={data.cmsData.leaderboards}
+	searchlists={data.cmsData.searchlists}
 	schedules={data.cmsData.schedules}
 />

--- a/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
@@ -232,6 +232,10 @@ export const adminLinks: AdminLinks = [
 			{
 				href: '/admin/leaderboard',
 				label: 'Leaderboards'
+			},
+			{
+				href: '/admin/searchlist',
+				label: 'Searchlists'
 			}
 		]
 	}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/+page.server.ts
@@ -1,0 +1,11 @@
+import { collections } from '$lib/server/database';
+
+export const load = async () => {
+	const searchlists = await collections.searchlists
+		.find({})
+		.sort({ updatedAt: -1 })
+		.project<{ _id: string; name: string; disabled?: boolean }>({ _id: 1, name: 1, disabled: 1 })
+		.toArray();
+
+	return { searchlists };
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	export let data;
+</script>
+
+<a href="{data.adminPrefix}/searchlist/new" class="underline block">Add searchlist</a>
+
+<h1 class="text-3xl">List of searchlists</h1>
+<ul>
+	{#each data.searchlists as searchlist}
+		<li>
+			<a href="{data.adminPrefix}/searchlist/{searchlist._id}" class="underline text-blue">
+				{searchlist.name}
+			</a>
+			{#if searchlist.disabled}
+				<span class="text-xs bg-gray-500 text-white px-2 py-0.5 rounded ml-1">Disabled</span>
+			{/if}
+			-
+			<span class="text-gray-550">[Searchlist={searchlist._id}]</span>
+		</li>
+	{:else}
+		No searchlists yet
+	{/each}
+</ul>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/[id]/+page.server.ts
@@ -1,0 +1,172 @@
+import { collections } from '$lib/server/database';
+import { error, redirect, type Actions } from '@sveltejs/kit';
+import { z } from 'zod';
+import { adminPrefix } from '$lib/server/admin';
+import type { Tag } from '$lib/types/Tag';
+import {
+	SORT_KEYS,
+	PAGINATION_MODES,
+	VIEW_MODES,
+	SEARCH_TARGET_KEYS,
+	type SearchTargetKey
+} from '$lib/types/Searchlist';
+
+export const load = async ({ params }) => {
+	const searchlist = await collections.searchlists.findOne({ _id: params.id });
+	if (!searchlist) {
+		throw error(404, 'Searchlist not found');
+	}
+	const tags = await collections.tags
+		.find({})
+		.project<Pick<Tag, '_id' | 'name'>>({ _id: 1, name: 1 })
+		.toArray();
+	return { searchlist, tags };
+};
+
+function parseTagIds(raw: FormDataEntryValue | null): string[] {
+	if (!raw) {
+		return [];
+	}
+	try {
+		const parsed = JSON.parse(String(raw)) as Array<{ value: string }>;
+		return parsed.map((x) => String(x.value));
+	} catch {
+		return [];
+	}
+}
+
+const updateSchema = z.object({
+	name: z.string().min(1).max(100),
+	disabled: z.boolean({ coerce: true }).default(false),
+	displayWidgetName: z.boolean({ coerce: true }).default(false),
+	hideSearchbar: z.boolean({ coerce: true }).default(false),
+	prefillSearchterm: z.boolean({ coerce: true }).default(false),
+	initialSearchterm: z.string().max(200).optional(),
+	hideSearchterm: z.boolean({ coerce: true }).default(false),
+	priceEnabled: z.boolean({ coerce: true }).default(false),
+	priceDefaultMin: z
+		.string()
+		.optional()
+		.transform((v) => (v === '' || v === undefined ? undefined : Number(v))),
+	priceDefaultMax: z
+		.string()
+		.optional()
+		.transform((v) => (v === '' || v === undefined ? undefined : Number(v))),
+	stockEnabled: z.boolean({ coerce: true }).default(false),
+	stockDefaultChecked: z.boolean({ coerce: true }).default(false),
+	tagsEnabled: z.boolean({ coerce: true }).default(false),
+	sortDisplayed: z.boolean({ coerce: true }).default(false),
+	sortDefault: z.enum(SORT_KEYS),
+	viewDefault: z.enum(VIEW_MODES),
+	viewHideToggle: z.boolean({ coerce: true }).default(false),
+	paginationMode: z.enum(PAGINATION_MODES),
+	paginationPerPage: z
+		.string()
+		.transform((v) => Number(v))
+		.refine((n) => Number.isFinite(n) && n >= 1, { message: 'must be ≥ 1' })
+});
+
+export const actions: Actions = {
+	update: async ({ request, params }) => {
+		const data = await request.formData();
+		const sortOptions = data.getAll('sortOptions').map(String);
+		const targetsRaw = data.getAll('searchTarget').map(String);
+		const allowedTagIds = parseTagIds(data.get('allowedTagIds'));
+
+		const parsed = updateSchema.parse({
+			name: data.get('name'),
+			disabled: data.get('disabled'),
+			displayWidgetName: data.get('displayWidgetName'),
+			hideSearchbar: data.get('hideSearchbar'),
+			prefillSearchterm: data.get('prefillSearchterm'),
+			initialSearchterm: data.get('initialSearchterm') ?? undefined,
+			hideSearchterm: data.get('hideSearchterm'),
+			priceEnabled: data.get('priceEnabled'),
+			priceDefaultMin: data.get('priceDefaultMin') ?? undefined,
+			priceDefaultMax: data.get('priceDefaultMax') ?? undefined,
+			stockEnabled: data.get('stockEnabled'),
+			stockDefaultChecked: data.get('stockDefaultChecked'),
+			tagsEnabled: data.get('tagsEnabled'),
+			sortDisplayed: data.get('sortDisplayed'),
+			sortDefault: data.get('sortDefault'),
+			viewDefault: data.get('viewDefault'),
+			viewHideToggle: data.get('viewHideToggle'),
+			paginationMode: data.get('paginationMode'),
+			paginationPerPage: data.get('paginationPerPage')
+		});
+
+		const validSortOptions = SORT_KEYS.filter((k) => sortOptions.includes(k));
+		if (validSortOptions.length === 0) {
+			throw error(400, 'At least one sort option must be selected');
+		}
+		if (!validSortOptions.includes(parsed.sortDefault)) {
+			throw error(400, 'Default sort option must be among the selected options');
+		}
+
+		const searchTargets = Object.fromEntries(
+			SEARCH_TARGET_KEYS.map((k) => [k, targetsRaw.includes(k)])
+		) as Record<SearchTargetKey, boolean>;
+
+		const $set: Record<string, unknown> = {
+			name: parsed.name,
+			disabled: parsed.disabled,
+			displayWidgetName: parsed.displayWidgetName,
+			hideSearchbar: parsed.hideSearchbar,
+			prefillSearchterm: parsed.prefillSearchterm,
+			hideSearchterm: parsed.hideSearchterm,
+			searchTargets,
+			filters: {
+				price: {
+					enabled: parsed.priceEnabled,
+					...(parsed.priceDefaultMin !== undefined &&
+						Number.isFinite(parsed.priceDefaultMin) && {
+							defaultMin: parsed.priceDefaultMin
+						}),
+					...(parsed.priceDefaultMax !== undefined &&
+						Number.isFinite(parsed.priceDefaultMax) && {
+							defaultMax: parsed.priceDefaultMax
+						})
+				},
+				stock: {
+					enabled: parsed.stockEnabled,
+					defaultChecked: parsed.stockDefaultChecked
+				},
+				tags: {
+					enabled: parsed.tagsEnabled,
+					allowedTagIds
+				}
+			},
+			sort: {
+				displayed: parsed.sortDisplayed,
+				options: validSortOptions,
+				default: parsed.sortDefault
+			},
+			view: {
+				default: parsed.viewDefault,
+				hideToggle: parsed.viewHideToggle
+			},
+			pagination: {
+				mode: parsed.paginationMode,
+				perPage: parsed.paginationPerPage
+			},
+			updatedAt: new Date()
+		};
+		const update: Record<string, unknown> = { $set };
+		if (parsed.initialSearchterm) {
+			$set.initialSearchterm = parsed.initialSearchterm;
+		} else {
+			update.$unset = { initialSearchterm: '' };
+		}
+
+		await collections.searchlists.updateOne({ _id: params.id }, update);
+
+		throw redirect(303, `${adminPrefix()}/searchlist/${params.id}`);
+	},
+	delete: async ({ params }) => {
+		if (params.id === 'default' || params.id === 'search') {
+			throw error(400, `The "${params.id}" searchlist cannot be deleted`);
+		}
+		await collections.searchlists.deleteOne({ _id: params.id });
+		throw redirect(303, `${adminPrefix()}/searchlist`);
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/[id]/+page.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+	import MultiSelect from 'svelte-multiselect';
+	import {
+		SORT_KEYS,
+		PAGINATION_MODES,
+		VIEW_MODES,
+		SEARCH_TARGET_KEYS
+	} from '$lib/types/Searchlist';
+	import { currencies } from '$lib/stores/currencies';
+	import { CURRENCY_UNIT } from '$lib/types/Currency';
+
+	export let data;
+	const sl = data.searchlist;
+
+	$: priceStep = CURRENCY_UNIT[$currencies.main];
+
+	let name = sl.name;
+	let displayWidgetName = sl.displayWidgetName ?? false;
+	let hideSearchbar = sl.hideSearchbar;
+	let prefillSearchterm = sl.prefillSearchterm;
+	let initialSearchterm = sl.initialSearchterm ?? '';
+	let hideSearchterm = sl.hideSearchterm;
+
+	let searchTargets: Record<string, boolean> = { ...sl.searchTargets };
+
+	let priceEnabled = sl.filters.price.enabled;
+	let priceDefaultMin = sl.filters.price.defaultMin ?? '';
+	let priceDefaultMax = sl.filters.price.defaultMax ?? '';
+	let stockEnabled = sl.filters.stock.enabled;
+	let stockDefaultChecked = sl.filters.stock.defaultChecked;
+	let tagsEnabled = sl.filters.tags?.enabled ?? false;
+	const initialAllowedTagIds = sl.filters.tags?.allowedTagIds ?? [];
+
+	let sortDisplayed = sl.sort.displayed;
+	let sortOptions: Record<string, boolean> = Object.fromEntries(
+		SORT_KEYS.map((k) => [k, sl.sort.options.includes(k)])
+	);
+	let sortDefault = sl.sort.default;
+
+	let viewDefault = sl.view.default;
+	let viewHideToggle = sl.view.hideToggle;
+
+	let paginationMode = sl.pagination.mode;
+	let paginationPerPage = sl.pagination.perPage;
+
+	let disabled = sl.disabled ?? false;
+</script>
+
+<h1 class="text-3xl">Edit searchlist — <span class="text-gray-550">[Searchlist={sl._id}]</span></h1>
+
+<form method="post" class="flex flex-col gap-4">
+	<label class="form-label">
+		Searchlist name
+		<input class="form-input" type="text" name="name" bind:value={name} required maxlength="100" />
+	</label>
+
+	<label class="checkbox-label">
+		<input type="checkbox" class="form-checkbox" name="disabled" bind:checked={disabled} />
+		Disable this searchlist (returns 404 to the public, employees still see a banner)
+	</label>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="displayWidgetName"
+			bind:checked={displayWidgetName}
+		/>
+		Display widget name
+	</label>
+
+	<h2 class="text-2xl">Search input</h2>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="hideSearchbar"
+			bind:checked={hideSearchbar}
+		/>
+		Hide searchbar
+	</label>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="prefillSearchterm"
+			bind:checked={prefillSearchterm}
+		/>
+		Prefill searchterm
+	</label>
+
+	{#if prefillSearchterm}
+		<label class="form-label">
+			Initial searchterm
+			<input
+				class="form-input"
+				type="text"
+				name="initialSearchterm"
+				bind:value={initialSearchterm}
+				maxlength="200"
+			/>
+		</label>
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="hideSearchterm"
+				bind:checked={hideSearchterm}
+			/>
+			Hide searchterm (a new search will override it)
+		</label>
+	{/if}
+
+	<h2 class="text-2xl">Search input target</h2>
+	{#each SEARCH_TARGET_KEYS as key}
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="searchTarget"
+				value={key}
+				bind:checked={searchTargets[key]}
+			/>
+			{key}
+			{#if key === 'productTags' || key === 'productVariation'}
+				<span class="text-gray-550">(not honored in V1)</span>
+			{/if}
+		</label>
+	{/each}
+
+	<h2 class="text-2xl">Filters</h2>
+	<label class="checkbox-label">
+		<input type="checkbox" class="form-checkbox" name="priceEnabled" bind:checked={priceEnabled} />
+		Price filter
+	</label>
+	{#if priceEnabled}
+		<div class="flex gap-4 flex-wrap">
+			<label class="form-label">
+				Default min ({$currencies.main})
+				<input
+					class="form-input"
+					type="number"
+					name="priceDefaultMin"
+					bind:value={priceDefaultMin}
+					on:wheel|preventDefault
+					min="0"
+					step={priceStep}
+				/>
+			</label>
+			<label class="form-label">
+				Default max ({$currencies.main})
+				<input
+					class="form-input"
+					type="number"
+					name="priceDefaultMax"
+					bind:value={priceDefaultMax}
+					on:wheel|preventDefault
+					min="0"
+					step={priceStep}
+				/>
+			</label>
+		</div>
+	{/if}
+
+	<label class="checkbox-label">
+		<input type="checkbox" class="form-checkbox" name="stockEnabled" bind:checked={stockEnabled} />
+		Stock filter (in stock only)
+	</label>
+	{#if stockEnabled}
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="stockDefaultChecked"
+				bind:checked={stockDefaultChecked}
+			/>
+			Default "in stock only" checked
+		</label>
+	{/if}
+
+	<label class="checkbox-label">
+		<input type="checkbox" class="form-checkbox" name="tagsEnabled" bind:checked={tagsEnabled} />
+		Tag filter
+	</label>
+	{#if tagsEnabled}
+		<!-- svelte-ignore a11y-label-has-associated-control -->
+		<label class="form-label">
+			Tags to expose
+			<MultiSelect
+				--sms-options-bg="var(--body-mainPlan-backgroundColor)"
+				name="allowedTagIds"
+				options={data.tags.map((tag) => ({ value: tag._id, label: tag.name }))}
+				selected={initialAllowedTagIds.map((tagId) => ({
+					value: tagId,
+					label: data.tags.find((tag) => tag._id === tagId)?.name ?? tagId
+				}))}
+			/>
+		</label>
+	{/if}
+
+	<h2 class="text-2xl">Sort</h2>
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="sortDisplayed"
+			bind:checked={sortDisplayed}
+		/>
+		Show "Sort by" select
+	</label>
+	{#each SORT_KEYS as key}
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="sortOptions"
+				value={key}
+				bind:checked={sortOptions[key]}
+			/>
+			{key}
+		</label>
+	{/each}
+	<label class="form-label">
+		Default sort
+		<select class="form-input" name="sortDefault" bind:value={sortDefault}>
+			{#each SORT_KEYS as key}
+				<option value={key}>{key}</option>
+			{/each}
+		</select>
+	</label>
+
+	<h2 class="text-2xl">View</h2>
+	<label class="form-label">
+		Default view
+		<select class="form-input" name="viewDefault" bind:value={viewDefault}>
+			{#each VIEW_MODES as v}
+				<option value={v}>{v}</option>
+			{/each}
+		</select>
+	</label>
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="viewHideToggle"
+			bind:checked={viewHideToggle}
+		/>
+		Hide view toggle (force the default view)
+	</label>
+
+	<h2 class="text-2xl">Pagination</h2>
+	<label class="form-label">
+		Mode
+		<select class="form-input" name="paginationMode" bind:value={paginationMode}>
+			{#each PAGINATION_MODES.filter((m) => m !== 'infinite') as m}
+				<option value={m}>{m}</option>
+			{/each}
+		</select>
+	</label>
+	<label class="form-label">
+		Per page
+		<input
+			class="form-input"
+			type="number"
+			name="paginationPerPage"
+			bind:value={paginationPerPage}
+			on:wheel|preventDefault
+			min="1"
+			required
+		/>
+	</label>
+
+	<div class="flex flex-row justify-between gap-2">
+		<input type="submit" class="btn btn-blue text-white" formaction="?/update" value="Update" />
+		<a href="/searchlist/{sl._id}" class="btn body-mainCTA">View</a>
+
+		{#if sl._id !== 'default' && sl._id !== 'search'}
+			<input
+				type="submit"
+				class="btn btn-red text-white ml-auto"
+				formaction="?/delete"
+				value="Delete"
+				on:click={(e) => {
+					if (!confirm('Delete this searchlist?')) {
+						e.preventDefault();
+					}
+				}}
+			/>
+		{/if}
+	</div>
+</form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/new/+page.server.ts
@@ -1,0 +1,162 @@
+import { collections } from '$lib/server/database';
+import { error, redirect, type Actions } from '@sveltejs/kit';
+import { z } from 'zod';
+import { generateId } from '$lib/utils/generateId';
+import { adminPrefix } from '$lib/server/admin';
+import type { Tag } from '$lib/types/Tag';
+import {
+	SORT_KEYS,
+	PAGINATION_MODES,
+	VIEW_MODES,
+	SEARCH_TARGET_KEYS,
+	type SearchTargetKey
+} from '$lib/types/Searchlist';
+
+export const load = async () => {
+	const tags = await collections.tags
+		.find({})
+		.project<Pick<Tag, '_id' | 'name'>>({ _id: 1, name: 1 })
+		.toArray();
+	return { tags };
+};
+
+const schema = z.object({
+	name: z.string().min(1).max(100),
+	slug: z
+		.string()
+		.min(1)
+		.max(100)
+		.regex(/^[a-zA-Z0-9-]+$/),
+	displayWidgetName: z.boolean({ coerce: true }).default(false),
+	hideSearchbar: z.boolean({ coerce: true }).default(false),
+	prefillSearchterm: z.boolean({ coerce: true }).default(false),
+	initialSearchterm: z.string().max(200).optional(),
+	hideSearchterm: z.boolean({ coerce: true }).default(false),
+	priceEnabled: z.boolean({ coerce: true }).default(false),
+	priceDefaultMin: z
+		.string()
+		.optional()
+		.transform((v) => (v === '' || v === undefined ? undefined : Number(v))),
+	priceDefaultMax: z
+		.string()
+		.optional()
+		.transform((v) => (v === '' || v === undefined ? undefined : Number(v))),
+	stockEnabled: z.boolean({ coerce: true }).default(false),
+	stockDefaultChecked: z.boolean({ coerce: true }).default(false),
+	tagsEnabled: z.boolean({ coerce: true }).default(false),
+	sortDisplayed: z.boolean({ coerce: true }).default(false),
+	sortDefault: z.enum(SORT_KEYS),
+	viewDefault: z.enum(VIEW_MODES),
+	viewHideToggle: z.boolean({ coerce: true }).default(false),
+	paginationMode: z.enum(PAGINATION_MODES),
+	paginationPerPage: z
+		.string()
+		.transform((v) => Number(v))
+		.refine((n) => Number.isFinite(n) && n >= 1, { message: 'must be ≥ 1' })
+});
+
+function parseTagIds(raw: FormDataEntryValue | null): string[] {
+	if (!raw) {
+		return [];
+	}
+	try {
+		const parsed = JSON.parse(String(raw)) as Array<{ value: string }>;
+		return parsed.map((x) => String(x.value));
+	} catch {
+		return [];
+	}
+}
+
+export const actions: Actions = {
+	default: async ({ request }) => {
+		const data = await request.formData();
+		const sortOptions = data.getAll('sortOptions').map(String);
+		const targetsRaw = data.getAll('searchTarget').map(String);
+		const allowedTagIds = parseTagIds(data.get('allowedTagIds'));
+
+		const parsed = schema.parse({
+			name: data.get('name'),
+			slug: data.get('slug') || generateId(String(data.get('name') ?? ''), true),
+			displayWidgetName: data.get('displayWidgetName'),
+			hideSearchbar: data.get('hideSearchbar'),
+			prefillSearchterm: data.get('prefillSearchterm'),
+			initialSearchterm: data.get('initialSearchterm') ?? undefined,
+			hideSearchterm: data.get('hideSearchterm'),
+			priceEnabled: data.get('priceEnabled'),
+			priceDefaultMin: data.get('priceDefaultMin') ?? undefined,
+			priceDefaultMax: data.get('priceDefaultMax') ?? undefined,
+			stockEnabled: data.get('stockEnabled'),
+			stockDefaultChecked: data.get('stockDefaultChecked'),
+			tagsEnabled: data.get('tagsEnabled'),
+			sortDisplayed: data.get('sortDisplayed'),
+			sortDefault: data.get('sortDefault'),
+			viewDefault: data.get('viewDefault'),
+			viewHideToggle: data.get('viewHideToggle'),
+			paginationMode: data.get('paginationMode'),
+			paginationPerPage: data.get('paginationPerPage')
+		});
+
+		const validSortOptions = SORT_KEYS.filter((k) => sortOptions.includes(k));
+		if (validSortOptions.length === 0) {
+			throw error(400, 'At least one sort option must be selected');
+		}
+		if (!validSortOptions.includes(parsed.sortDefault)) {
+			throw error(400, 'Default sort option must be among the selected options');
+		}
+
+		const searchTargets = Object.fromEntries(
+			SEARCH_TARGET_KEYS.map((k) => [k, targetsRaw.includes(k)])
+		) as Record<SearchTargetKey, boolean>;
+
+		const existing = await collections.searchlists.findOne({ _id: parsed.slug });
+		if (existing) {
+			throw error(400, `Searchlist with slug "${parsed.slug}" already exists`);
+		}
+
+		const now = new Date();
+		await collections.searchlists.insertOne({
+			_id: parsed.slug,
+			name: parsed.name,
+			displayWidgetName: parsed.displayWidgetName,
+			hideSearchbar: parsed.hideSearchbar,
+			prefillSearchterm: parsed.prefillSearchterm,
+			hideSearchterm: parsed.hideSearchterm,
+			...(parsed.initialSearchterm && { initialSearchterm: parsed.initialSearchterm }),
+			searchTargets,
+			filters: {
+				price: {
+					enabled: parsed.priceEnabled,
+					...(parsed.priceDefaultMin !== undefined &&
+						Number.isFinite(parsed.priceDefaultMin) && { defaultMin: parsed.priceDefaultMin }),
+					...(parsed.priceDefaultMax !== undefined &&
+						Number.isFinite(parsed.priceDefaultMax) && { defaultMax: parsed.priceDefaultMax })
+				},
+				stock: {
+					enabled: parsed.stockEnabled,
+					defaultChecked: parsed.stockDefaultChecked
+				},
+				tags: {
+					enabled: parsed.tagsEnabled,
+					allowedTagIds
+				}
+			},
+			sort: {
+				displayed: parsed.sortDisplayed,
+				options: validSortOptions,
+				default: parsed.sortDefault
+			},
+			view: {
+				default: parsed.viewDefault,
+				hideToggle: parsed.viewHideToggle
+			},
+			pagination: {
+				mode: parsed.paginationMode,
+				perPage: parsed.paginationPerPage
+			},
+			createdAt: now,
+			updatedAt: now
+		});
+
+		throw redirect(303, `${adminPrefix()}/searchlist/${parsed.slug}`);
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/searchlist/new/+page.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+	import MultiSelect from 'svelte-multiselect';
+	import {
+		SORT_KEYS,
+		PAGINATION_MODES,
+		VIEW_MODES,
+		SEARCH_TARGET_KEYS
+	} from '$lib/types/Searchlist';
+	import { generateId } from '$lib/utils/generateId';
+	import { currencies } from '$lib/stores/currencies';
+	import { CURRENCY_UNIT } from '$lib/types/Currency';
+
+	export let data;
+
+	$: priceStep = CURRENCY_UNIT[$currencies.main];
+
+	let name = '';
+	let slug = '';
+	let slugManuallyEdited = false;
+
+	$: if (!slugManuallyEdited) {
+		slug = name ? generateId(name, true) : '';
+	}
+
+	let displayWidgetName = false;
+	let hideSearchbar = false;
+	let prefillSearchterm = false;
+	let initialSearchterm = '';
+	let hideSearchterm = false;
+
+	let searchTargets: Record<string, boolean> = {
+		title: true,
+		shortDescription: true,
+		longDescription: true,
+		productTags: false,
+		productVariation: false,
+		productCustomCta: false,
+		productCmsBefore: false,
+		productCmsAfter: false
+	};
+
+	let priceEnabled = true;
+	let priceDefaultMin = '';
+	let priceDefaultMax = '';
+	let stockEnabled = true;
+	let stockDefaultChecked = false;
+	let tagsEnabled = false;
+
+	let sortDisplayed = true;
+	let sortOptions: Record<string, boolean> = Object.fromEntries(SORT_KEYS.map((k) => [k, true]));
+	let sortDefault = 'alphaAsc';
+
+	let viewDefault = 'grid';
+	let viewHideToggle = false;
+
+	let paginationMode = 'loadMore';
+	let paginationPerPage = 12;
+</script>
+
+<h1 class="text-3xl">Add a searchlist</h1>
+
+<form method="post" class="flex flex-col gap-4">
+	<label class="form-label">
+		Searchlist name
+		<input class="form-input" type="text" name="name" bind:value={name} required maxlength="100" />
+	</label>
+
+	<label class="form-label">
+		Slug
+		<input
+			class="form-input"
+			type="text"
+			name="slug"
+			bind:value={slug}
+			on:input={() => (slugManuallyEdited = true)}
+			required
+			pattern="[a-zA-Z0-9-]+"
+		/>
+	</label>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="displayWidgetName"
+			bind:checked={displayWidgetName}
+		/>
+		Display widget name
+	</label>
+
+	<h2 class="text-2xl">Search input</h2>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="hideSearchbar"
+			bind:checked={hideSearchbar}
+		/>
+		Hide searchbar
+	</label>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="prefillSearchterm"
+			bind:checked={prefillSearchterm}
+		/>
+		Prefill searchterm
+	</label>
+
+	{#if prefillSearchterm}
+		<label class="form-label">
+			Initial searchterm
+			<input
+				class="form-input"
+				type="text"
+				name="initialSearchterm"
+				bind:value={initialSearchterm}
+				maxlength="200"
+			/>
+		</label>
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="hideSearchterm"
+				bind:checked={hideSearchterm}
+			/>
+			Hide searchterm (a new search will override it)
+		</label>
+	{/if}
+
+	<h2 class="text-2xl">Search input target</h2>
+	{#each SEARCH_TARGET_KEYS as key}
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="searchTarget"
+				value={key}
+				bind:checked={searchTargets[key]}
+			/>
+			{key}
+			{#if key === 'productTags' || key === 'productVariation'}
+				<span class="text-gray-550">(not honored in V1)</span>
+			{/if}
+		</label>
+	{/each}
+
+	<h2 class="text-2xl">Filters</h2>
+	<label class="checkbox-label">
+		<input type="checkbox" class="form-checkbox" name="priceEnabled" bind:checked={priceEnabled} />
+		Price filter
+	</label>
+	{#if priceEnabled}
+		<div class="flex gap-4 flex-wrap">
+			<label class="form-label">
+				Default min ({$currencies.main})
+				<input
+					class="form-input"
+					type="number"
+					name="priceDefaultMin"
+					bind:value={priceDefaultMin}
+					min="0"
+					step={priceStep}
+				/>
+			</label>
+			<label class="form-label">
+				Default max ({$currencies.main})
+				<input
+					class="form-input"
+					type="number"
+					name="priceDefaultMax"
+					bind:value={priceDefaultMax}
+					min="0"
+					step={priceStep}
+				/>
+			</label>
+		</div>
+	{/if}
+
+	<label class="checkbox-label">
+		<input type="checkbox" class="form-checkbox" name="stockEnabled" bind:checked={stockEnabled} />
+		Stock filter (in stock only)
+	</label>
+	{#if stockEnabled}
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="stockDefaultChecked"
+				bind:checked={stockDefaultChecked}
+			/>
+			Default "in stock only" checked
+		</label>
+	{/if}
+
+	<label class="checkbox-label">
+		<input type="checkbox" class="form-checkbox" name="tagsEnabled" bind:checked={tagsEnabled} />
+		Tag filter
+	</label>
+	{#if tagsEnabled}
+		<!-- svelte-ignore a11y-label-has-associated-control -->
+		<label class="form-label">
+			Tags to expose
+			<MultiSelect
+				--sms-options-bg="var(--body-mainPlan-backgroundColor)"
+				name="allowedTagIds"
+				options={data.tags.map((tag) => ({ value: tag._id, label: tag.name }))}
+			/>
+		</label>
+	{/if}
+
+	<h2 class="text-2xl">Sort</h2>
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="sortDisplayed"
+			bind:checked={sortDisplayed}
+		/>
+		Show "Sort by" select
+	</label>
+	{#each SORT_KEYS as key}
+		<label class="checkbox-label">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="sortOptions"
+				value={key}
+				bind:checked={sortOptions[key]}
+			/>
+			{key}
+		</label>
+	{/each}
+	<label class="form-label">
+		Default sort
+		<select class="form-input" name="sortDefault" bind:value={sortDefault}>
+			{#each SORT_KEYS as key}
+				<option value={key}>{key}</option>
+			{/each}
+		</select>
+	</label>
+
+	<h2 class="text-2xl">View</h2>
+	<label class="form-label">
+		Default view
+		<select class="form-input" name="viewDefault" bind:value={viewDefault}>
+			{#each VIEW_MODES as v}
+				<option value={v}>{v}</option>
+			{/each}
+		</select>
+	</label>
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
+			class="form-checkbox"
+			name="viewHideToggle"
+			bind:checked={viewHideToggle}
+		/>
+		Hide view toggle (force the default view)
+	</label>
+
+	<h2 class="text-2xl">Pagination</h2>
+	<label class="form-label">
+		Mode
+		<select class="form-input" name="paginationMode" bind:value={paginationMode}>
+			{#each PAGINATION_MODES.filter((m) => m !== 'infinite') as m}
+				<option value={m}>{m}</option>
+			{/each}
+		</select>
+	</label>
+	<label class="form-label">
+		Per page
+		<input
+			class="form-input"
+			type="number"
+			name="paginationPerPage"
+			bind:value={paginationPerPage}
+			min="1"
+			required
+		/>
+	</label>
+
+	<input type="submit" class="btn btn-blue self-start text-white" value="Submit" />
+</form>

--- a/src/routes/(app)/cart/+page.svelte
+++ b/src/routes/(app)/cart/+page.svelte
@@ -69,6 +69,7 @@
 			countdowns={data.cmsBasketTopData.countdowns}
 			galleries={data.cmsBasketTopData.galleries}
 			leaderboards={data.cmsBasketTopData.leaderboards}
+			searchlists={data.cmsBasketTopData.searchlists}
 			schedules={data.cmsBasketTopData.schedules}
 			class={data.hideCmsZonesOnMobile ? 'prose max-w-full hidden lg:contents' : 'prose max-w-full'}
 		/>
@@ -569,6 +570,7 @@
 			countdowns={data.cmsBasketBottomData.countdowns}
 			galleries={data.cmsBasketBottomData.galleries}
 			leaderboards={data.cmsBasketBottomData.leaderboards}
+			searchlists={data.cmsBasketBottomData.searchlists}
 			schedules={data.cmsBasketBottomData.schedules}
 			class={data.hideCmsZonesOnMobile ? 'prose max-w-full hidden lg:contents' : 'prose max-w-full'}
 		/>

--- a/src/routes/(app)/product/[id]/+layout.svelte
+++ b/src/routes/(app)/product/[id]/+layout.svelte
@@ -22,6 +22,7 @@
 		countdowns={data.cmsData.countdowns}
 		galleries={data.cmsData.galleries}
 		leaderboards={data.cmsData.leaderboards}
+		searchlists={data.cmsData.searchlists}
 		schedules={data.cmsData.schedules}
 	/>{:else}
 	<slot />

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -501,6 +501,7 @@
 			countdowns={data.productCMSBefore.countdowns}
 			galleries={data.productCMSBefore.galleries}
 			leaderboards={data.productCMSBefore.leaderboards}
+			searchlists={data.productCMSBefore.searchlists}
 			schedules={data.productCMSBefore.schedules}
 			class={data.product.mobile?.hideContentBefore || data.hideCmsZonesOnMobile
 				? 'prose max-w-full hidden lg:block'
@@ -1142,6 +1143,7 @@
 			countdowns={data.productCMSAfter.countdowns}
 			galleries={data.productCMSAfter.galleries}
 			leaderboards={data.productCMSAfter.leaderboards}
+			searchlists={data.productCMSAfter.searchlists}
 			schedules={data.productCMSAfter.schedules}
 			class={data.product.mobile?.hideContentAfter || data.hideCmsZonesOnMobile
 				? 'prose max-w-full hidden lg:block'

--- a/src/routes/(app)/searchlist/[slug]/+page.server.ts
+++ b/src/routes/(app)/searchlist/[slug]/+page.server.ts
@@ -1,0 +1,102 @@
+import { error } from '@sveltejs/kit';
+import { collections } from '$lib/server/database';
+import { readUrlState, searchProducts, type VatContext } from '$lib/server/searchlist';
+import type { Picture } from '$lib/types/Picture';
+import type { Tag } from '$lib/types/Tag';
+import type { VatProfile } from '$lib/types/VatProfile';
+import { runtimeConfig } from '$lib/server/runtime-config';
+import { rateLimit } from '$lib/server/rateLimit';
+import { CUSTOMER_ROLE_ID } from '$lib/types/User';
+
+export const load = async ({ params, url, locals }) => {
+	// hooks.server.ts only rate-limits mutating methods (POST/PUT/PATCH/DELETE);
+	// the searchlist GET is otherwise unprotected against scraping / regex-scan abuse.
+	rateLimit(locals.clientIp, 'searchlist', 120, { minutes: 1 });
+
+	const searchlist = await collections.searchlists.findOne({ _id: params.slug });
+	if (!searchlist) {
+		throw error(404, 'Searchlist not found');
+	}
+
+	const isEmployee = locals.user?.roleId !== undefined && locals.user.roleId !== CUSTOMER_ROLE_ID;
+	if (searchlist.disabled && !isEmployee) {
+		throw error(404, 'Searchlist not found');
+	}
+
+	const state = readUrlState(url, searchlist);
+
+	const vatProfiles = await collections.vatProfiles
+		.find({})
+		.project<Pick<VatProfile, '_id' | 'rates'>>({ _id: 1, rates: 1 })
+		.map((p) => ({ _id: p._id.toString(), rates: p.rates }))
+		.toArray();
+	const vatContext: VatContext = {
+		vatProfiles,
+		bebopCountry: runtimeConfig.vatCountry,
+		userCountry: locals.countryCode,
+		vatSingleCountry: runtimeConfig.vatSingleCountry,
+		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
+	};
+
+	const { products, total, totalPages } = await searchProducts(
+		searchlist,
+		state,
+		locals,
+		vatContext
+	);
+
+	const productIds = products.map((p) => p._id);
+	const pictures = productIds.length
+		? await collections.pictures
+				.find({ productId: { $in: productIds } })
+				.sort({ order: 1, createdAt: 1 })
+				.toArray()
+		: [];
+
+	const picturesByProductId: Record<string, Picture[]> = {};
+	for (const pic of pictures) {
+		const pid = pic.productId;
+		if (!pid) {
+			continue;
+		}
+		(picturesByProductId[pid] ||= []).push(pic);
+	}
+
+	const digitalFiles = productIds.length
+		? await collections.digitalFiles
+				.find({ productId: { $in: productIds } })
+				.project<{ productId: string }>({ productId: 1, _id: 0 })
+				.toArray()
+		: [];
+	const digitalFilesByProductId: Record<string, boolean> = {};
+	for (const df of digitalFiles) {
+		if (df.productId) {
+			digitalFilesByProductId[df.productId] = true;
+		}
+	}
+
+	const allowedTagIds = searchlist.filters.tags?.allowedTagIds ?? [];
+	const allowedTags =
+		searchlist.filters.tags?.enabled && allowedTagIds.length > 0
+			? await collections.tags
+					.find({ _id: { $in: allowedTagIds } })
+					.project<Pick<Tag, '_id' | 'name'>>({
+						_id: 1,
+						name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] }
+					})
+					.toArray()
+			: [];
+
+	return {
+		searchlist,
+		state,
+		products,
+		picturesByProductId,
+		digitalFilesByProductId,
+		total,
+		totalPages,
+		allowedTags,
+		basePath: `/searchlist/${params.slug}`,
+		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
+	};
+};

--- a/src/routes/(app)/searchlist/[slug]/+page.svelte
+++ b/src/routes/(app)/searchlist/[slug]/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import Searchlist from '$lib/components/Searchlist.svelte';
+
+	export let data;
+</script>
+
+<svelte:head>
+	<title>{data.searchlist.name}</title>
+</svelte:head>
+
+<main class="mx-auto max-w-7xl flex flex-col gap-4 px-6 py-10 body-mainPlan">
+	{#if data.searchlist.displayWidgetName}
+		<h1 class="page-title body-title">{data.searchlist.name}</h1>
+	{/if}
+	<Searchlist
+		searchlist={data.searchlist}
+		state={data.state}
+		products={data.products}
+		picturesByProductId={data.picturesByProductId}
+		digitalFilesByProductId={data.digitalFilesByProductId}
+		hasPosOptions={!!data.hasPosOptions}
+		total={data.total}
+		totalPages={data.totalPages}
+		basePath={data.basePath}
+		allowedTags={data.allowedTags}
+		displayVatIncluded={data.displayVatIncluded}
+	/>
+</main>


### PR DESCRIPTION
## Summary

Closes #1787.

Adds a **Searchlist** widget : an admin-configurable facet engine over products that unifies product lists, search engines, and rayon-style displays under a single entity.

A `default` searchlist is seeded automatically, protected from deletion, and re-created on boot if the document is removed from Mongo.

## Customer-facing

On `/searchlist/{slug}` :

- Optional searchbar with magnifier (Enter / 🔍 submit) and brush (🧹 reset to admin defaults)
- Optional sort, price min/max, "in stock only", tag dropdown
- `tag:slug` syntax in the searchbar — applies the slug as-is (no curation gate), `0` results if the slug doesn't exist
- Grid view (2 cols mobile → 4 cols desktop) or list view, with optional toggle
- Pagination : classic / Load more / **true infinite scroll** (IntersectionObserver on a sentinel)
- URL state (`q`, `pmin`, `pmax`, `stock`, `tag`, `sort`, `view`, `page`) — shareable, refresh-safe, back-button friendly
- Empty state with a Reset CTA when no result matches

When every interactive control is disabled (searchbar + filters + sort + view toggle), the form (🔍/🧹) is also hidden — the searchlist renders as a clean product list.

## Admin

`/admin/searchlist/` (list / new / edit / delete). Per searchlist :

| Section | Knobs |
|---|---|
| Identity | Name + slug (auto-filled, editable, mixed-case accepted) + `Display widget name` |
| Search input | Hide searchbar; prefill an initial term; hide the searchterm even when used |
| Search targets | Product fields the search matches against (title, descriptions, custom CTA, CMS before/after) |
| Filters | Price (default min/max in mainCurrency, step matches display precision); Stock + default-checked; Tag dropdown + curated allowedTagIds |
| Sort | Toggle display; pick exposed options; choose default |
| View | Default view + hide-toggle option |
| Pagination | Mode + items per page |

The `default` searchlist cannot be deleted from the admin UI.

## Currency & VAT

- Price filter bounds (`pmin`/`pmax`) and price sort are interpreted in `mainCurrency`. Products in any currency are converted at query time via a single aggregation pipeline (`_factor` per currency × `_vatMult` per product → `_priceInMain`), with a `$facet` returning products + count in one round-trip.
- When `displayVatIncludedInProduct` is on, displayed prices, the bounds, and the sort all run on TTC values. The per-product VAT rate is resolved from `vatProfiles` + customer country.
- Half-display-unit tolerance on each bound, so a product whose displayed price rounds to the bound (e.g. stored 2.9213 EUR displayed as 2.92) is included.
- Price inputs are constrained to the main currency's display precision via `step` (1 for JPY/XPF/SAT, 0.01 for EUR, 1e-8 for BTC) and clamped on submit.

## CMS embedding

`[Searchlist=slug]` in CMS content now renders the widget **inline** alongside the existing `[Product=…]`, `[Schedule=…]`, etc. tokens. Embedded mode shows the first page only and suppresses every interactive control (`embedded` prop on the Searchlist component), so a CMS-embedded widget never navigates the page away.

## V1 scope

- Products only. `productTags` and `productVariation` admin search-target toggles are exposed but not honored at query time (V2).
- Inline CMS widget renders the first page only; for filters / pagination the user opens `/searchlist/{slug}`.

## i18n

Customer-facing labels added in all 7 supported locales (`en`, `fr`, `de`, `it`, `nl`, `pt`, `es-sv`) under the `searchlist.*` namespace, overridable per-locale through Settings → Languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
