### PR TITLE
🐛🤖 Fix autoclean confirm dialog firing on unrelated /admin/config saves (#2604)

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
@@ -67,23 +67,64 @@
 		}
 	}
 
+	// Snapshot initial auto-clean control values so confirmUpdate only triggers when the
+	// admin actually modified an auto-clean field (issue #2604).
+	const initialAutoclean = {
+		onOrderExpireOrCancel: dataCleanupOnExpire,
+		allowUserManualCleanup: dataCleanupManual,
+		scheduledEnabled: dataCleanupScheduled,
+		delayValue: cleanupDelayValue,
+		delayUnit: cleanupDelayUnit,
+		orderStatuses: [...cleanupStatuses].sort().join(',')
+	};
+
+	function autocleanChanged(currentStatuses: string[]) {
+		if (dataCleanupOnExpire !== initialAutoclean.onOrderExpireOrCancel) {
+			return true;
+		}
+		if (dataCleanupManual !== initialAutoclean.allowUserManualCleanup) {
+			return true;
+		}
+		if (dataCleanupScheduled !== initialAutoclean.scheduledEnabled) {
+			return true;
+		}
+		if (cleanupDelayValue !== initialAutoclean.delayValue) {
+			return true;
+		}
+		if (cleanupDelayUnit !== initialAutoclean.delayUnit) {
+			return true;
+		}
+		// Status checkboxes only render when scheduled is on; if it's off both initially
+		// and now, currentStatuses is always [] (DOM-empty) and would falsely mismatch a
+		// stale non-empty initialAutoclean.orderStatuses.
+		if (
+			(initialAutoclean.scheduledEnabled || dataCleanupScheduled) &&
+			currentStatuses.slice().sort().join(',') !== initialAutoclean.orderStatuses
+		) {
+			return true;
+		}
+		return false;
+	}
+
 	function confirmUpdate(e: Event) {
-		if (dataCleanupScheduled && cleanupDelayValue > 0) {
-			const formData = new FormData(e.target as HTMLFormElement);
-			const statuses = formData.getAll('dataCleanup.scheduled.orderStatuses').map(String);
-			if (statuses.length > 0) {
-				const multiplier = DELAY_MULTIPLIERS[cleanupDelayUnit] ?? 86400;
-				const cutoffDate = new Date(Date.now() - cleanupDelayValue * multiplier * 1000);
-				if (
-					!confirm(
-						`Are you sure? It will delete personal data for every order with status [${statuses.join(
-							', '
-						)}] older than ${cutoffDate.toLocaleDateString($locale)}. This cannot be undone.`
-					)
-				) {
-					e.preventDefault();
-				}
-			}
+		const formData = new FormData(e.target as HTMLFormElement);
+		const statuses = formData.getAll('dataCleanup.scheduled.orderStatuses').map(String);
+		if (!autocleanChanged(statuses)) {
+			return;
+		}
+		const dangerous = dataCleanupScheduled && cleanupDelayValue > 0 && statuses.length > 0;
+		let message: string;
+		if (dangerous) {
+			const multiplier = DELAY_MULTIPLIERS[cleanupDelayUnit] ?? 86400;
+			const cutoffDate = new Date(Date.now() - cleanupDelayValue * multiplier * 1000);
+			message = `Are you sure? It will delete personal data for every order with status [${statuses.join(
+				', '
+			)}] older than ${cutoffDate.toLocaleDateString($locale)}. This cannot be undone.`;
+		} else {
+			message = 'Auto-clean settings have been modified. Confirm?';
+		}
+		if (!confirm(message)) {
+			e.preventDefault();
 		}
 	}
 


### PR DESCRIPTION
## Summary
Fixes #2604.

The auto-clean confirmation dialog on `/admin/config` was warning the admin every time they saved the page — even when they had not touched any auto-clean setting. Saving currency, VAT, or any unrelated field popped the destructive-action warning, which trained admins to dismiss it reflexively.

## Behaviour after fix
- Saving `/admin/config` without touching any auto-clean setting → **no warning**.
- Saving after modifying any auto-clean setting → **warning shown**, including when the admin is disabling scheduled auto-cleanup.
- When the post-save state will still actively delete data (scheduled cleanup on, with a delay and at least one order status selected), the warning keeps the existing detailed wording — *"It will delete personal data for every order with status [...] older than [...]. This cannot be undone."*
- When the post-save state will not delete data (e.g. scheduled cleanup just turned off), the warning shows a generic *"Auto-clean settings have been modified. Confirm?"* — so the wording stays honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)