### PR TITLE
🐛 Fix premature expiration of Bitcoin onchain payments

### DIFF
--- a/src/lib/components/Order/PaymentItem.svelte
+++ b/src/lib/components/Order/PaymentItem.svelte
@@ -55,7 +55,9 @@
 				amount={payment.price.amount}
 				currency={payment.price.currency}
 			/>
-			- {t(`order.paymentStatus.${payment.status}`)}
+			- {payment.status === 'pending' && payment.awaitingConfirmation
+					? t('order.paymentStatus.awaitingConfirmation')
+					: t(`order.paymentStatus.${payment.status}`)}
 		</span>
 	</summary>
 

--- a/src/lib/components/Order/PaymentItem.svelte
+++ b/src/lib/components/Order/PaymentItem.svelte
@@ -56,8 +56,8 @@
 				currency={payment.price.currency}
 			/>
 			- {payment.status === 'pending' && payment.awaitingConfirmation
-					? t('order.paymentStatus.awaitingConfirmation')
-					: t(`order.paymentStatus.${payment.status}`)}
+				? t('order.paymentStatus.awaitingConfirmation')
+				: t(`order.paymentStatus.${payment.status}`)}
 		</span>
 	</summary>
 

--- a/src/lib/components/Order/PaymentQRCodes.svelte
+++ b/src/lib/components/Order/PaymentQRCodes.svelte
@@ -57,9 +57,15 @@
 	<!-- Payment instruction text -->
 	{#if payment.method !== 'point-of-sale'}
 		<div class="payment-instruction">
-			<p>{t('order.payToComplete')}</p>
-			{#if payment.method === 'bitcoin'}
-				<p>{t('order.payToCompleteBitcoin', { count: payment.confirmationBlocksRequired })}</p>
+			{#if payment.method === 'bitcoin' && payment.awaitingConfirmation}
+				<p class="text-green-600">
+					{t('order.awaitingConfirmationBitcoin', { count: payment.confirmationBlocksRequired })}
+				</p>
+			{:else}
+				<p>{t('order.payToComplete')}</p>
+				{#if payment.method === 'bitcoin'}
+					<p>{t('order.payToCompleteBitcoin', { count: payment.confirmationBlocksRequired })}</p>
+				{/if}
 			{/if}
 		</div>
 	{/if}

--- a/src/lib/server/bitcoin-nodeless.test.ts
+++ b/src/lib/server/bitcoin-nodeless.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { bip84Address, bip48Address } from './bitcoin-nodeless';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { bip84Address, bip48Address, getSatoshiReceivedNodeless } from './bitcoin-nodeless';
+import { runtimeConfig } from './runtime-config';
 
 describe('bitcoin-nodeless', () => {
 	it('should derivate public key', () => {
@@ -121,5 +122,85 @@ describe('bitcoin-nodeless', () => {
 			expect(fromVpub).toBe(fromTpub);
 			expect(fromVpub).toMatch(/^tb1q/);
 		});
+	});
+});
+
+describe('getSatoshiReceivedNodeless', () => {
+	const ADDRESS = 'bc1qrw2swpufzdx9gy4aewv5q45e53stcf95ker0p7';
+	const BLOCK_HEIGHT = 100;
+	const orderCreatedAt = new Date('2026-06-01T00:00:00Z');
+	const AMOUNT = 100_000;
+
+	const secs = (d: Date) => Math.floor(d.getTime() / 1000);
+
+	// One inbound TX paying AMOUNT to ADDRESS. `blockHeight`/`blockTime` omitted → mempool.
+	function makeTx(opts: { blockHeight?: number; blockTime?: Date; amount?: number } = {}) {
+		const confirmed = opts.blockHeight !== undefined && opts.blockTime !== undefined;
+		return {
+			txid: `tx-${opts.blockHeight ?? 'mempool'}-${opts.blockTime?.getTime() ?? 0}`,
+			status: confirmed
+				? { confirmed: true, block_height: opts.blockHeight, block_time: secs(opts.blockTime ?? orderCreatedAt) }
+				: { confirmed: false },
+			vout: [{ scriptpubkey_address: ADDRESS, value: opts.amount ?? AMOUNT }]
+		};
+	}
+
+	function mockFetchTxs(txs: unknown[]) {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => ({ ok: true, status: 200, statusText: 'OK', json: async () => txs }))
+		);
+	}
+
+	beforeEach(() => {
+		runtimeConfig.bitcoinBlockHeight = BLOCK_HEIGHT;
+		runtimeConfig.bitcoinNodeless = {
+			...runtimeConfig.bitcoinNodeless,
+			mempoolUrl: 'https://mempool.example'
+		};
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('counts a full-amount mempool TX as pending, not received', async () => {
+		mockFetchTxs([makeTx()]); // unconfirmed
+		const res = await getSatoshiReceivedNodeless(ADDRESS, 1, orderCreatedAt);
+		expect(res.satReceived).toBe(0);
+		expect(res.pendingSatReceived).toBe(AMOUNT);
+		expect(res.transactions).toHaveLength(0);
+	});
+
+	it('counts a confirmed-but-too-shallow TX as pending, not received', async () => {
+		// block_height 100 with current tip 100 = 1 confirmation, threshold needs 3
+		mockFetchTxs([makeTx({ blockHeight: 100, blockTime: new Date('2026-06-01T01:00:00Z') })]);
+		const res = await getSatoshiReceivedNodeless(ADDRESS, 3, orderCreatedAt);
+		expect(res.satReceived).toBe(0);
+		expect(res.pendingSatReceived).toBe(AMOUNT);
+	});
+
+	it('counts a threshold-confirmed TX as received even when mined after the expiry window', async () => {
+		// Regression guard: the old upper time-bound dropped TXs confirmed late.
+		mockFetchTxs([makeTx({ blockHeight: 98, blockTime: new Date('2027-01-01T00:00:00Z') })]);
+		const res = await getSatoshiReceivedNodeless(ADDRESS, 3, orderCreatedAt);
+		expect(res.satReceived).toBe(AMOUNT);
+		expect(res.pendingSatReceived).toBe(0);
+		expect(res.transactions).toHaveLength(1);
+	});
+
+	it('ignores TXs mined before the order was created', async () => {
+		mockFetchTxs([makeTx({ blockHeight: 50, blockTime: new Date('2026-05-01T00:00:00Z') })]);
+		const res = await getSatoshiReceivedNodeless(ADDRESS, 3, orderCreatedAt);
+		expect(res.satReceived).toBe(0);
+		expect(res.pendingSatReceived).toBe(0);
+		expect(res.transactions).toHaveLength(0);
+	});
+
+	it('counts a mempool TX as received when threshold is 0', async () => {
+		mockFetchTxs([makeTx()]); // unconfirmed
+		const res = await getSatoshiReceivedNodeless(ADDRESS, 0, orderCreatedAt);
+		expect(res.satReceived).toBe(AMOUNT);
+		expect(res.pendingSatReceived).toBe(0);
 	});
 });

--- a/src/lib/server/bitcoin-nodeless.test.ts
+++ b/src/lib/server/bitcoin-nodeless.test.ts
@@ -139,7 +139,11 @@ describe('getSatoshiReceivedNodeless', () => {
 		return {
 			txid: `tx-${opts.blockHeight ?? 'mempool'}-${opts.blockTime?.getTime() ?? 0}`,
 			status: confirmed
-				? { confirmed: true, block_height: opts.blockHeight, block_time: secs(opts.blockTime ?? orderCreatedAt) }
+				? {
+						confirmed: true,
+						block_height: opts.blockHeight,
+						block_time: secs(opts.blockTime ?? orderCreatedAt)
+				  }
 				: { confirmed: false },
 			vout: [{ scriptpubkey_address: ADDRESS, value: opts.amount ?? AMOUNT }]
 		};

--- a/src/lib/server/bitcoin-nodeless.ts
+++ b/src/lib/server/bitcoin-nodeless.ts
@@ -159,10 +159,15 @@ export async function generateDerivationIndex(): Promise<number> {
 export async function getSatoshiReceivedNodeless(
 	address: string,
 	confirmations: number,
-	orderCreatedAt: Date,
-	orderExpiresAt: Date
+	orderCreatedAt: Date
 ): Promise<{
 	satReceived: number;
+	/**
+	 * Funds received from address-paying TXs that are detected but NOT yet confirmed
+	 * to the required threshold (mempool 0-conf, or confirmed but too shallow). Used to
+	 * keep an order `pending` while a payment is in flight instead of expiring it.
+	 */
+	pendingSatReceived: number;
 	transactions: Array<{
 		currency: 'SAT';
 		amount: number;
@@ -200,29 +205,17 @@ export async function getSatoshiReceivedNodeless(
 		)
 		.parse(json);
 
-	const transactions = res
+	// Relevant = TXs paying our (single-use) address, not predating the order.
+	// We intentionally do NOT reject TXs confirmed after `orderExpiresAt`: a payment
+	// broadcast before expiry but mined late (slow blocks) must still count as paid.
+	const relevant = res
 		.filter((tx) => {
-			if (confirmations > 0) {
-				if (
-					!tx.status.block_height ||
-					tx.status.block_height > runtimeConfig.bitcoinBlockHeight - confirmations + 1
-				) {
-					return false;
-				}
-			}
-
 			if (tx.status.confirmed && tx.status.block_time) {
 				const txTime = new Date(tx.status.block_time * 1000);
-
 				if (txTime < orderCreatedAt) {
 					return false;
 				}
-
-				if (txTime > orderExpiresAt) {
-					return false;
-				}
 			}
-
 			return true;
 		})
 		.filter((tx) => tx.vout.some((vout) => vout.scriptpubkey_address === address))
@@ -231,13 +224,22 @@ export async function getSatoshiReceivedNodeless(
 			amount: sum(
 				tx.vout.filter((vout) => vout.scriptpubkey_address === address).map((vout) => vout.value)
 			),
-			id: tx.txid
+			id: tx.txid,
+			// Confirmed to the required depth? (confirmations === 0 → accept unconfirmed)
+			confirmed:
+				confirmations <= 0 ||
+				(!!tx.status.block_height &&
+					tx.status.block_height <= runtimeConfig.bitcoinBlockHeight - confirmations + 1)
 		}));
 
-	const total = sum(transactions.map((tx) => tx.amount));
+	// `transactions` keeps its existing meaning: threshold-confirmed received funds.
+	const transactions = relevant
+		.filter((tx) => tx.confirmed)
+		.map(({ currency, amount, id }) => ({ currency, amount, id }));
 
 	return {
-		satReceived: total,
+		satReceived: sum(transactions.map((tx) => tx.amount)),
+		pendingSatReceived: sum(relevant.filter((tx) => !tx.confirmed).map((tx) => tx.amount)),
 		transactions
 	};
 }

--- a/src/lib/server/locks/order-lock.ts
+++ b/src/lib/server/locks/order-lock.ts
@@ -163,6 +163,36 @@ async function maintainOrders() {
 								if (result.transactions) {
 									payment.transactions = result.transactions;
 								}
+								// Persist the "awaiting confirmation" flag (onchain funds detected
+								// but not yet confirmed) so the buyer-facing order page can show it.
+								// Only write on change — this loop runs every 2s.
+								{
+									const awaitingConfirmation = result.awaitingConfirmation ?? false;
+									const missingSince = result.mempoolMissingSince ?? null;
+									const awaitingChanged =
+										(payment.awaitingConfirmation ?? false) !== awaitingConfirmation;
+									const missingChanged =
+										(payment.mempoolMissingSince?.getTime() ?? null) !==
+										(missingSince?.getTime() ?? null);
+									if (awaitingChanged || missingChanged) {
+										await collections.orders.updateOne(
+											{ _id: order._id, 'payments._id': payment._id },
+											missingSince
+												? {
+														$set: {
+															'payments.$.awaitingConfirmation': awaitingConfirmation,
+															'payments.$.mempoolMissingSince': missingSince
+														}
+												  }
+												: {
+														$set: { 'payments.$.awaitingConfirmation': awaitingConfirmation },
+														$unset: { 'payments.$.mempoolMissingSince': 1 }
+												  }
+										);
+										payment.awaitingConfirmation = awaitingConfirmation;
+										payment.mempoolMissingSince = missingSince ?? undefined;
+									}
+								}
 								break;
 							default:
 								result.status satisfies never;

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -477,7 +477,12 @@ export async function onOrderPaymentFailed(
 					})
 			},
 			$unset: {
-				'payments.$.posTapToPay': 1
+				'payments.$.posTapToPay': 1,
+				// If an onchain TX left the mempool without being mined, the payment
+				// expires as if it was never seen — drop the "awaiting confirmation" mark
+				// and the RBF grace timer.
+				'payments.$.awaitingConfirmation': 1,
+				'payments.$.mempoolMissingSince': 1
 			}
 		},
 		{ returnDocument: 'after', session: opts?.session }

--- a/src/lib/server/sdk/contrib/PPBitcoinNodeless.test.ts
+++ b/src/lib/server/sdk/contrib/PPBitcoinNodeless.test.ts
@@ -23,7 +23,11 @@ describe('PPBitcoinNodeless.checkPayment', () => {
 		return {
 			txid: `tx-${opts.blockHeight ?? 'mempool'}`,
 			status: confirmed
-				? { confirmed: true, block_height: opts.blockHeight, block_time: secs(opts.blockTime ?? ORDER_CREATED_AT) }
+				? {
+						confirmed: true,
+						block_height: opts.blockHeight,
+						block_time: secs(opts.blockTime ?? ORDER_CREATED_AT)
+				  }
 				: { confirmed: false },
 			vout: [{ scriptpubkey_address: ADDRESS, value: AMOUNT }]
 		};

--- a/src/lib/server/sdk/contrib/PPBitcoinNodeless.test.ts
+++ b/src/lib/server/sdk/contrib/PPBitcoinNodeless.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PPBitcoinNodeless from './PPBitcoinNodeless';
+import { runtimeConfig, runtimeConfigUpdatedAt } from '$lib/server/runtime-config';
+import type { Order } from '$lib/types/Order';
+
+describe('PPBitcoinNodeless.checkPayment', () => {
+	const ADDRESS = 'bc1qrw2swpufzdx9gy4aewv5q45e53stcf95ker0p7';
+	const AMOUNT = 100_000;
+	const ORDER_CREATED_AT = new Date('2026-06-01T00:00:00Z');
+
+	const secs = (d: Date) => Math.floor(d.getTime() / 1000);
+	const minutesAgo = (n: number) => new Date(Date.now() - n * 60_000);
+
+	function mockFetchTxs(txs: unknown[]) {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => ({ ok: true, status: 200, statusText: 'OK', json: async () => txs }))
+		);
+	}
+
+	function fullAmountTx(opts: { blockHeight?: number; blockTime?: Date } = {}) {
+		const confirmed = opts.blockHeight !== undefined;
+		return {
+			txid: `tx-${opts.blockHeight ?? 'mempool'}`,
+			status: confirmed
+				? { confirmed: true, block_height: opts.blockHeight, block_time: secs(opts.blockTime ?? ORDER_CREATED_AT) }
+				: { confirmed: false },
+			vout: [{ scriptpubkey_address: ADDRESS, value: AMOUNT }]
+		};
+	}
+
+	function makePayment(over: Partial<Order['payments'][number]> = {}) {
+		return {
+			address: ADDRESS,
+			price: { amount: AMOUNT, currency: 'SAT' },
+			expiresAt: new Date('2026-06-01T00:20:00Z'), // 20 min after order creation
+			...over
+		} as unknown as Order['payments'][number];
+	}
+
+	const order = { createdAt: ORDER_CREATED_AT } as unknown as Order;
+
+	beforeEach(() => {
+		runtimeConfig.bitcoinBlockHeight = 100;
+		runtimeConfig.bitcoinNodeless = {
+			...runtimeConfig.bitcoinNodeless,
+			mempoolUrl: 'https://mempool.example'
+		};
+		runtimeConfig.confirmationBlocksThresholds = {
+			currency: 'SAT',
+			defaultBlocks: 1,
+			thresholds: []
+		};
+		// Skip the rate-limited block-height refresh fetch.
+		runtimeConfigUpdatedAt['bitcoinBlockHeight'] = new Date();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('marks paid once the TX is confirmed to threshold', async () => {
+		mockFetchTxs([fullAmountTx({ blockHeight: 100 })]); // 1 confirmation, threshold 1
+		const res = await PPBitcoinNodeless.checkPayment(makePayment(), order);
+		expect(res.status).toBe('paid');
+	});
+
+	it('holds as awaiting confirmation while a full-amount TX sits in the mempool (before expiry)', async () => {
+		mockFetchTxs([fullAmountTx()]); // unconfirmed
+		const res = await PPBitcoinNodeless.checkPayment(makePayment(), order);
+		expect(res.status).toBe('pending');
+		expect(res.awaitingConfirmation).toBe(true);
+		expect(res.mempoolMissingSince).toBeNull();
+	});
+
+	it('expires past the deadline when no TX was ever seen', async () => {
+		mockFetchTxs([]); // nothing in mempool
+		const res = await PPBitcoinNodeless.checkPayment(
+			makePayment({ expiresAt: minutesAgo(5) }),
+			order
+		);
+		expect(res.status).toBe('expired');
+	});
+
+	it('starts a grace window on the first miss after a previously-seen TX drops', async () => {
+		mockFetchTxs([]); // TX gone from mempool
+		const before = Date.now();
+		const res = await PPBitcoinNodeless.checkPayment(
+			makePayment({ expiresAt: minutesAgo(5), awaitingConfirmation: true }),
+			order
+		);
+		expect(res.status).toBe('pending');
+		expect(res.awaitingConfirmation).toBe(true);
+		expect(res.mempoolMissingSince).toBeInstanceOf(Date);
+		expect((res.mempoolMissingSince as Date).getTime()).toBeGreaterThanOrEqual(before);
+	});
+
+	it('keeps holding within the 3-minute grace window', async () => {
+		mockFetchTxs([]);
+		const missingSince = minutesAgo(1);
+		const res = await PPBitcoinNodeless.checkPayment(
+			makePayment({
+				expiresAt: minutesAgo(5),
+				awaitingConfirmation: true,
+				mempoolMissingSince: missingSince
+			}),
+			order
+		);
+		expect(res.status).toBe('pending');
+		expect((res.mempoolMissingSince as Date).getTime()).toBe(missingSince.getTime());
+	});
+
+	it('expires once the grace window has elapsed', async () => {
+		mockFetchTxs([]);
+		const res = await PPBitcoinNodeless.checkPayment(
+			makePayment({
+				expiresAt: minutesAgo(10),
+				awaitingConfirmation: true,
+				mempoolMissingSince: minutesAgo(5) // > 3 min ago
+			}),
+			order
+		);
+		expect(res.status).toBe('expired');
+	});
+
+	it('resets the grace timer when an RBF replacement reappears', async () => {
+		mockFetchTxs([fullAmountTx()]); // replacement back in mempool
+		const res = await PPBitcoinNodeless.checkPayment(
+			makePayment({
+				expiresAt: minutesAgo(5),
+				awaitingConfirmation: true,
+				mempoolMissingSince: minutesAgo(1)
+			}),
+			order
+		);
+		expect(res.status).toBe('pending');
+		expect(res.awaitingConfirmation).toBe(true);
+		expect(res.mempoolMissingSince).toBeNull();
+	});
+});

--- a/src/lib/server/sdk/contrib/PPBitcoinNodeless.ts
+++ b/src/lib/server/sdk/contrib/PPBitcoinNodeless.ts
@@ -18,6 +18,14 @@ import type {
 } from '../pp';
 import type { Order } from '$lib/types/Order';
 
+/**
+ * Once a full-amount TX has been seen in the mempool past the order's expiry deadline,
+ * keep the order alive for this long after the TX disappears. Rides out the brief gap of
+ * an RBF replacement (original evicted, replacement not yet propagated) or a lagging
+ * mempool backend, instead of expiring an order that is actively being paid.
+ */
+const MEMPOOL_DROP_GRACE_MS = 3 * 60 * 1000;
+
 export default {
 	meta: { processor: 'bitcoin-nodeless', method: 'bitcoin', emoji: '₿' },
 
@@ -54,20 +62,48 @@ export default {
 		const received = await getSatoshiReceivedNodeless(
 			payment.address,
 			nConfirmations,
-			order.createdAt,
-			payment.expiresAt
+			order.createdAt
 		);
 
-		if (received.satReceived >= toSatoshis(payment.price.amount, payment.price.currency)) {
+		const required = toSatoshis(payment.price.amount, payment.price.currency);
+
+		if (received.satReceived >= required) {
 			return {
 				status: 'paid',
 				received: { amount: received.satReceived, currency: 'SAT' },
 				transactions: received.transactions
 			};
 		}
-		if (payment.expiresAt < new Date()) {
+
+		const transactions = received.transactions;
+		// Is a full-amount TX present in the mempool right now (unconfirmed / too shallow)?
+		const seenNow = received.pendingSatReceived >= required;
+
+		if (seenNow) {
+			// Funds committed and awaiting confirmation — hold the order, clear any grace timer.
+			return { status: 'pending', awaitingConfirmation: true, mempoolMissingSince: null, transactions };
+		}
+
+		const now = new Date();
+		if (payment.expiresAt < now) {
+			// Past the deadline with no TX in the mempool right now. If we had already seen a
+			// full-amount TX (RBF replacement may be in flight), ride out a short grace window
+			// before expiring; otherwise expire as if the TX was never seen.
+			if (payment.awaitingConfirmation) {
+				const missingSince = payment.mempoolMissingSince ?? now;
+				if (now.getTime() - missingSince.getTime() < MEMPOOL_DROP_GRACE_MS) {
+					return {
+						status: 'pending',
+						awaitingConfirmation: true,
+						mempoolMissingSince: missingSince,
+						transactions
+					};
+				}
+			}
 			return { status: 'expired' };
 		}
-		return { status: 'pending', transactions: received.transactions };
+
+		// Still within the deadline and no full-amount TX in the mempool: plain pending.
+		return { status: 'pending', awaitingConfirmation: false, mempoolMissingSince: null, transactions };
 	}
 } satisfies PaymentProcessorDefinition;

--- a/src/lib/server/sdk/contrib/PPBitcoinNodeless.ts
+++ b/src/lib/server/sdk/contrib/PPBitcoinNodeless.ts
@@ -81,7 +81,12 @@ export default {
 
 		if (seenNow) {
 			// Funds committed and awaiting confirmation — hold the order, clear any grace timer.
-			return { status: 'pending', awaitingConfirmation: true, mempoolMissingSince: null, transactions };
+			return {
+				status: 'pending',
+				awaitingConfirmation: true,
+				mempoolMissingSince: null,
+				transactions
+			};
 		}
 
 		const now = new Date();
@@ -104,6 +109,11 @@ export default {
 		}
 
 		// Still within the deadline and no full-amount TX in the mempool: plain pending.
-		return { status: 'pending', awaitingConfirmation: false, mempoolMissingSince: null, transactions };
+		return {
+			status: 'pending',
+			awaitingConfirmation: false,
+			mempoolMissingSince: null,
+			transactions
+		};
 	}
 } satisfies PaymentProcessorDefinition;

--- a/src/lib/server/sdk/pp.ts
+++ b/src/lib/server/sdk/pp.ts
@@ -34,6 +34,16 @@ export interface CreatePaymentResult {
 
 export interface CheckPaymentResult {
 	status: 'paid' | 'pending' | 'expired' | 'failed' | 'canceled';
+	/**
+	 * For onchain payments: a full-amount TX is detected but not yet confirmed to the
+	 * required threshold. Surfaced to the buyer as "received, awaiting confirmation".
+	 */
+	awaitingConfirmation?: boolean;
+	/**
+	 * For onchain payments: the persisted start of the post-expiry grace window (see
+	 * `OrderPayment.mempoolMissingSince`). `null` means "clear it". Persisted by the worker.
+	 */
+	mempoolMissingSince?: Date | null;
 	received?: Price;
 	transactions?: Array<{
 		id: string;

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -613,6 +613,11 @@
 			"other": "Die Zahlung wird nach {count} Bestätigungen bestätigt.",
 			"zero": "Die Zahlung wird ohne Wartezeit auf Bestätigungen bestätigt."
 		},
+		"awaitingConfirmationBitcoin": {
+			"one": "Zahlung empfangen — warte auf 1 Bestätigung.",
+			"other": "Zahlung empfangen — warte auf {count} Bestätigungen.",
+			"zero": "Zahlung empfangen — wird bestätigt."
+		},
 		"paymentAccountHolder": "Kontoinhaber",
 		"paymentAccountHolderAddress": "Adresse",
 		"paymentAddress": "Zahlungsadresse",
@@ -626,6 +631,7 @@
 		"paymentLinkGeneric": "Klicken Sie hier, um mit zu bezahlen",
 		"paymentPaidAt": "Zahlung erfolgt am {date}",
 		"paymentStatus": {
+			"awaitingConfirmation": "empfangen, wartet auf Bestätigung",
 			"canceled": "storniert",
 			"canceledTemplate": "Bestellung storniert!",
 			"expired": "abgelaufen",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -613,6 +613,11 @@
 			"other": "Payment will be confirmed after {count} confirmations.",
 			"zero": "Payment will be confirmed without waiting for confirmations."
 		},
+		"awaitingConfirmationBitcoin": {
+			"one": "Payment received — waiting for 1 confirmation.",
+			"other": "Payment received — waiting for {count} confirmations.",
+			"zero": "Payment received — confirming."
+		},
 		"paymentAccountHolder": "Account holder",
 		"paymentAccountHolderAddress": "Address",
 		"paymentAddress": "Payment address",
@@ -626,6 +631,7 @@
 		"paymentLinkGeneric": "Click here to pay with",
 		"paymentPaidAt": "Payment done on {date}",
 		"paymentStatus": {
+			"awaitingConfirmation": "received, awaiting confirmation",
 			"canceled": "canceled",
 			"canceledTemplate": "Order canceled!",
 			"expired": "expired",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -613,6 +613,11 @@
 			"other": "El pago sera confirmado después de {count} confirmaciones.",
 			"zero": "El pago sera confirmado inmediatamente."
 		},
+		"awaitingConfirmationBitcoin": {
+			"one": "Pago recibido — esperando 1 confirmación.",
+			"other": "Pago recibido — esperando {count} confirmaciones.",
+			"zero": "Pago recibido — confirmando."
+		},
 		"paymentAccountHolder": "Titular de la cuenta",
 		"paymentAccountHolderAddress": "Dirección",
 		"paymentAddress": "Dirección de pago",
@@ -626,6 +631,7 @@
 		"paymentLinkGeneric": "Haga clic aquí para pagar con",
 		"paymentPaidAt": "Pago realizado el {date}",
 		"paymentStatus": {
+			"awaitingConfirmation": "recibido, esperando confirmación",
 			"canceled": "cancelado",
 			"canceledTemplate": "¡Pedido cancelado!",
 			"expired": "expirado",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -613,6 +613,11 @@
 			"other": "Le paiement sera validé après {count} confirmations.",
 			"zero": "Le paiement sera validé sans attendre les confirmations."
 		},
+		"awaitingConfirmationBitcoin": {
+			"one": "Paiement reçu — en attente d'1 confirmation.",
+			"other": "Paiement reçu — en attente de {count} confirmations.",
+			"zero": "Paiement reçu — confirmation en cours."
+		},
 		"paymentAccountHolder": "Titulaire du compte",
 		"paymentAccountHolderAddress": "Adresse",
 		"paymentAddress": "Adresse de paiement ",
@@ -626,6 +631,7 @@
 		"paymentLinkGeneric": "Cliquez ici pour payer avec",
 		"paymentPaidAt": "Paiement effectué le {date}",
 		"paymentStatus": {
+			"awaitingConfirmation": "reçu, en attente de confirmation",
 			"canceled": "annulé",
 			"canceledTemplate": "Votre commande a été annulée manuellement en back-office.",
 			"expired": "expiré",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -613,6 +613,11 @@
 			"other": "Il pagamento sarà confermato dopo {count} conferme.",
 			"zero": "Il pagamento sarà effettuato senza aspettare la conferma."
 		},
+		"awaitingConfirmationBitcoin": {
+			"one": "Pagamento ricevuto — in attesa di 1 conferma.",
+			"other": "Pagamento ricevuto — in attesa di {count} conferme.",
+			"zero": "Pagamento ricevuto — conferma in corso."
+		},
 		"paymentAccountHolder": "Intestatario dell'account",
 		"paymentAccountHolderAddress": "Indirizzo",
 		"paymentAddress": "Indirizzo di fatturazione",
@@ -626,6 +631,7 @@
 		"paymentLinkGeneric": "Clicca qui per pagare con",
 		"paymentPaidAt": "Pagamento effetuato il {date}",
 		"paymentStatus": {
+			"awaitingConfirmation": "ricevuto, in attesa di conferma",
 			"canceled": "Annullato",
 			"canceledTemplate": "Ordine annullato canceled!",
 			"expired": "Scaduto",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -613,6 +613,11 @@
 			"other": "De betaling wordt bevestigd na {count} bevestigingen.",
 			"zero": "De betaling wordt bevestigd zonder op bevestigingen te wachten."
 		},
+		"awaitingConfirmationBitcoin": {
+			"one": "Betaling ontvangen — wachten op 1 bevestiging.",
+			"other": "Betaling ontvangen — wachten op {count} bevestigingen.",
+			"zero": "Betaling ontvangen — bevestigen."
+		},
 		"paymentAccountHolder": "Rekeninghouder",
 		"paymentAccountHolderAddress": "Adres",
 		"paymentAddress": "Betaal adres",
@@ -626,6 +631,7 @@
 		"paymentLinkGeneric": "Klik hier om mee te betalen",
 		"paymentPaidAt": "Betaling gedaan op {date}",
 		"paymentStatus": {
+			"awaitingConfirmation": "ontvangen, wacht op bevestiging",
 			"canceled": "geannuleerd",
 			"canceledTemplate": "Bestelling geannuleerd!",
 			"expired": "verlopen",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -613,6 +613,11 @@
 			"other": "O pagamento será confirmado após {count} confirmações.",
 			"zero": "O pagamento será confirmado sem esperar por confirmações."
 		},
+		"awaitingConfirmationBitcoin": {
+			"one": "Pagamento recebido — a aguardar 1 confirmação.",
+			"other": "Pagamento recebido — a aguardar {count} confirmações.",
+			"zero": "Pagamento recebido — a confirmar."
+		},
 		"paymentAccountHolder": "Titular da conta",
 		"paymentAccountHolderAddress": "Morada",
 		"paymentAddress": "Morada de pagamento",
@@ -626,6 +631,7 @@
 		"paymentLinkGeneric": "Clique aqui para pagar com",
 		"paymentPaidAt": "Pagamento efetuado em {date}",
 		"paymentStatus": {
+			"awaitingConfirmation": "recebido, a aguardar confirmação",
 			"canceled": "cancelado",
 			"canceledTemplate": "Encomenda cancelada!",
 			"expired": "expirado",

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -172,6 +172,19 @@ export interface OrderPayment {
 	};
 
 	lastStatusNotified?: OrderPaymentStatus;
+	/**
+	 * Onchain bitcoin only: a full-amount TX has been detected but is not yet confirmed
+	 * to the required threshold. Keeps the order from expiring while funds are in flight
+	 * and lets the buyer see "received, awaiting confirmation".
+	 */
+	awaitingConfirmation?: boolean;
+	/**
+	 * Onchain bitcoin only: when a previously-seen full-amount TX disappeared from the
+	 * mempool *after* the order's expiry deadline. Starts a short grace window so an RBF
+	 * replacement (or a lagging mempool backend) can reappear before the order expires.
+	 * Cleared as soon as the TX is seen again.
+	 */
+	mempoolMissingSince?: Date;
 	bankTransferNumber?: string;
 	detail?: string;
 	cashbackAmount?: Price;

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -148,6 +148,7 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 			currencySnapshot: payment.currencySnapshot,
 			confirmationBlocksRequired:
 				payment.method === 'bitcoin' ? getConfirmationBlocks(payment.price) : 0,
+			awaitingConfirmation: payment.awaitingConfirmation ?? false,
 			...(payment.bankTransferNumber && { bankTransferNumber: payment.bankTransferNumber }),
 			...(payment.detail && { detail: payment.detail }),
 			...(payment.cashbackAmount && { cashbackAmount: payment.cashbackAmount })


### PR DESCRIPTION
Fixes #2587 

## Problem

Orders were expiring the moment the payment deadline passed — even when a full-amount transaction was already visible in the mempool, just not yet confirmed to the required depth.

## Fixes

Three related changes:

- **`getSatoshiReceivedNodeless`** now returns `pendingSatReceived` for TXs detected but not yet confirmed to the required depth, and removes the upper block-time bound that was dropping legitimately-late-mined TXs.
- **`PPBitcoinNodeless`** uses `pendingSatReceived` to keep an order `pending` (with `awaitingConfirmation: true`) while funds are in flight, and adds a 3-minute grace window when a TX disappears from the mempool post-deadline (rides out RBF replacements).
- **`OrderPayment`** gains `awaitingConfirmation` and `mempoolMissingSince` fields; the order-lock worker persists changes on each poll cycle; the buyer-facing order page shows "received, awaiting confirmation" with a per-language block-count message.

## Tests

Added coverage in `bitcoin-nodeless.test.ts` and `PPBitcoinNodeless.test.ts` for the pending/awaiting-confirmation paths and the mempool-disappearance grace window.

## i18n

Added the awaiting-confirmation strings to all 7 translation files (de, en, es-sv, fr, it, nl, pt).