### PR TITLE
🆕🤖 Warn when S3 is not configured on picture-upload pages (#2591)

### DIFF
--- a/src/lib/components/S3NotConfiguredWarning.svelte
+++ b/src/lib/components/S3NotConfiguredWarning.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	/**
+	 * Shown on admin pages that upload pictures (products, pictures, tag widgets,
+	 * slider widgets, calendar events) when S3 storage is not configured yet —
+	 * so the operator goes to /admin/s3 first instead of hitting an upload error.
+	 */
+	export let adminPrefix: string;
+</script>
+
+<p class="alert-warning">
+	S3 storage is not configured. Configure it in
+	<a href="{adminPrefix}/s3" class="underline">S3 settings</a>
+	before uploading pictures.
+</p>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/+layout.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+layout.server.ts
@@ -4,6 +4,7 @@ import { collections } from '$lib/server/database.js';
 import { isLndConfigured } from '$lib/server/lnd.js';
 import { paymentMethods } from '$lib/server/payment-methods.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
+import { s3IsConfigured } from '$lib/server/s3.js';
 
 const DEFAULT_CMS_PAGES = [
 	'home',
@@ -79,6 +80,7 @@ export async function load({ locals }) {
 		role: locals.user?.roleId ? collections.roles.findOne({ _id: locals.user.roleId }) : null,
 		adminPrefix: adminPrefix(),
 		isBitcoinConfigured,
-		isLndConfigured: isLndConfigured()
+		isLndConfigured: isLndConfigured(),
+		s3IsConfigured: !!s3IsConfigured()
 	};
 }

--- a/src/routes/(app)/admin[[hash=admin_hash]]/gallery/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/gallery/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
+
 	export let data;
 </script>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <a href="{data.adminPrefix}/gallery/new" class="underline block">Add gallery</a>
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/gallery/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/gallery/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { applyAction, deserialize } from '$app/forms';
 	import { preUploadPicture } from '$lib/types/Picture.js';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 	let name = data.gallery.name;
@@ -51,6 +52,10 @@
 		}
 	}
 </script>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <form method="post" class="flex flex-col gap-4" action="?/update" bind:this={formElement}>
 	<label class="form-label">

--- a/src/routes/(app)/admin[[hash=admin_hash]]/gallery/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/gallery/new/+page.svelte
@@ -3,6 +3,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { preUploadPicture } from '$lib/types/Picture';
 	import { generateId } from '$lib/utils/generateId';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 	let name = '';
@@ -45,6 +46,10 @@
 </script>
 
 <h1 class="text-3xl">Add a gallery</h1>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <form
 	method="post"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/picture/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/picture/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import Picture from '$lib/components/Picture.svelte';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 </script>
 
 <h1 class="text-3xl">List of pictures with no associated product or widget</h1>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <a href="{data.adminPrefix}/picture/new" class="block underline">New picture</a>
 <a href="{data.adminPrefix}/picture/name" class="block underline">Bulk picture name editor</a>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/picture/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/picture/[id]/+page.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 	import Picture from '$lib/components/Picture.svelte';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 	let darkPicture = 'light';
 </script>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <form method="post" action="?/update" class="flex flex-col gap-4">
 	{#if data.picture.productId}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/picture/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/picture/new/+page.svelte
@@ -3,6 +3,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { TAGTYPES, preUploadPicture } from '$lib/types/Picture.js';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 
@@ -67,6 +68,10 @@
 </script>
 
 <h1 class="text-3xl">Add a picture</h1>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <form
 	method="post"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ProductItem from '$lib/components/ProductItem.svelte';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 	import { downloadFile } from '$lib/utils/downloadFile.js';
 	import { page } from '$app/stores';
 	import { PRODUCT_PAGINATION_LIMIT } from '$lib/types/Product.js';
@@ -44,6 +45,10 @@
 		downloadFile(blob, 'backup.json');
 	}
 </script>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <a href="{data.adminPrefix}/product/new" class="underline block">Add product</a>
 <a href="{data.adminPrefix}/product/prices" class="underline block">Products price</a>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import PictureComponent from '$lib/components/Picture.svelte';
 	import ProductForm from '$lib/components/ProductForm.svelte';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 
