### PR TITLE
🐛🤖 Graceful payment generation error + PSP test connection (#2546)

### DIFF
--- a/src/lib/components/Order/PaymentForm.svelte
+++ b/src/lib/components/Order/PaymentForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { SerializedOrderPayment } from '$lib/types/Order';
 	import { useI18n } from '$lib/i18n';
+	import { enhance } from '$app/forms';
 
 	const { t } = useI18n();
 
@@ -31,7 +32,7 @@
 			: t('pos.cta.resendPaymentMethod');
 </script>
 
-<form {action} method="post" class="flex flex-col gap-2">
+<form {action} method="post" class="flex flex-col gap-2" use:enhance>
 	<!-- Amount input -->
 	<label>
 		{amountLabel}

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -1789,6 +1789,77 @@ export async function createOrder(
 	return orderId;
 }
 
+/**
+ * Thrown when a payment record cannot be created/initialised against a PSP.
+ * Caller routes catch it and surface a friendly banner instead of a 402 error page.
+ *
+ * TODO(#2546): classify the cause so the UI can vary the wording.
+ * `kind` should become one of:
+ *  - 'transient' (PSP 5xx, timeout, ECONNREFUSED, 429) → "try again later"
+ *  - 'config' (401/403/400 from PSP, invalid credentials, bad amount) → "contact the shop"
+ *  - 'unknown' (anything else, fallback transient)
+ * Done generically for now since the inner errors aren't typed enough to discriminate safely.
+ */
+export class PaymentGenerationError extends Error {
+	readonly method: PaymentMethod;
+	readonly reason: string;
+	constructor(method: PaymentMethod, reason: string, cause?: unknown) {
+		super(`Payment generation failed for method ${method}: ${reason}`);
+		this.name = 'PaymentGenerationError';
+		this.method = method;
+		this.reason = reason;
+		if (cause) {
+			(this as { cause?: unknown }).cause = cause;
+		}
+	}
+}
+
+/**
+ * Notifies the super-admin (shop owner) that a payment couldn't be initiated against a PSP.
+ *
+ * Pattern lifted from the existing "NEW DISCOUNT" notification at the top of `createOrder`:
+ * insert a row directly into `emailNotifications` with hardcoded HTML, no template lookup.
+ *
+ * Important — we deliberately do NOT include the raw provider error in the email body.
+ * Several PSPs echo back the submitted credential in their error responses (e.g. Stripe
+ * "Invalid API Key provided: sk_..."), and the email can be intercepted, forwarded,
+ * indexed by webmail providers or shared in a multi-recipient inbox. The shopowner
+ * gets enough information here (method, context, order link) to know where to look; the
+ * raw error is still printed to the server logs via the route-level `console.error`.
+ *
+ * TODO(#2546): templatise this once we have a proper admin-managed template for it. Should be
+ * folded into the broader email-notifications rework drafted in PR #1979 — that PR introduces
+ * a generic notification pipeline that will absorb this hardcoded insert as well as the discount
+ * one above.
+ */
+export async function notifySuperAdminPaymentFailure(params: {
+	method: PaymentMethod;
+	context: string;
+	orderId?: string;
+}): Promise<void> {
+	const dest = runtimeConfig.sellerIdentity?.contact.email || SMTP_USER;
+	if (!dest) {
+		return;
+	}
+	const orderLine = params.orderId
+		? `<p>Order: <a href="${ORIGIN}/order/${params.orderId}">${params.orderId}</a></p>`
+		: '';
+	await collections.emailNotifications.insertOne({
+		_id: new ObjectId(),
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		subject: 'PAYMENT GENERATION FAILED',
+		htmlContent:
+			`<p>A payment could not be initiated.</p>` +
+			`<p>Context: ${params.context}</p>` +
+			`<p>Method: ${params.method}</p>` +
+			orderLine +
+			`<p>Please review the configuration of the corresponding payment processor in /admin. ` +
+			`The provider error message is available in the server logs.</p>`,
+		dest
+	});
+}
+
 async function generatePaymentInfo(params: {
 	method: PaymentMethod;
 	orderId: string;
@@ -1818,7 +1889,11 @@ async function generatePaymentInfo(params: {
 			});
 			return { ...result, processor: pp.meta.processor };
 		} catch (err) {
-			throw error(402, err instanceof Error ? err.message : 'Payment creation failed');
+			throw new PaymentGenerationError(
+				params.method,
+				err instanceof Error ? err.message : 'Payment creation failed',
+				err
+			);
 		}
 	}
 
@@ -1830,7 +1905,10 @@ async function generatePaymentInfo(params: {
 		case 'bank-transfer':
 			return { address: runtimeConfig.sellerIdentity?.bank?.iban };
 		default:
-			throw error(402, `No payment processor available for method ${params.method}`);
+			throw new PaymentGenerationError(
+				params.method,
+				`No payment processor available for method ${params.method}`
+			);
 	}
 }
 
@@ -1863,7 +1941,10 @@ function paymentPrice(paymentMethod: PaymentMethod, price: Price): Price {
 				currency: runtimeConfig.mainCurrency
 			};
 		default:
-			throw error(402, `No payment processor configured for method ${paymentMethod}`);
+			throw new PaymentGenerationError(
+				paymentMethod,
+				`No payment processor configured for method ${paymentMethod}`
+			);
 	}
 }
 

