### PR TITLE
🐛🤖 Stop pagination buttons from sticking to viewport (#2576)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -238,7 +238,7 @@
 	   e.g. /admin/config/vat) to avoid matching forms nested inside banner/widget components. */
 	:is(main.body-mainPlan:not(.no-sticky-actions), main.body-mainPlan:not(.no-sticky-actions) main)
 		> form
-		> div:has(input[type='submit'], button[type='submit'], button[formaction]) {
+		> div:not(.no-sticky):has(input[type='submit'], button[type='submit'], button[formaction]) {
 		position: sticky;
 		bottom: 0;
 		z-index: 10;
@@ -250,7 +250,7 @@
 	:is(main.body-mainPlan:not(.no-sticky-actions), main.body-mainPlan:not(.no-sticky-actions) main)
 		> form
 		> fieldset
-		> div:last-child:has(input[type='submit'], button[type='submit'], button[formaction]) {
+		> div:last-child:not(.no-sticky):has(input[type='submit'], button[type='submit'], button[formaction]) {
 		position: sticky;
 		bottom: 0;
 		z-index: 10;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.svelte
@@ -115,7 +115,7 @@
 		</label>
 	</div>
 	<OrdersList orders={data.orders} adminPrefix={data.adminPrefix} orderLabels={data.labels} />
-	<div class="flex gap-2">
+	<div class="no-sticky flex gap-2">
 		<input type="hidden" value={next} name="skip" />
 		{#if Number($page.url.searchParams.get('skip'))}
 			<button

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/+page.svelte
@@ -192,7 +192,7 @@
 		{/each}
 	</div>
 
-	<div class="flex flex-row mx-auto mt-4 gap-4">
+	<div class="no-sticky flex flex-row mx-auto mt-4 gap-4">
 		<input type="hidden" value={next} name="skip" />
 		{#if Number($page.url.searchParams.get('skip'))}
 			<button


### PR DESCRIPTION
## Summary
Fixes #2576.

On the back-office product list (`/admin/product`) and orders list (`/admin/order`), the **Previous** and **Next** pagination buttons were sticking to the bottom of the viewport with a white background — the same sticky behaviour we use for real "Save" / "Update" action bars. Pagination is navigation, not a save action, so it should scroll normally with the page.

## Behaviour after fix
- `/admin/product` Previous/Next: no longer sticky, scrolls with the page, no stray white background.
- `/admin/order` Previous/Next: same fix, same behaviour.
- Real save/update action bars (e.g. the bottom of `/admin/config`, every edit form) keep their sticky behaviour — only the explicitly-opted-out pagination rows are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)