@@ -27,6 +28,10 @@
 			});
 	}
 </script>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <ProductForm
 	globalDeliveryFees={data.deliveryFees}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
 	import PictureComponent from '$lib/components/Picture.svelte';
 	import ProductForm from '$lib/components/ProductForm.svelte';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 </script>
 
 <h1 class="text-3xl">Add a product</h1>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <ProductForm
 	globalDeliveryFees={data.deliveryFees}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/schedule/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/schedule/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
+
 	export let data;
 </script>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <a href="{data.adminPrefix}/schedule/new" class="underline block">Add schedule</a>
 <a href="{data.adminPrefix}/schedule/event-default-picture" class="underline block"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/schedule/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/schedule/[id]/+page.svelte
@@ -9,6 +9,7 @@
 	import { browser } from '$app/environment';
 	import CurrencyLabel from '$lib/components/CurrencyLabel.svelte';
 	import { currencies } from '$lib/stores/currencies';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 
@@ -144,6 +145,10 @@
 </script>
 
 <h1 class="text-3xl">Edit a schedule</h1>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <form
 	method="post"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/schedule/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/schedule/new/+page.svelte
@@ -6,6 +6,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { browser } from '$app/environment';
 	import Select from 'svelte-select';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 
@@ -77,6 +78,10 @@
 </script>
 
 <h1 class="text-3xl">Add a schedule</h1>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <form
 	method="post"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/slider/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/slider/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
+
 	export let data;
 </script>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <a href="/admin/slider/new" class="underline block">Add slider</a>
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/slider/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/slider/new/+page.svelte
@@ -4,6 +4,7 @@
 	import { preUploadPicture } from '$lib/types/Picture';
 	import { MAX_NAME_LIMIT } from '$lib/types/Product';
 	import { generateId } from '$lib/utils/generateId';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 
@@ -49,6 +50,10 @@
 </script>
 
 <h1 class="text-3xl">Add a slider</h1>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <form
 	method="post"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/tags/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/tags/+page.svelte
@@ -3,6 +3,7 @@
 	import { typedKeys } from '$lib/utils/typedKeys.js';
 	import IconTrash from '$lib/components/icons/IconTrash.svelte';
 	import type { TagFamily } from '$lib/types/TagFamily';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 
@@ -96,6 +97,10 @@
 	};
 	const tagsMap = new Map(data.tags.map((tag) => [tag._id, tag]));
 </script>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <a href="{data.adminPrefix}/tags/new" class="underline block mb-4">Create new tag</a>
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/tags/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/tags/new/+page.svelte
@@ -4,6 +4,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { preUploadPicture } from '$lib/types/Picture.js';
 	import { page } from '$app/stores';
+	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 
 	export let data;
 	let pageId = $page.url.searchParams.get('id') || null;
@@ -60,6 +61,10 @@
 </script>
 
 <h1 class="text-3xl">Add a tag</h1>
+
+{#if !data.s3IsConfigured}
+	<S3NotConfiguredWarning adminPrefix={data.adminPrefix} />
+{/if}
 
 <form
 	method="post"


### PR DESCRIPTION
Closes #2591.

## What

Stacktenant ships be-BOPs without S3 configured. Without a hint, the operator goes straight to "create product" or "upload picture" and hits an opaque upload error.

This PR shows a yellow warning at the top of every admin page that lets the operator upload a picture, with an inline link to `/admin/s3`.

## Covered pages

- `/admin/product` (list, new, edit)
- `/admin/picture` (list, new, edit)
- `/admin/tags/new` (tag widget)
- `/admin/slider/new` (slider widget)
- `/admin/schedule/new` and `/admin/schedule/[id]` (calendar widget event creation)

The check reuses the existing `s3IsConfigured()` helper exposed via the admin layout, alongside `isBitcoinConfigured` / `isLndConfigured`. The wording is centralised in a tiny `S3NotConfiguredWarning.svelte` so the 10 landing surfaces stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)