--- a/src/lib/server/sdk/test-connection.ts
+++ b/src/lib/server/sdk/test-connection.ts
@@ -1,0 +1,67 @@
+import { getProcessor } from './pp';
+
+const TEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Lightweight PSP connectivity check used by the "Test connection" admin button on
+ * each PSP configuration page (#2546).
+ *
+ * Calls the same `createPayment` SDK entrypoint a customer checkout would hit, but
+ * with synthetic params (1 EUR, identifiable `orderId`/`paymentId`, `orderNumber: 0`).
+ * No order or payment is persisted in our DB — the PSP-side artifact (Stripe
+ * PaymentIntent, PayPal order, etc.) is left to expire on its own.
+ *
+ * The check therefore exercises the real network path + credentials. A success means
+ * the configuration is good enough to take real payments; a failure tells the shopowner
+ * to verify their credentials — we deliberately do NOT echo the raw provider error
+ * back to the UI. Several PSPs reply with the submitted credential in their error body
+ * (Stripe: "Invalid API Key provided: sk_..."), so a generic message is the only
+ * future-proof way to avoid leaking secrets — we can't whitelist every PSP's format.
+ * The raw error is still logged server-side via console.error for operator debugging.
+ *
+ * A hard 15s timeout protects against PSP SDKs that don't enforce their own (we hit
+ * this on Swiss Bitcoin Pay where a bad API key just made the call hang indefinitely).
+ */
+export async function testProcessorConnection(
+	processorName: string
+): Promise<{ ok: boolean; reason?: string }> {
+	const pp = getProcessor(processorName);
+	if (!pp) {
+		return { ok: false, reason: `Unknown processor: ${processorName}` };
+	}
+	if (!pp.isEnabled()) {
+		return { ok: false, reason: 'Processor is not configured (missing credentials).' };
+	}
+	const testId = `be-bop-connection-test-${Date.now()}`;
+	try {
+		await Promise.race([
+			pp.createPayment({
+				orderId: testId,
+				orderNumber: 0,
+				paymentId: testId,
+				toPay: { amount: 1, currency: 'EUR' }
+			}),
+			new Promise<never>((_, reject) =>
+				setTimeout(
+					() =>
+						reject(
+							new Error(
+								`Test timed out after ${TEST_TIMEOUT_MS / 1000}s — provider did not respond`
+							)
+						),
+					TEST_TIMEOUT_MS
+				)
+			)
+		]);
+		return { ok: true };
+	} catch (err) {
+		console.error(`testProcessorConnection(${processorName}) raw error:`, err);
+		const isTimeout = err instanceof Error && err.message.startsWith('Test timed out');
+		return {
+			ok: false,
+			reason: isTimeout
+				? `The provider did not respond within ${TEST_TIMEOUT_MS / 1000}s. Please try again later.`
+				: 'Connection failed. Please verify the saved credentials and try again.'
+		};
+	}
+}

--- a/src/lib/server/swiss-bitcoin-pay.ts
+++ b/src/lib/server/swiss-bitcoin-pay.ts
@@ -55,6 +55,14 @@ export interface CheckoutStatus {
 	redirectAfterPaid?: string;
 }
 
