### PR TITLE
🐛🤖 Add show/hide toggle to nsec input in /admin/nostr (#2527)

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/nostr/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/nostr/+page.svelte
@@ -7,6 +7,7 @@
 	let nsecInputEl: HTMLInputElement;
 	let readOnlyForm = data.settingsEnforcedByEnvVars;
 	let writeNsecDisabled = !!data.nostr.privateKey || readOnlyForm;
+	let showNsec = false;
 
 	let relays = data.nostrRelays;
 	let displayPublicMessages = true;
@@ -78,16 +79,28 @@
 <form action="?/updatePrivateKey" method="post" class="flex flex-col gap-4 mb-6">
 	<label class="form-label">
 		Private Key (nsec format)
-		<input
-			bind:this={nsecInputEl}
-			type="password"
-			class="form-input"
-			name="privateKey"
-			bind:value={data.nostr.privateKey}
-			disabled={writeNsecDisabled}
-			required
-			placeholder="nsec1..."
-		/>
+		<div class="flex gap-2 items-center">
+			<input
+				bind:this={nsecInputEl}
+				type={showNsec ? 'text' : 'password'}
+				class="form-input flex-1"
+				name="privateKey"
+				value={data.nostr.privateKey ?? ''}
+				on:input={(e) => (data.nostr.privateKey = e.currentTarget.value)}
+				disabled={writeNsecDisabled}
+				required
+				placeholder="nsec1..."
+			/>
+			<button
+				type="button"
+				class="btn btn-gray"
+				on:click={() => (showNsec = !showNsec)}
+				title={showNsec ? 'Hide private key' : 'Show private key'}
+				aria-label={showNsec ? 'Hide private key' : 'Show private key'}
+			>
+				{showNsec ? '🙈' : '👁️'}
+			</button>
+		</div>
 	</label>
 	<div class="flex justify-between items-center mt-6">
 		<div class="flex gap-3">


### PR DESCRIPTION
Closes #2527.

## What

The "Generate New Key" button on /admin/nostr writes a freshly generated nsec into the input, then `type="password"` (added by #2263) immediately masks it — the operator can't read or copy the key before saving, and loses it.

## Fix

Keep the masking by default (#2263's intent) and add a 👁️/🙈 toggle button next to the input so the operator can reveal the value when generating a new key, copying an existing one, or auditing what is saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)