+/**
+ * Swiss Bitcoin Pay's HTTP API can hang for several minutes on bad credentials or
+ * network blips — there is no SDK-level timeout. We enforce one here so the customer
+ * checkout (and the admin "test connection" button) fail fast instead of stalling
+ * behind a reverse-proxy 5xx (see #2546).
+ */
+const SBP_HTTP_TIMEOUT_MS = 15_000;
+
 export async function sbpCreateCheckout(request: CheckoutRequest): Promise<CheckoutResponse> {
 	if (!isSwissBitcoinPayConfigured()) {
 		throw new Error('Swiss Bitcoin Pay is not enabled');
@@ -67,7 +75,8 @@ export async function sbpCreateCheckout(request: CheckoutRequest): Promise<Check
 			'api-key': runtimeConfig.swissBitcoinPay.apiKey,
 			'user-agent': `be-BOP`
 		},
-		body: JSON.stringify(request)
+		body: JSON.stringify(request),
+		signal: AbortSignal.timeout(SBP_HTTP_TIMEOUT_MS)
 	});
 
 	if (!response.ok) {
@@ -78,7 +87,8 @@ export async function sbpCreateCheckout(request: CheckoutRequest): Promise<Check
 
 export async function sbpGetCheckoutStatus(id: string): Promise<CheckoutStatus> {
 	const response = await fetch(`${apiUrl()}/checkout/${id}`, {
-		method: 'GET'
+		method: 'GET',
+		signal: AbortSignal.timeout(SBP_HTTP_TIMEOUT_MS)
 	});
 
 	if (!response.ok) {

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -170,6 +170,7 @@
 		"multiplePaymentMethods": "Mehrere Zahlungsmethoden verwenden",
 		"multiplePaymentMethodsHelpText": "Sie können Zahlungsmethoden im nächsten Schritt festlegen.",
 		"noDeliveryInCountry": "Die Lieferung ist in Ihrem Land für einige Artikel in Ihrem Warenkorb nicht möglich.",
+		"paymentGenerationFailed": "Die Zahlung konnte nicht initiiert werden. Bitte versuchen Sie es in wenigen Augenblicken erneut, oder kontaktieren Sie den Shop-Betreiber, falls das Problem weiterhin besteht.",
 		"note": {
 			"label": "Hinterlassen Sie eine Nachricht für den Händler",
 			"title": "Notiz"

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -167,6 +167,7 @@
 		"multiplePaymentMethods": "Use several payment methods",
 		"multiplePaymentMethodsHelpText": "You can set payment methods at the next step.",
 		"noDeliveryInCountry": "Delivery is not available in your country for some of the items of your cart.",
+		"paymentGenerationFailed": "We couldn't initiate your payment. Please try again in a few moments, or contact the shop owner if the problem persists.",
 		"additionalFields": {
 			"title": "Additional information"
 		},

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -170,6 +170,7 @@
 		"multiplePaymentMethods": "Usar varios métodos de pago",
 		"multiplePaymentMethodsHelpText": "Puedes configurar métodos de pago en el siguiente paso.",
 		"noDeliveryInCountry": "La entrega no está disponible en tu país para algunos de los artículos de la lista de compras.",
+		"paymentGenerationFailed": "No pudimos iniciar el pago. Por favor, inténtalo de nuevo en unos instantes o contacta con la tienda si el problema persiste.",
 		"note": {
 			"label": "Dejar una nota para el comerciante",
 			"title": "Nota"

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -170,6 +170,7 @@
 		"multiplePaymentMethods": "Utiliser plusieurs méthodes de paiements",
 		"multiplePaymentMethodsHelpText": "Vous pourrez définir les méthodes de paiement à l'étape suivante.",
 		"noDeliveryInCountry": "La livraison n'est pas disponible dans votre pays pour certains articles de votre panier.",
+		"paymentGenerationFailed": "Le paiement n'a pas pu être initié. Veuillez réessayer dans quelques instants, ou contactez le vendeur de la boutique si le problème persiste.",
 		"note": {
 			"label": "Laissez un message au vendeur",
 			"title": "Note"

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -170,6 +170,7 @@
 		"multiplePaymentMethods": "Usa differenti metodi di pagamento",
 		"multiplePaymentMethodsHelpText": "Potrete decidere il vostro tipo di pagamento alla prossima tappa.",
 		"noDeliveryInCountry": "La spedizione non è disponibile nel vostro paese per alcuni articoli presenti nel carrello.",
+		"paymentGenerationFailed": "Non è stato possibile avviare il pagamento. Si prega di riprovare tra qualche istante, o di contattare il negoziante se il problema persiste.",
 		"note": {
 			"label": "Lascia un messaggio per il venditore",
 			"title": "Messaggio"

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -170,6 +170,7 @@
 		"multiplePaymentMethods": "Maak gebruik van meerdere betaalmethoden",
 		"multiplePaymentMethodsHelpText": "Bij de volgende stap kunt u de betaalmethoden instellen.",
 		"noDeliveryInCountry": "Voor sommige artikelen in uw winkelwagentje is bezorging in uw land niet mogelijk.",
+		"paymentGenerationFailed": "De betaling kon niet worden gestart. Probeer het binnen enkele ogenblikken opnieuw, of neem contact op met de verkoper als het probleem aanhoudt.",
 		"note": {
 			"label": "Laat een briefje achter voor de verkoper",
 			"title": "Opmerking"

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -170,6 +170,7 @@
 		"multiplePaymentMethods": "Usar vários métodos de pagamento",
 		"multiplePaymentMethodsHelpText": "Pode definir os métodos de pagamento no próximo passo.",
 		"noDeliveryInCountry": "A entrega não está disponível no seu país para alguns dos artigos do seu carrinho.",
+		"paymentGenerationFailed": "Não foi possível iniciar o pagamento. Por favor, tente novamente dentro de alguns instantes, ou contacte o vendedor da loja se o problema persistir.",
 		"note": {
 			"label": "Deixe uma nota para o comerciante",
 			"title": "Nota"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/[id]/+page.server.ts
@@ -3,7 +3,11 @@ import { collections } from '$lib/server/database';
 import { queueEmail } from '$lib/server/email';
 import { ORIGIN } from '$lib/server/env-config';
 import { validateEmailOrNpub } from '$lib/server/nostr';
-import { addOrderPayment } from '$lib/server/orders';
+import {
+	addOrderPayment,
+	notifySuperAdminPaymentFailure,
+	PaymentGenerationError
+} from '$lib/server/orders';
 import { paymentMethods, type PaymentMethod } from '$lib/server/payment-methods.js';
 import { rateLimit } from '$lib/server/rateLimit';
 import { userIdentifier } from '$lib/server/user';
@@ -68,19 +72,32 @@ export const actions = {
 			throw error(400, 'Amount is greater than the remaining amount to pay');
 		}
 
-		await addOrderPayment(
-			order,
-			parsed.method,
-			{
-				amount,
-				currency: order.currencySnapshot.main.totalPrice.currency
-			},
-			{
-				expiresAt: null,
-				...(parsed.method === 'point-of-sale' &&
-					parsed.posSubtype && { posSubtype: parsed.posSubtype })
+		try {
+			await addOrderPayment(
+				order,
+				parsed.method,
+				{
+					amount,
+					currency: order.currencySnapshot.main.totalPrice.currency
+				},
+				{
+					expiresAt: null,
+					...(parsed.method === 'point-of-sale' &&
+						parsed.posSubtype && { posSubtype: parsed.posSubtype })
+				}
+			);
+		} catch (err) {
+			if (err instanceof PaymentGenerationError) {
+				console.error('PaymentGenerationError on staff addPayment:', err.method, err.reason);
+				await notifySuperAdminPaymentFailure({
+					method: err.method,
+					context: 'staff "add payment" action on existing order',
+					orderId: order._id
+				});
+				return fail(400, { paymentGenerationFailed: true });
 			}
-		);
+			throw err;
+		}
 
 		throw redirect(303, request.headers.get('referer') || `/order/${order._id}`);
 	},

--- a/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.server.ts
@@ -1,5 +1,7 @@
 import { collections } from '$lib/server/database.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
+import { rateLimit } from '$lib/server/rateLimit';
+import { testProcessorConnection } from '$lib/server/sdk/test-connection';
 import { z } from 'zod';
 
 export async function load() {
@@ -45,5 +47,9 @@ export const actions = {
 			password: '',
 			hmacKey: ''
 		};
+	},
+	testConnection: async function ({ locals }) {
+		rateLimit(locals.clientIp, 'pp.test.osb', 5, { minutes: 1 });
+		return await testProcessorConnection('osb');
 	}
 };

--- a/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/osb/+page.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
+
 	export let data;
+	export let form;
+
+	let testInFlight = false;
+	let testCooldownUntil = 0;
+	$: testDisabled = testInFlight || Date.now() < testCooldownUntil;
 </script>
 
 <h1 class="text-3xl">OSB</h1>
@@ -28,3 +35,26 @@
 	</div>
 </form>
 <form class="contents" method="post" action="?/delete" id="delete-form"></form>
+
+<form
+	method="post"
+	action="?/testConnection"
+	use:enhance={() => {
+		testInFlight = true;
+		return async ({ update }) => {
+			await update({ reset: false });
+			testInFlight = false;
+			testCooldownUntil = Date.now() + 10_000;
+		};
+	}}
+	class="flex flex-col gap-2"
+>
+	<button class="btn btn-blue self-start" type="submit" disabled={testDisabled}>
+		{testInFlight ? 'Testing…' : 'Test connection'}
+	</button>
+	{#if form?.ok}
+		<div class="alert-success">Connection successful. OSB credentials are working.</div>
+	{:else if form?.reason}
+		<div class="alert-error">Connection failed: {form.reason}</div>
+	{/if}
+</form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/paypal/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/paypal/+page.server.ts
@@ -1,6 +1,8 @@
 import { collections } from '$lib/server/database.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { CURRENCIES, type Currency } from '$lib/types/Currency.js';
+import { rateLimit } from '$lib/server/rateLimit';
+import { testProcessorConnection } from '$lib/server/sdk/test-connection';
 import { z } from 'zod';
 
 export async function load() {
@@ -50,5 +52,9 @@ export const actions = {
 			currency: 'EUR',
 			sandbox: false
 		};
+	},
+	testConnection: async function ({ locals }) {
+		rateLimit(locals.clientIp, 'pp.test.paypal', 5, { minutes: 1 });
+		return await testProcessorConnection('paypal');
 	}
 };

--- a/src/routes/(app)/admin[[hash=admin_hash]]/paypal/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/paypal/+page.svelte
@@ -3,8 +3,14 @@
 	import Select from 'svelte-select';
 	import CurrencyLabel from '$lib/components/CurrencyLabel.svelte';
 	import { currencies } from '$lib/stores/currencies';
+	import { enhance } from '$app/forms';
 
 	export let data;
+	export let form;
+
+	let testInFlight = false;
+	let testCooldownUntil = 0;
+	$: testDisabled = testInFlight || Date.now() < testCooldownUntil;
 
 	// PayPal supports all fiat currencies (no BTC/SAT)
 	// Sort: main → secondary → fiat A-Z (excluding crypto)
@@ -61,3 +67,26 @@
 	</div>
 </form>
 <form class="contents" method="post" action="?/delete" id="delete-form"></form>
+
+<form
+	method="post"
+	action="?/testConnection"
+	use:enhance={() => {
+		testInFlight = true;
+		return async ({ update }) => {
+			await update({ reset: false });
+			testInFlight = false;
+			testCooldownUntil = Date.now() + 10_000;
+		};
+	}}
+	class="flex flex-col gap-2"
+>
+	<button class="btn btn-blue self-start" type="submit" disabled={testDisabled}>
+		{testInFlight ? 'Testing…' : 'Test connection'}
+	</button>
+	{#if form?.ok}
+		<div class="alert-success">Connection successful. PayPal credentials are working.</div>
+	{:else if form?.reason}
+		<div class="alert-error">Connection failed: {form.reason}</div>
+	{/if}
+</form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/stripe/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/stripe/+page.server.ts
@@ -1,6 +1,8 @@
 import { collections } from '$lib/server/database.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { CURRENCIES, type Currency } from '$lib/types/Currency.js';
+import { rateLimit } from '$lib/server/rateLimit';
+import { testProcessorConnection } from '$lib/server/sdk/test-connection';
 import { z } from 'zod';
 
 export async function load() {
@@ -48,5 +50,9 @@ export const actions = {
 			publicKey: '',
 			currency: 'EUR'
 		};
+	},
+	testConnection: async function ({ locals }) {
+		rateLimit(locals.clientIp, 'pp.test.stripe', 5, { minutes: 1 });
+		return await testProcessorConnection('stripe');
 	}
 };

--- a/src/routes/(app)/admin[[hash=admin_hash]]/stripe/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/stripe/+page.svelte
@@ -3,8 +3,14 @@
 	import Select from 'svelte-select';
 	import CurrencyLabel from '$lib/components/CurrencyLabel.svelte';
 	import { currencies } from '$lib/stores/currencies';
+	import { enhance } from '$app/forms';
 
 	export let data;
+	export let form;
+
+	let testInFlight = false;
+	let testCooldownUntil = 0;
+	$: testDisabled = testInFlight || Date.now() < testCooldownUntil;
 
 	// Stripe supports all fiat currencies (no BTC/SAT)
 	// Sort: main → secondary → fiat A-Z (excluding crypto)
@@ -64,3 +70,27 @@
 	</div>
 </form>
 <form class="contents" method="post" action="?/delete" id="delete-form"></form>
+
+<form
+	method="post"
+	action="?/testConnection"
+	use:enhance={() => {
+		testInFlight = true;
+		return async ({ update }) => {
+			await update({ reset: false });
+			testInFlight = false;
+			// 10s debounce to throttle accidental hammering on top of the server-side rateLimit.
+			testCooldownUntil = Date.now() + 10_000;
+		};
+	}}
+	class="flex flex-col gap-2"
+>
+	<button class="btn btn-blue self-start" type="submit" disabled={testDisabled}>
+		{testInFlight ? 'Testing…' : 'Test connection'}
+	</button>
+	{#if form?.ok}
+		<div class="alert-success">Connection successful. Stripe credentials are working.</div>
+	{:else if form?.reason}
+		<div class="alert-error">Connection failed: {form.reason}</div>
+	{/if}
+</form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/sumup/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/sumup/+page.server.ts
@@ -1,6 +1,8 @@
 import { collections } from '$lib/server/database.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { CURRENCIES, type Currency } from '$lib/types/Currency.js';
+import { rateLimit } from '$lib/server/rateLimit';
+import { testProcessorConnection } from '$lib/server/sdk/test-connection';
 import { z } from 'zod';
 
 export async function load() {
@@ -48,5 +50,9 @@ export const actions = {
 			merchantCode: '',
 			currency: 'EUR'
 		};
+	},
+	testConnection: async function ({ locals }) {
+		rateLimit(locals.clientIp, 'pp.test.sumup', 5, { minutes: 1 });
+		return await testProcessorConnection('sumup');
 	}
 };

--- a/src/routes/(app)/admin[[hash=admin_hash]]/sumup/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/sumup/+page.svelte
@@ -3,8 +3,14 @@
 	import Select from 'svelte-select';
 	import CurrencyLabel from '$lib/components/CurrencyLabel.svelte';
 	import { currencies } from '$lib/stores/currencies';
+	import { enhance } from '$app/forms';
 
 	export let data;
+	export let form;
+
+	let testInFlight = false;
+	let testCooldownUntil = 0;
+	$: testDisabled = testInFlight || Date.now() < testCooldownUntil;
 
 	// SumUp supports all fiat currencies (no BTC/SAT)
 	// Sort: main → secondary → fiat A-Z (excluding crypto)
@@ -64,3 +70,26 @@
 	</div>
 </form>
 <form class="contents" method="post" action="?/delete" id="delete-form"></form>
+
+<form
+	method="post"
+	action="?/testConnection"
+	use:enhance={() => {
+		testInFlight = true;
+		return async ({ update }) => {
+			await update({ reset: false });
+			testInFlight = false;
+			testCooldownUntil = Date.now() + 10_000;
+		};
+	}}
+	class="flex flex-col gap-2"
+>
+	<button class="btn btn-blue self-start" type="submit" disabled={testDisabled}>
+		{testInFlight ? 'Testing…' : 'Test connection'}
+	</button>
+	{#if form?.ok}
+		<div class="alert-success">Connection successful. SumUp credentials are working.</div>
+	{:else if form?.reason}
+		<div class="alert-error">Connection failed: {form.reason}</div>
+	{/if}
+</form>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/swiss-bitcoin-pay/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/swiss-bitcoin-pay/+page.server.ts
@@ -1,6 +1,8 @@
 import { collections } from '$lib/server/database.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { updateLightningInvoiceDescription } from '$lib/server/actions.js';
+import { rateLimit } from '$lib/server/rateLimit';
+import { testProcessorConnection } from '$lib/server/sdk/test-connection';
 import { z } from 'zod';
 
 export async function load() {
@@ -41,5 +43,9 @@ export const actions = {
 			apiKey: ''
 		};
 	},
-	updateLightningInvoiceDescription
+	updateLightningInvoiceDescription,
+	testConnection: async function ({ locals }) {
+		rateLimit(locals.clientIp, 'pp.test.swiss-bitcoin-pay', 5, { minutes: 1 });
+		return await testProcessorConnection('swiss-bitcoin-pay');
+	}
 };

--- a/src/routes/(app)/admin[[hash=admin_hash]]/swiss-bitcoin-pay/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/swiss-bitcoin-pay/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
 	import SetLightningQrCodeDescription from '$lib/components/SetLightningQrCodeDescription.svelte';
+	import { enhance } from '$app/forms';
 	export let data;
+	export let form;
+
+	let testInFlight = false;
+	let testCooldownUntil = 0;
+	$: testDisabled = testInFlight || Date.now() < testCooldownUntil;
 </script>
 
 <h1 class="text-3xl">Swiss Bitcoin Pay</h1>
@@ -17,6 +23,31 @@
 	</div>
 </form>
 <form class="contents" method="post" action="?/delete" id="delete-form"></form>
+
+<form
+	method="post"
+	action="?/testConnection"
+	use:enhance={() => {
+		testInFlight = true;
+		return async ({ update }) => {
+			await update({ reset: false });
+			testInFlight = false;
+			testCooldownUntil = Date.now() + 10_000;
+		};
+	}}
+	class="flex flex-col gap-2"
+>
+	<button class="btn btn-blue self-start" type="submit" disabled={testDisabled}>
+		{testInFlight ? 'Testing…' : 'Test connection'}
+	</button>
+	{#if form?.ok}
+		<div class="alert-success">
+			Connection successful. Swiss Bitcoin Pay credentials are working.
+		</div>
+	{:else if form?.reason}
+		<div class="alert-error">Connection failed: {form.reason}</div>
+	{/if}
+</form>
 
 <h2 class="text-2xl">Invoices</h2>
 

--- a/src/routes/(app)/checkout/+page.server.ts
+++ b/src/routes/(app)/checkout/+page.server.ts
@@ -1,9 +1,13 @@
 import { collections, withTransaction } from '$lib/server/database';
 import { paymentMethods } from '$lib/server/payment-methods';
 import { COUNTRY_ALPHA2S, type CountryAlpha2 } from '$lib/types/Country';
-import { error, redirect } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
-import { createOrder } from '$lib/server/orders';
+import {
+	createOrder,
+	notifySuperAdminPaymentFailure,
+	PaymentGenerationError
+} from '$lib/server/orders';
 import { isEmailConfigured } from '$lib/server/email';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { checkCartItems, getCartFromDb } from '$lib/server/cart.js';
@@ -565,80 +569,99 @@ export const actions = {
 
 		rateLimit(locals.clientIp, 'email', 10, { minutes: 1 });
 		let orderId = '';
-		await withTransaction(async (session) => {
-			orderId = await createOrder(
-				cart.items.map((item) => ({
-					// Workaround since the type item._id of the cart item is not ObjectId
-					_id: item._id && ObjectId.isValid(item._id) ? new ObjectId(item._id) : undefined,
-					quantity: item.quantity,
-					product: byId[item.productId],
-					...(item.customPrice && {
-						customPrice: { amount: item.customPrice.amount, currency: item.customPrice.currency }
-					}),
-					...(item.chosenVariations && { chosenVariations: item.chosenVariations }),
-					depositPercentage: item.depositPercentage,
-					...(item.discountPercentage !== undefined &&
-						item.discountPercentage > 0 && {
-							discountPercentage: item.discountPercentage
-						}),
-					...(item.booking && {
-						booking: {
-							...item.booking,
-							_id: new ObjectId()
-						}
-					})
-				})),
-				paymentMethod,
-				{
-					locale: locals.language,
-					user: userIdentifier(locals),
-					...(posSubtype && { posSubtype }),
-					notifications: {
-						paymentStatus: {
-							npub: npubAddress,
-							email
-						}
-					},
-					cart,
-					promoCode: cart.promoCode,
-					channel: webChannelForUser(locals.user?.hasPosOptions),
-					shippingAddress: shippingInfo?.shipping,
-					billingAddress: billingInfo?.billing || shippingInfo?.shipping,
-					userVatCountry: vatCountry,
-					...(locals.user?.hasPosOptions && isFreeVat && { reasonFreeVat }),
-					...(locals.user?.hasPosOptions &&
-						discountAmount &&
-						discountType &&
-						discountJustification && {
-							discount: {
-								amount: discountAmount,
-								type: discountType,
-								justification: discountJustification
+		try {
+			await withTransaction(async (session) => {
+				orderId = await createOrder(
+					cart.items.map((item) => ({
+						// Workaround since the type item._id of the cart item is not ObjectId
+						_id: item._id && ObjectId.isValid(item._id) ? new ObjectId(item._id) : undefined,
+						quantity: item.quantity,
+						product: byId[item.productId],
+						...(item.customPrice && {
+							customPrice: {
+								amount: item.customPrice.amount,
+								currency: item.customPrice.currency
 							}
 						}),
-					...(note && { note: note.noteContent }),
-					...(customCheckoutFields.length && { customCheckoutFields }),
-					...(agreements.allowCollectIP && { clientIp: locals.clientIp }),
-					...(locals.user?.hasPosOptions &&
-						runtimeConfig.deliveryFees.allowFreeForPOS &&
-						offerDeliveryFees && { reasonOfferDeliveryFees }),
-					...(receiptNote && { receiptNote: receiptNote.receiptNoteContent }),
-					engagements: {
-						...(agreements.allowCollectIP && { acceptedIPCollect: agreements.allowCollectIP }),
-						...(agreements.teecees && { acceptedTermsOfUse: agreements.teecees }),
-						...(agreements.isOnlyDeposit && {
-							acceptedDepositConditionsAndFullPayment: agreements.isOnlyDeposit
-						}),
-						...(agreements.isVATNullForeigner && {
-							acceptedExportationAndVATObligation: agreements.isVATNullForeigner
+						...(item.chosenVariations && { chosenVariations: item.chosenVariations }),
+						depositPercentage: item.depositPercentage,
+						...(item.discountPercentage !== undefined &&
+							item.discountPercentage > 0 && {
+								discountPercentage: item.discountPercentage
+							}),
+						...(item.booking && {
+							booking: {
+								...item.booking,
+								_id: new ObjectId()
+							}
 						})
-					},
-					...(physicalFullyPaid && { onLocation: physicalFullyPaid.onLocation }),
-					...(desiredPayment.paymentTimeOut && { paymentTimeOut: desiredPayment.paymentTimeOut }),
-					session
-				}
-			);
-		});
+					})),
+					paymentMethod,
+					{
+						locale: locals.language,
+						user: userIdentifier(locals),
+						...(posSubtype && { posSubtype }),
+						notifications: {
+							paymentStatus: {
+								npub: npubAddress,
+								email
+							}
+						},
+						cart,
+						promoCode: cart.promoCode,
+						channel: webChannelForUser(locals.user?.hasPosOptions),
+						shippingAddress: shippingInfo?.shipping,
+						billingAddress: billingInfo?.billing || shippingInfo?.shipping,
+						userVatCountry: vatCountry,
+						...(locals.user?.hasPosOptions && isFreeVat && { reasonFreeVat }),
+						...(locals.user?.hasPosOptions &&
+							discountAmount &&
+							discountType &&
+							discountJustification && {
+								discount: {
+									amount: discountAmount,
+									type: discountType,
+									justification: discountJustification
+								}
+							}),
+						...(note && { note: note.noteContent }),
+						...(customCheckoutFields.length && { customCheckoutFields }),
+						...(agreements.allowCollectIP && { clientIp: locals.clientIp }),
+						...(locals.user?.hasPosOptions &&
+							runtimeConfig.deliveryFees.allowFreeForPOS &&
+							offerDeliveryFees && { reasonOfferDeliveryFees }),
+						...(receiptNote && { receiptNote: receiptNote.receiptNoteContent }),
+						engagements: {
+							...(agreements.allowCollectIP && {
+								acceptedIPCollect: agreements.allowCollectIP
+							}),
+							...(agreements.teecees && { acceptedTermsOfUse: agreements.teecees }),
+							...(agreements.isOnlyDeposit && {
+								acceptedDepositConditionsAndFullPayment: agreements.isOnlyDeposit
+							}),
+							...(agreements.isVATNullForeigner && {
+								acceptedExportationAndVATObligation: agreements.isVATNullForeigner
+							})
+						},
+						...(physicalFullyPaid && { onLocation: physicalFullyPaid.onLocation }),
+						...(desiredPayment.paymentTimeOut && {
+							paymentTimeOut: desiredPayment.paymentTimeOut
+						}),
+						session
+					}
+				);
+			});
+		} catch (err) {
+			if (err instanceof PaymentGenerationError) {
+				console.error('PaymentGenerationError on /checkout:', err.method, err.reason);
+				await notifySuperAdminPaymentFailure({
+					method: err.method,
+					context: 'e-shop checkout (cart submission)'
+				});
+				return fail(400, { paymentGenerationFailed: true });
+			}
+			throw err;
+		}
 		const displayHeadless =
 			url.searchParams.get('display') === 'headless' ? '?display=headless' : '';
 		throw redirect(303, `/order/${orderId}${displayHeadless}`);

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -22,6 +22,7 @@
 	import { formatBookedDates } from '$lib/utils/formatBookedDates.js';
 
 	export let data;
+	export let form;
 	let submitting = false;
 
 	let actionCount = 0;
@@ -82,27 +83,28 @@
 
 	function checkForm(event: SubmitEvent) {
 		submitting = true;
-		try {
-			for (const input of typedValues(npubInputs)) {
-				if (!input) {
-					continue;
-				}
-
-				input.value = trimPrefix(input.value.trim(), 'nostr:');
-				if (
-					input.value &&
-					(!input.value.startsWith('npub1') || bech32.decodeUnsafe(input.value)?.prefix !== 'npub')
-				) {
-					input.setCustomValidity(t('checkout.invalidNpub'));
-					input.reportValidity();
-
-					event.preventDefault();
-					return;
-				}
+		for (const input of typedValues(npubInputs)) {
+			if (!input) {
+				continue;
 			}
-		} finally {
-			submitting = false;
+
+			input.value = trimPrefix(input.value.trim(), 'nostr:');
+			if (
+				input.value &&
+				(!input.value.startsWith('npub1') || bech32.decodeUnsafe(input.value)?.prefix !== 'npub')
+			) {
+				input.setCustomValidity(t('checkout.invalidNpub'));
+				input.reportValidity();
+
+				event.preventDefault();
+				// Validation failed → the form is NOT being submitted, re-enable the button.
+				submitting = false;
+				return;
+			}
 		}
+		// Validation passed → the browser is submitting to the server now; keep `submitting`
+		// true so the "Payer" button stays disabled until the server response triggers a
+		// navigation (success) or a re-render with `form?.paymentGenerationFailed` (failure).
 	}
 
 	let paymentMethod: (typeof paymentMethods)[0] | undefined = undefined;
@@ -328,6 +330,11 @@
 	>
 		<form id="checkout" method="post" class="col-span-2 flex gap-4 flex-col" on:submit={checkForm}>
 			<h1 class="page-title body-title">{t('checkout.title')}</h1>
+			{#if form?.paymentGenerationFailed}
+				<div class="alert-error">
+					{t('checkout.paymentGenerationFailed')}
+				</div>
+			{/if}
 			<section class="gap-4 grid grid-cols-6">
 				<h2 class="font-light text-2xl col-span-6">{t('checkout.shipmentInfo')}</h2>
 				{#if isDigital}

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -21,7 +21,9 @@
 	import { CUSTOMER_ROLE_ID } from '$lib/types/User.js';
 
 	export let data;
-	export let form;
+	// `form` carries action results from this page's own actions AND from staff actions
+	// posted to /admin/order/[id] or /pos/order/[id] via `use:enhance` in PaymentForm.
+	export let form: { success?: boolean; paymentGenerationFailed?: boolean } | null = null;
 
 	let count = 0;
 
@@ -136,6 +138,12 @@
 			<h1 class="text-3xl body-title">
 				{t('order.singleTitle', { number: data.order.number })}
 			</h1>
+
+			{#if form?.paymentGenerationFailed}
+				<div class="alert-error">
+					{t('checkout.paymentGenerationFailed')}
+				</div>
+			{/if}
 
 			{#if roleIsStaff}
 				<div class="order-labels flex flex-row gap-1">

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/+page.server.ts
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/+page.server.ts
@@ -1,9 +1,15 @@
 import { collections, withTransaction } from '$lib/server/database';
-import { addOrderPayment, onOrderPaymentFailed, paymentMethodExpiration } from '$lib/server/orders';
+import {
+	addOrderPayment,
+	notifySuperAdminPaymentFailure,
+	onOrderPaymentFailed,
+	paymentMethodExpiration,
+	PaymentGenerationError
+} from '$lib/server/orders';
 import { logAccountingEvent, employeeFromLocals } from '$lib/server/accounting-log';
 import { paymentMethods, ALL_PAYMENT_METHODS } from '$lib/server/payment-methods.js';
 import { typedInclude } from '$lib/utils/typedIncludes';
-import { error, redirect } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 
 export const actions = {
@@ -56,38 +62,51 @@ export const actions = {
 			throw error(400, 'Payment method not available for this order');
 		}
 
-		await withTransaction(async (session) => {
-			await logAccountingEvent(
-				{
-					eventType: 'paymentReplace',
-					before: {
-						method: payment.method,
-						paymentId: payment._id.toString(),
-						status: payment.status
+		try {
+			await withTransaction(async (session) => {
+				await logAccountingEvent(
+					{
+						eventType: 'paymentReplace',
+						before: {
+							method: payment.method,
+							paymentId: payment._id.toString(),
+							status: payment.status
+						},
+						after: {
+							method: parsed.method,
+							price: payment.currencySnapshot.main.price
+						},
+						objectId: order._id.toString(),
+						objectType: 'order',
+						...employeeFromLocals(locals)
 					},
-					after: {
-						method: parsed.method,
-						price: payment.currencySnapshot.main.price
-					},
-					objectId: order._id.toString(),
-					objectType: 'order',
-					...employeeFromLocals(locals)
-				},
-				session
-			);
+					session
+				);
 
-			await onOrderPaymentFailed(order, payment, 'canceled', {
-				preserveOrderStatus: true,
-				session
-			});
+				await onOrderPaymentFailed(order, payment, 'canceled', {
+					preserveOrderStatus: true,
+					session
+				});
 
-			await addOrderPayment(order, parsed.method, payment.currencySnapshot.main.price, {
-				expiresAt: paymentMethodExpiration(parsed.method),
-				session,
-				...(parsed.method === 'point-of-sale' &&
-					parsed.posSubtype && { posSubtype: parsed.posSubtype })
+				await addOrderPayment(order, parsed.method, payment.currencySnapshot.main.price, {
+					expiresAt: paymentMethodExpiration(parsed.method),
+					session,
+					...(parsed.method === 'point-of-sale' &&
+						parsed.posSubtype && { posSubtype: parsed.posSubtype })
+				});
 			});
-		});
+		} catch (err) {
+			if (err instanceof PaymentGenerationError) {
+				console.error('PaymentGenerationError on replaceMethod:', err.method, err.reason);
+				await notifySuperAdminPaymentFailure({
+					method: err.method,
+					context: 'customer payment retry / method replacement',
+					orderId: order._id
+				});
+				return fail(400, { paymentGenerationFailed: true });
+			}
+			throw err;
+		}
 		throw redirect(303, request.headers.get('referer') || `/order/${order._id}`);
 	}
 };

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { useI18n } from '$lib/i18n.js';
+
+	export let form;
+
+	const { t } = useI18n();
+</script>
+
+<main class="mx-auto max-w-3xl p-6 flex flex-col gap-4">
+	{#if form?.paymentGenerationFailed}
+		<div class="alert-error">
+			{t('checkout.paymentGenerationFailed')}
+		</div>
+	{/if}
+	<a href="/order/{$page.params.id}" class="body-hyperlink underline">← Order #{$page.params.id}</a>
+</main>

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.server.ts
@@ -12,7 +12,12 @@ import { removeUserCarts } from '$lib/server/cart';
 import { userIdentifier } from '$lib/server/user';
 import { fail, redirect, error } from '@sveltejs/kit';
 import { z } from 'zod';
-import { createOrder, addOrderPayment } from '$lib/server/orders';
+import {
+	createOrder,
+	addOrderPayment,
+	notifySuperAdminPaymentFailure,
+	PaymentGenerationError
+} from '$lib/server/orders';
 import { orderRemainingToPay } from '$lib/types/Order';
 import { CURRENCY_UNIT } from '$lib/types/Currency';
 import { runtimeConfig } from '$lib/server/runtime-config';
@@ -336,18 +341,31 @@ export const actions = {
 					? Math.min(paymentParams.data.customAmount, remainingToPay)
 					: order.currencySnapshot.main.totalPrice.amount;
 
-			await addOrderPayment(
-				order,
-				selectedMethod,
-				{
-					amount: amountToPay,
-					currency: order.currencySnapshot.main.totalPrice.currency
-				},
-				{
-					ignorePendingPayments: true,
-					...(selectedSubtype && { posSubtype: selectedSubtype })
+			try {
+				await addOrderPayment(
+					order,
+					selectedMethod,
+					{
+						amount: amountToPay,
+						currency: order.currencySnapshot.main.totalPrice.currency
+					},
+					{
+						ignorePendingPayments: true,
+						...(selectedSubtype && { posSubtype: selectedSubtype })
+					}
+				);
+			} catch (err) {
+				if (err instanceof PaymentGenerationError) {
+					console.error('PaymentGenerationError on POS split addPayment:', err.method, err.reason);
+					await notifySuperAdminPaymentFailure({
+						method: err.method,
+						context: 'POS split — addPayment',
+						orderId: order._id
+					});
+					return fail(400, { paymentGenerationFailed: true });
 				}
-			);
+				throw err;
+			}
 
 			const returnUrl = `/pos/touch/tab/${params.orderTabSlug}/split?mode=${splitMode}`;
 			throw redirect(303, `/order/${order._id}?returnTo=${encodeURIComponent(returnUrl)}`);

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/split/+page.svelte
@@ -26,6 +26,7 @@
 	const POS_SPLIT_SHARES_MAX_NUMS = 9;
 
 	export let data;
+	export let form;
 	const tabSlug = data.tabSlug;
 	$: tab = data.orderTab;
 
@@ -328,6 +329,11 @@
 	}}
 >
 	<main class="mb-auto flex-grow min-h-0 overflow-y-auto">
+		{#if form?.paymentGenerationFailed}
+			<div class="alert-error m-2">
+				{t('checkout.paymentGenerationFailed')}
+			</div>
+		{/if}
 		<div
 			class="grid {isMobile && (rightPannel !== 'menu' || isPortrait)
 				? 'grid-cols-1'

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -1,12 +1,16 @@
 import { collections } from '$lib/server/database';
-import { createOrder } from '$lib/server/orders';
+import {
+	createOrder,
+	notifySuperAdminPaymentFailure,
+	PaymentGenerationError
+} from '$lib/server/orders';
 import {
 	resolveSubscriptionDuration,
 	resolveSubscriptionReminderSeconds
 } from '$lib/server/subscriptions';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { userQuery } from '$lib/server/user.js';
-import { error, redirect } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import { subHours, subSeconds } from 'date-fns';
 import type { Actions } from './$types';
 
@@ -130,31 +134,44 @@ export const actions: Actions = {
 			throw redirect(303, `/order/${existingPendingOrder._id}`);
 		}
 
-		const orderId = await createOrder(
-			[
+		let orderId: string;
+		try {
+			orderId = await createOrder(
+				[
+					{
+						quantity: 1,
+						product
+					}
+				],
+				paidPayment.method,
 				{
-					quantity: 1,
-					product
-				}
-			],
-			paidPayment.method,
-			{
-				locale: locals.language,
-				user: subscription.user,
-				shippingAddress: lastOrder.shippingAddress,
-				userVatCountry:
-					lastOrder.shippingAddress?.country ||
-					locals.countryCode ||
-					runtimeConfig.vatCountry ||
-					undefined,
-				notifications: {
-					paymentStatus: {
-						...(subscription.user.email && { email: subscription.user.email }),
-						...(subscription.user.npub && { npub: subscription.user.npub })
+					locale: locals.language,
+					user: subscription.user,
+					shippingAddress: lastOrder.shippingAddress,
+					userVatCountry:
+						lastOrder.shippingAddress?.country ||
+						locals.countryCode ||
+						runtimeConfig.vatCountry ||
+						undefined,
+					notifications: {
+						paymentStatus: {
+							...(subscription.user.email && { email: subscription.user.email }),
+							...(subscription.user.npub && { npub: subscription.user.npub })
+						}
 					}
 				}
+			);
+		} catch (err) {
+			if (err instanceof PaymentGenerationError) {
+				console.error('PaymentGenerationError on subscription renewal:', err.method, err.reason);
+				await notifySuperAdminPaymentFailure({
+					method: err.method,
+					context: 'subscription renewal'
+				});
+				return fail(400, { paymentGenerationFailed: true });
 			}
-		);
+			throw err;
+		}
 
 		throw redirect(303, `/order/${orderId}`);
 	}

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -7,12 +7,19 @@
 	const { t, locale } = useI18n();
 
 	export let data;
+	export let form;
 </script>
 
 <main class="mx-auto max-w-7xl py-10 px-6 flex flex-col gap-4 items-start">
 	<h1 class="text-3xl">
 		{t('subscription.singleTitle', { number: data.subscription.number })}
 	</h1>
+
+	{#if form?.paymentGenerationFailed}
+		<div class="alert-error">
+			{t('checkout.paymentGenerationFailed')}
+		</div>
+	{/if}
 
 	<ProductItem product={data.product} picture={data.picture} />
 


### PR DESCRIPTION
## Summary
Fixes #2546.

When a payment processor refuses or stalls when be-BOP asks it to initiate a payment (bad credentials, transient PSP outage, slow remote endpoint…), be-BOP used to throw a raw 402 page at the customer's face — and on some providers like Swiss Bitcoin Pay, the connection would even hang for minutes before flipping to the generic CMS `/error` page. Trust-destroying and impossible to recover from inside the checkout flow.

## Behaviour after fix

### Customer
- A friendly inline banner replaces the error page on every flow that talks to a PSP — e-shop checkout, payment retry on an existing order, subscription renewal, POS split checkout. The customer stays on the page they were on (no redirect) and can try again or change method without losing their cart / order context.
- The banner reads: *"We couldn't initiate your payment. Please try again in a few moments, or contact the shop owner if the problem persists."* Translated in en, fr, de, es-sv, it, nl, pt.
- The **Pay** button on `/checkout` now stays disabled for the **entire** server round-trip (previously re-enabled itself the moment client-side validation finished, allowing accidental duplicate submissions during the seconds the PSP takes to answer).
- Swiss Bitcoin Pay specifically: the connection used to be allowed to hang indefinitely on a bad API key, eventually surfacing a reverse-proxy 5xx HTML page. It now fails fast (15s) and surfaces the same friendly banner as any other PSP failure.

### Staff (on /order/[id])
- The "Add payment" action triggered from the staff view of an order now also surfaces the friendly banner instead of an error page when the PSP refuses. The staff member stays on `/order/[id]` and can retry or pick another method.

### Super-admin
- A new automatic email lands in the shop owner's mailbox each time a payment fails to be initiated, with: the context (checkout / staff add-payment / renewal / POS split / retry), the payment method involved, and a link to the order when one was already created.
- The raw provider error message is deliberately **not** included in the email — several PSPs echo back submitted credentials in their error responses, and emails get forwarded, indexed, shared inboxes happen. The shop owner is told to consult the server logs if they want the gritty detail.

### Admin — new "Test connection" button on every supported PSP page
- On `/admin/stripe`, `/admin/sumup`, `/admin/swiss-bitcoin-pay`, `/admin/paypal` and `/admin/osb`, a new **Test connection** button lets the shop owner validate the saved credentials without waiting for a real customer to hit the broken setup. It triggers a single 1 EUR synthetic payment against the provider; nothing is persisted in be-BOP's own DB, the PSP-side artifact expires on its own.
- Result is displayed inline:
  - **Green banner** on success: credentials work.
  - **Red banner** on failure with a generic *"Connection failed. Please verify the saved credentials and try again."* — same security principle as the email, no raw provider response is shown.
  - **Separate banner** when the provider doesn't answer within 15s ("provider did not respond"), so a network blip is distinguishable from a credentials problem.
- Throttled by a server-side rate limit (5 tries per minute per IP per provider) and a 10s client-side debounce on the button — no spam, no abuse vector against the provider's own rate limits.

## Out of scope
- Distinguishing in the customer banner between *transient* (PSP down, retry in a minute) and *configuration* (bad credentials, contact us) failures. The current message covers both safely. A TODO comment on the new `PaymentGenerationError` class flags this for a follow-up iteration.
- Templatising the super-admin email; for now it follows the same hardcoded-HTML pattern as the existing "NEW DISCOUNT" notification. The comment in code points to PR #1979's broader email-notifications rework which should absorb both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)