### PR TITLE
🆕🤖 Same-day booking control on bookable products (#2590)

### DIFF
--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -297,6 +297,11 @@
 			sunday: null
 		}
 	};
+	// Default the same-day cutoff hour whenever the operator turns the option on, so the bound
+	// `<input type="time">` has a value to display from the first reactive cycle.
+	$: if (bookingSpec.allowSameDayBooking && !bookingSpec.sameDayBookingMaxHour) {
+		bookingSpec.sameDayBookingMaxHour = '14:00';
+	}
 	let days = typedFromEntries(
 		dayList.map((day) => [
 			day,
@@ -1163,14 +1168,42 @@
 						<div class="bg-indigo-50 p-4 rounded-lg space-y-4">
 							<label class="form-label">
 								Booking slot duration
-								<select name="bookingSpec.slotMinutes" class="form-input">
+								<select
+									name="bookingSpec.slotMinutes"
+									class="form-input"
+									bind:value={bookingSpec.slotMinutes}
+								>
 									{#each bookingSpecSlotOptions as { value, label }}
-										<option {value} selected={product.bookingSpec?.slotMinutes === value}>
+										<option {value}>
 											{label}
 										</option>
 									{/each}
 								</select>
 							</label>
+
+							{#if bookingSpec.slotMinutes === 60 * 24}
+								<label class="form-label flex-row gap-2 items-center">
+									<input
+										type="checkbox"
+										name="bookingSpec.allowSameDayBooking"
+										bind:checked={bookingSpec.allowSameDayBooking}
+									/>
+									<span>Allow booking on same day</span>
+								</label>
+
+								{#if bookingSpec.allowSameDayBooking}
+									<label class="form-label">
+										Max hour for same-day booking (schedule timezone)
+										<input
+											type="time"
+											name="bookingSpec.sameDayBookingMaxHour"
+											class="form-input"
+											bind:value={bookingSpec.sameDayBookingMaxHour}
+											required
+										/>
+									</label>
+								{/if}
+							{/if}
 
 							<label class="form-label">
 								Timezone

--- a/src/lib/components/ScheduleWidget/ScheduleWidgetCalendar.svelte
+++ b/src/lib/components/ScheduleWidget/ScheduleWidgetCalendar.svelte
@@ -28,7 +28,11 @@
 	>;
 	let className = '';
 	export let isDayDisabled: (date: Date) => boolean = () => false;
-	export let selectedDate = new Date();
+	// Type is nullable so consumers that need a "nothing preselected" state can pass `null`
+	// explicitly (booking product page). Default stays `new Date()` so other consumers — notably
+	// the public ScheduleWidget calendar display — keep their "today preselected" behaviour
+	// without needing to bind the prop.
+	export let selectedDate: Date | null = new Date();
 	export let rangeMode = false;
 	export let selectedEndDate: Date | null = null;
 	export let maxRangeDays = 0;
@@ -39,6 +43,24 @@
 	let currentDate = new Date();
 	let days: Date[] = [];
 	let weekDays: string[] = [];
+
+	// Keep the displayed month in sync with the externally-controlled `selectedDate`. Without
+	// this, a preselection in another month (or a click on a spillover day at the grid edge)
+	// would stay on the original page with the selection rendered as a greyed "other-month"
+	// cell — confusing the customer and hiding any selection that falls on a month that has
+	// no spillover at the page edges.
+	let prevSelectedDate: Date | null = null;
+	$: if (selectedDate !== prevSelectedDate) {
+		prevSelectedDate = selectedDate;
+		if (
+			selectedDate &&
+			(selectedDate.getMonth() !== currentDate.getMonth() ||
+				selectedDate.getFullYear() !== currentDate.getFullYear())
+		) {
+			currentDate = startOfMonth(selectedDate);
+			generateCalendar();
+		}
+	}
 
 	let scheduleEventByDay: Record<string, ScheduleEvent[]> = {};
 	for (const event of schedule.events) {
@@ -187,7 +209,7 @@
 					{isEventDay(day) ? 'eventCalendar-hasEvent font-bold' : ''}
 					{isStart || isEnd ? 'ring-2 ring-black' : ''}
 					{inRange ? (disabled ? 'bg-gray-100' : 'bg-blue-100') : ''}
-					{disabled || isOtherMonth ? 'text-gray-300' : ''}
+					{disabled ? 'text-gray-300' : isOtherMonth ? 'text-gray-500' : ''}
 					{inRange && disabled ? 'text-gray-400' : ''}
 					{disabled ? 'cursor-not-allowed' : 'hover:bg-gray-100 cursor-pointer'}"
 				style="background-color:{customColorEvents.length === 1

--- a/src/lib/server/cart.ts
+++ b/src/lib/server/cart.ts
@@ -14,6 +14,7 @@ import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import { userQuery } from './user';
 import { removeEmpty } from '$lib/utils/removeEmpty';
 import { addDays, addMinutes } from 'date-fns';
+import { isSameDayInShopTz, sameDayBookingStatus } from '$lib/utils/sameDayBooking';
 import type { Currency } from '$lib/types/Currency';
 import { toCurrency } from '$lib/utils/toCurrency';
 import { sum } from '$lib/utils/sum';
@@ -23,6 +24,8 @@ export const CART_ERROR_CODES = [
 	'NOT_FOR_SALE',
 	'NOT_PWYW',
 	'BOOKING_INFO_REQUIRED',
+	'BOOKING_SAME_DAY_DISABLED',
+	'BOOKING_SAME_DAY_CUTOFF_PASSED',
 	'MAX_PRICE_EXCEEDED',
 	'SUBSCRIPTION_CUSTOM_PRICE',
 	'NOT_PREORDER',
@@ -180,6 +183,33 @@ export async function addToCartInDb(
 			'BOOKING_INFO_REQUIRED',
 			'Product is a booking, please provide booking time and duration'
 		);
+	}
+
+	// Same-day rule for 24h-slot bookings. Defense in depth — the date picker already greys out
+	// today, but a direct POST (curl, Nostr, stale tab) could still bypass the client check.
+	// All comparisons happen in the shop's timezone via the shared helper.
+	if (product.bookingSpec && params.booking) {
+		const spec = product.bookingSpec;
+		const now = new Date();
+		const tz = spec.schedule.timezone;
+		const datesToCheck = params.booking.bookedDates?.length
+			? params.booking.bookedDates
+			: [params.booking.time];
+		const includesToday = datesToCheck.some((d) => isSameDayInShopTz(d, now, tz));
+		if (includesToday) {
+			const status = sameDayBookingStatus(spec, now);
+			if (status === 'disabled') {
+				cartError('BOOKING_SAME_DAY_DISABLED', 'Same-day booking is not allowed for this product');
+			}
+			if (status === 'cutoffPassed') {
+				const maxHour = spec.sameDayBookingMaxHour ?? '14:00';
+				cartError(
+					'BOOKING_SAME_DAY_CUTOFF_PASSED',
+					`Same-day booking cutoff (${maxHour}) has passed`,
+					{ maxHour }
+				);
+			}
+		}
 	}
 
 	if (

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -94,7 +94,11 @@
 		"vatNullOutsideSellerCountry": "Einfuhrsteuern müssen vom Kunden bei Lieferung an den Zoll entrichtet werden.",
 		"vatRate": "MwSt.-Satz für {country}",
 		"vatSellerCountry": "Das Land ist das Land des Verkäufers.",
-		"maxQuantityReached": "Maximale Menge pro Bestellung erreicht ({max})"
+		"maxQuantityReached": "Maximale Menge pro Bestellung erreicht ({max})",
+		"error": {
+			"BOOKING_SAME_DAY_DISABLED": "Buchungen für heute sind für dieses Produkt nicht verfügbar.",
+			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Buchungen für heute sind nach {maxHour} nicht mehr möglich."
+		}
 	},
 	"cartFromUrl": {
 		"close": "Schließen",
@@ -917,7 +921,11 @@
 			"selectedDate": "Ausgewählt: {date}",
 			"selectedRangeWithAvailable": "{totalDays} Tage ausgewählt, {availableDays} Tage verfügbar: {dates}",
 			"noAvailableDays": "Keine verfügbaren Tage im ausgewählten Bereich",
-			"maxRangeInfo": "Maximaler Buchungszeitraum: {days} Tage"
+			"maxRangeInfo": "Maximaler Buchungszeitraum: {days} Tage",
+			"sameDay": {
+				"disabled": "Buchungen für heute sind für dieses Produkt nicht verfügbar.",
+				"cutoffPassed": "Buchungen für heute sind nach {maxHour} nicht mehr möglich."
+			}
 		},
 		"checkBackLater": "Bitte schauen Sie später wieder vorbei",
 		"cta": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -94,7 +94,11 @@
 		"vatNullOutsideSellerCountry": "Import taxes must be paid by the customer to customs upon delivery.",
 		"vatRate": "VAT rate for {country}",
 		"vatSellerCountry": "The country is the seller's country.",
-		"maxQuantityReached": "Maximum quantity per order reached ({max})"
+		"maxQuantityReached": "Maximum quantity per order reached ({max})",
+		"error": {
+			"BOOKING_SAME_DAY_DISABLED": "Bookings for today are not available for this product.",
+			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Bookings for today are no longer possible past {maxHour}."
+		}
 	},
 	"cartFromUrl": {
 		"close": "Close",
@@ -919,7 +923,11 @@
 			"selectedRangeWithAvailable": "{totalDays} days selected, {availableDays} days available: {dates}",
 			"noAvailableDays": "No available days in selected range",
 			"maxRangeExceeded": "Maximum selection is {days} days",
-			"maxRangeInfo": "Maximum booking period: {days} days"
+			"maxRangeInfo": "Maximum booking period: {days} days",
+			"sameDay": {
+				"disabled": "Bookings for today are not available for this product.",
+				"cutoffPassed": "Bookings for today are no longer possible past {maxHour}."
+			}
 		},
 		"checkBackLater": "Please check back later",
 		"cta": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -94,7 +94,11 @@
 		"vatNullOutsideSellerCountry": "Los impuestos de importación deben ser pagados por el cliente en la aduana al momento de la entrega.",
 		"vatRate": "Tasa de IVA para {country}",
 		"vatSellerCountry": "El país es el del vendedor.",
-		"maxQuantityReached": "Cantidad máxima por pedido alcanzada ({max})"
+		"maxQuantityReached": "Cantidad máxima por pedido alcanzada ({max})",
+		"error": {
+			"BOOKING_SAME_DAY_DISABLED": "Las reservas para hoy no están disponibles para este producto.",
+			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Las reservas para hoy ya no son posibles después de las {maxHour}."
+		}
 	},
 	"cartFromUrl": {
 		"close": "Cerrar",
@@ -917,7 +921,11 @@
 			"selectedDate": "Seleccionado: {date}",
 			"selectedRangeWithAvailable": "{totalDays} días seleccionados, {availableDays} días disponibles: {dates}",
 			"noAvailableDays": "No hay días disponibles en el rango seleccionado",
-			"maxRangeInfo": "Período máximo de reserva: {days} días"
+			"maxRangeInfo": "Período máximo de reserva: {days} días",
+			"sameDay": {
+				"disabled": "Las reservas para hoy no están disponibles para este producto.",
+				"cutoffPassed": "Las reservas para hoy ya no son posibles después de las {maxHour}."
+			}
 		},
 		"checkBackLater": "Por favor, revise más tarde",
 		"cta": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -94,7 +94,11 @@
 		"vatNullOutsideSellerCountry": "La TVA sur les produits physiques devra être acquitée par le client aux douanes lors de la livraison",
 		"vatRate": "Taux de TVA : {country}",
 		"vatSellerCountry": "La TVA est celle du pays du vendeur.",
-		"maxQuantityReached": "Quantité maximale par commande atteinte ({max})"
+		"maxQuantityReached": "Quantité maximale par commande atteinte ({max})",
+		"error": {
+			"BOOKING_SAME_DAY_DISABLED": "Les réservations pour aujourd'hui ne sont pas disponibles pour ce produit.",
+			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Les réservations pour aujourd'hui ne sont plus possibles passé {maxHour}."
+		}
 	},
 	"cartFromUrl": {
 		"close": "Fermer",
@@ -917,7 +921,11 @@
 			"selectedDate": "Sélectionné: {date}",
 			"selectedRangeWithAvailable": "{totalDays} jours sélectionnés, {availableDays} jours disponibles: {dates}",
 			"noAvailableDays": "Aucun jour disponible dans la plage sélectionnée",
-			"maxRangeInfo": "Période de réservation maximale: {days} jours"
+			"maxRangeInfo": "Période de réservation maximale: {days} jours",
+			"sameDay": {
+				"disabled": "Les réservations pour aujourd'hui ne sont pas disponibles pour ce produit.",
+				"cutoffPassed": "Les réservations pour aujourd'hui ne sont plus possibles passé {maxHour}."
+			}
 		},
 		"checkBackLater": "Veuillez revenir plus tard",
 		"cta": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -94,7 +94,11 @@
 		"vatNullOutsideSellerCountry": "Le tasse d'importazione devono essere pagate dal cliente alla ricezione.",
 		"vatRate": "IVA per {country}",
 		"vatSellerCountry": "Il paese è quello del venditore.",
-		"maxQuantityReached": "Quantità massima per ordine raggiunta ({max})"
+		"maxQuantityReached": "Quantità massima per ordine raggiunta ({max})",
+		"error": {
+			"BOOKING_SAME_DAY_DISABLED": "Le prenotazioni per oggi non sono disponibili per questo prodotto.",
+			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Le prenotazioni per oggi non sono più possibili dopo le {maxHour}."
+		}
 	},
 	"cartFromUrl": {
 		"close": "Chiudi",
@@ -917,7 +921,11 @@
 			"selectedDate": "Selezionato: {date}",
 			"selectedRangeWithAvailable": "{totalDays} giorni selezionati, {availableDays} giorni disponibili: {dates}",
 			"noAvailableDays": "Nessun giorno disponibile nell'intervallo selezionato",
-			"maxRangeInfo": "Periodo massimo di prenotazione: {days} giorni"
+			"maxRangeInfo": "Periodo massimo di prenotazione: {days} giorni",
+			"sameDay": {
+				"disabled": "Le prenotazioni per oggi non sono disponibili per questo prodotto.",
+				"cutoffPassed": "Le prenotazioni per oggi non sono più possibili dopo le {maxHour}."
+			}
 		},
 		"checkBackLater": "Ricontrolla tra un po'",
 		"cta": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -94,7 +94,11 @@
 		"vatNullOutsideSellerCountry": "Importbelastingen moeten bij levering door de klant aan de douane worden betaald.",
 		"vatRate": "Btw-tarief voor {country}",
 		"vatSellerCountry": "Het land is het land van de verkoper.",
-		"maxQuantityReached": "Maximale hoeveelheid per bestelling bereikt ({max})"
+		"maxQuantityReached": "Maximale hoeveelheid per bestelling bereikt ({max})",
+		"error": {
+			"BOOKING_SAME_DAY_DISABLED": "Boekingen voor vandaag zijn niet beschikbaar voor dit product.",
+			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Boekingen voor vandaag zijn niet meer mogelijk na {maxHour}."
+		}
 	},
 	"cartFromUrl": {
 		"close": "Sluiten",
@@ -917,7 +921,11 @@
 			"selectedDate": "Geselecteerd: {date}",
 			"selectedRangeWithAvailable": "{totalDays} dagen geselecteerd, {availableDays} dagen beschikbaar: {dates}",
 			"noAvailableDays": "Geen beschikbare dagen in het geselecteerde bereik",
-			"maxRangeInfo": "Maximale boekingsperiode: {days} dagen"
+			"maxRangeInfo": "Maximale boekingsperiode: {days} dagen",
+			"sameDay": {
+				"disabled": "Boekingen voor vandaag zijn niet beschikbaar voor dit product.",
+				"cutoffPassed": "Boekingen voor vandaag zijn niet meer mogelijk na {maxHour}."
+			}
 		},
 		"checkBackLater": "Kom later nog eens terug",
 		"cta": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -94,7 +94,11 @@
 		"vatNullOutsideSellerCountry": "Os impostos de importação devem ser pagos pelo cliente à alfândega no momento da entrega.",
 		"vatRate": "Taxa de IVA para {country}",
 		"vatSellerCountry": "O país é o país do vendedor.",
-		"maxQuantityReached": "Quantidade máxima por encomenda atingida ({max})"
+		"maxQuantityReached": "Quantidade máxima por encomenda atingida ({max})",
+		"error": {
+			"BOOKING_SAME_DAY_DISABLED": "As reservas para hoje não estão disponíveis para este produto.",
+			"BOOKING_SAME_DAY_CUTOFF_PASSED": "As reservas para hoje já não são possíveis após as {maxHour}."
+		}
 	},
 	"cartFromUrl": {
 		"close": "Fechar",
@@ -917,7 +921,11 @@
 			"selectedDate": "Selecionado: {date}",
 			"selectedRangeWithAvailable": "{totalDays} dias selecionados, {availableDays} dias disponíveis: {dates}",
 			"noAvailableDays": "Nenhum dia disponível no intervalo selecionado",
-			"maxRangeInfo": "Período máximo de reserva: {days} dias"
+			"maxRangeInfo": "Período máximo de reserva: {days} dias",
+			"sameDay": {
+				"disabled": "As reservas para hoje não estão disponíveis para este produto.",
+				"cutoffPassed": "As reservas para hoje já não são possíveis após as {maxHour}."
+			}
 		},
 		"checkBackLater": "Por favor, volte a verificar mais tarde",
 		"cta": {

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -66,6 +66,16 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 		slotMinutes: number;
 		/** Maximum number of calendar days selectable in a date range booking. 0 or undefined = unlimited. */
 		maxBookableDays?: number;
+		/**
+		 * Whether the customer can book the current day. Only honored when slotMinutes is a full day
+		 * (24h). Defaults to false: today is not selectable. When true, see sameDayBookingMaxHour.
+		 */
+		allowSameDayBooking?: boolean;
+		/**
+		 * HH:mm cutoff (in the schedule's timezone) past which today is no longer bookable, when
+		 * allowSameDayBooking is true. Defaults to "14:00".
+		 */
+		sameDayBookingMaxHour?: string;
 		schedule: {
 			timezone: string; // eg "Europe/Berlin"
 			monday: {

--- a/src/lib/utils/sameDayBooking.test.ts
+++ b/src/lib/utils/sameDayBooking.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import type { Product } from '$lib/types/Product';
+import {
+	isSameDayInShopTz,
+	sameDayBookingStatus,
+	toShopTzCalendarDayInstant
+} from './sameDayBooking';
+
+type BookingSpec = NonNullable<Product['bookingSpec']>;
+
+function spec(overrides: Partial<BookingSpec> = {}): BookingSpec {
+	return {
+		slotMinutes: 1440,
+		allowSameDayBooking: true,
+		sameDayBookingMaxHour: '14:00',
+		schedule: {
+			timezone: 'Europe/Paris',
+			monday: null,
+			tuesday: null,
+			wednesday: null,
+			thursday: null,
+			friday: null,
+			saturday: null,
+			sunday: null
+		},
+		...overrides
+	};
+}
+
+describe('sameDayBookingStatus', () => {
+	it('returns `null` for hourly bookings (rule does not apply)', () => {
+		const s = spec({ slotMinutes: 60 });
+		expect(sameDayBookingStatus(s, new Date('2026-06-25T08:00:00Z'))).toBe(null);
+	});
+
+	it('returns `disabled` when the admin opted out of same-day booking', () => {
+		const s = spec({ allowSameDayBooking: false });
+		expect(sameDayBookingStatus(s, new Date('2026-06-25T08:00:00Z'))).toBe('disabled');
+	});
+
+	it('returns `null` when same-day is allowed and the cutoff has not been crossed yet', () => {
+		// Paris cutoff at 14:00; "now" is 12:00 Paris (= 10:00 UTC in summer DST).
+		const s = spec({ allowSameDayBooking: true, sameDayBookingMaxHour: '14:00' });
+		expect(sameDayBookingStatus(s, new Date('2026-06-25T10:00:00Z'))).toBe(null);
+	});
+
+	it('returns `cutoffPassed` once the configured cutoff hour has been crossed', () => {
+		// Paris cutoff at 14:00; "now" is 16:00 Paris (= 14:00 UTC in summer DST).
+		const s = spec({ allowSameDayBooking: true, sameDayBookingMaxHour: '14:00' });
+		expect(sameDayBookingStatus(s, new Date('2026-06-25T14:00:00Z'))).toBe('cutoffPassed');
+	});
+
+	it("anchors the cutoff on the shop's timezone, not the visitor's", () => {
+		// Shop in Singapore (UTC+8 year-round). Cutoff 14:00 Singapore = 06:00 UTC.
+		const s = spec({
+			allowSameDayBooking: true,
+			sameDayBookingMaxHour: '14:00',
+			schedule: { ...spec().schedule, timezone: 'Asia/Singapore' }
+		});
+		// 13:30 Singapore = 05:30 UTC → before cutoff
+		expect(sameDayBookingStatus(s, new Date('2026-06-25T05:30:00Z'))).toBe(null);
+		// 14:30 Singapore = 06:30 UTC → past cutoff
+		expect(sameDayBookingStatus(s, new Date('2026-06-25T06:30:00Z'))).toBe('cutoffPassed');
+	});
+});
+
+describe('toShopTzCalendarDayInstant', () => {
+	// Inputs use `new Date(y, m, d)` (runtime-local midnight) so `format(_, 'yyyy-MM-dd')`
+	// yields the intended calendar day regardless of the test runtime timezone (CI = UTC,
+	// dev machines usually not). The point is *not* to test date-fns' `format`, but to lock
+	// in the shop-tz serialization once the visitor's calendar day is known.
+
+	it("serializes the picked day to midnight in the shop's tz (shop far behind UTC)", () => {
+		// Shop in Pacific/Niue (UTC−11 year-round). Midnight 2026-06-25 Niue = 11:00 UTC.
+		const picked = new Date(2026, 5, 25);
+		expect(toShopTzCalendarDayInstant(picked, 'Pacific/Niue').toISOString()).toBe(
+			'2026-06-25T11:00:00.000Z'
+		);
+	});
+
+	it("serializes the picked day to midnight in the shop's tz (shop far ahead of UTC)", () => {
+		// Shop in Pacific/Kiritimati (UTC+14 year-round). Midnight 2026-06-25 there = 10:00 UTC on 2026-06-24.
+		const picked = new Date(2026, 5, 25);
+		expect(toShopTzCalendarDayInstant(picked, 'Pacific/Kiritimati').toISOString()).toBe(
+			'2026-06-24T10:00:00.000Z'
+		);
+	});
+
+	it('honors DST — midnight on the day of the spring-forward transition', () => {
+		// Europe/Paris switches CET→CEST on 2026-03-29 at 02:00 local. Midnight that day is
+		// still CET (UTC+1), so 2026-03-29 00:00 Paris = 2026-03-28 23:00 UTC.
+		const picked = new Date(2026, 2, 29);
+		expect(toShopTzCalendarDayInstant(picked, 'Europe/Paris').toISOString()).toBe(
+			'2026-03-28T23:00:00.000Z'
+		);
+	});
+});
+
+describe('isSameDayInShopTz', () => {
+	it('returns true for two instants that fall on the same shop-tz calendar day', () => {
+		// Shop in Europe/Paris. 2026-06-25 06:00 UTC = 08:00 Paris; 2026-06-25 21:00 UTC = 23:00 Paris.
+		const a = new Date('2026-06-25T06:00:00Z');
+		const b = new Date('2026-06-25T21:00:00Z');
+		expect(isSameDayInShopTz(a, b, 'Europe/Paris')).toBe(true);
+	});
+
+	it('returns false when the shop-tz day boundary sits between the two instants', () => {
+		// 2026-06-25 23:00 UTC = 01:00 Paris on 2026-06-26 → different Paris day than 06:00 UTC.
+		const a = new Date('2026-06-25T06:00:00Z');
+		const b = new Date('2026-06-25T23:00:00Z');
+		expect(isSameDayInShopTz(a, b, 'Europe/Paris')).toBe(false);
+	});
+
+	it("disagrees with the visitor's calendar when the shop tz is far away", () => {
+		// Shop in Pacific/Niue (UTC−11). 2026-06-25 05:00 UTC = 2026-06-24 18:00 Niue,
+		// but 2026-06-25 20:00 UTC = 2026-06-25 09:00 Niue → different days *in Niue*
+		// even though a visitor in UTC would see them both on 2026-06-25.
+		const a = new Date('2026-06-25T05:00:00Z');
+		const b = new Date('2026-06-25T20:00:00Z');
+		expect(isSameDayInShopTz(a, b, 'Pacific/Niue')).toBe(false);
+	});
+});

--- a/src/lib/utils/sameDayBooking.ts
+++ b/src/lib/utils/sameDayBooking.ts
@@ -1,0 +1,63 @@
+import { format } from 'date-fns';
+import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+import type { Product } from '$lib/types/Product';
+
+const FULL_DAY_MINUTES = 24 * 60;
+
+export type SameDayBookingStatus = 'disabled' | 'cutoffPassed' | null;
+
+/**
+ * Decide whether today is bookable for an all-day booking product, in the *shop's* timezone.
+ *
+ * Returns:
+ *  - `'disabled'` when the admin has opted out of same-day booking on this product.
+ *  - `'cutoffPassed'` when same-day is allowed but the configured cutoff hour has been
+ *    crossed (in `spec.schedule.timezone`, not the visitor's tz).
+ *  - `null` when today is bookable, or when the rule is not applicable (slot ≠ all-day).
+ *
+ * Shared client + server so the date picker, the SSR data and the cart `addToCart`
+ * validation cannot drift apart.
+ */
+export function sameDayBookingStatus(
+	spec: NonNullable<Product['bookingSpec']>,
+	now: Date = new Date()
+): SameDayBookingStatus {
+	if (spec.slotMinutes !== FULL_DAY_MINUTES) {
+		return null;
+	}
+	if (!spec.allowSameDayBooking) {
+		return 'disabled';
+	}
+	const maxHour = spec.sameDayBookingMaxHour ?? '14:00';
+	const nowInTz = toZonedTime(now, spec.schedule.timezone);
+	const [mh, mm] = maxHour.split(':').map((s) => parseInt(s, 10));
+	const cutoffMinutes = mh * 60 + mm;
+	const nowMinutes = nowInTz.getHours() * 60 + nowInTz.getMinutes();
+	return nowMinutes >= cutoffMinutes ? 'cutoffPassed' : null;
+}
+
+/**
+ * Convert a calendar day Date (interpreted in the browser's tz) into the UTC instant of
+ * midnight on the same yyyy-MM-dd in the shop's timezone. Use this when serializing the
+ * day the visitor picked so the cart action interprets it as the same calendar day the
+ * visitor saw, even when the visitor and the shop sit in different timezones.
+ */
+export function toShopTzCalendarDayInstant(date: Date, timezone: string): Date {
+	return fromZonedTime(format(date, 'yyyy-MM-dd') + 'T00:00:00', timezone);
+}
+
+/**
+ * Same-calendar-day check evaluated in the shop's timezone. Use this in place of
+ * date-fns `isSameDay` whenever "today" is meant in the shop's reference frame —
+ * the default `isSameDay` compares in the browser tz and drifts as soon as the
+ * visitor's tz differs from the shop's.
+ */
+export function isSameDayInShopTz(date: Date, now: Date, timezone: string): boolean {
+	const d = toZonedTime(date, timezone);
+	const n = toZonedTime(now, timezone);
+	return (
+		d.getFullYear() === n.getFullYear() &&
+		d.getMonth() === n.getMonth() &&
+		d.getDate() === n.getDate()
+	);
+}

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -36,12 +36,14 @@ async function getCartAndRemoveSomeItems(userIdentifier: UserIdentifier): Promis
 	const now = new Date();
 
 	const itemsAfterRemoval = cartInDb.items.filter((item) => {
-		if (!item.booking || item.booking.start >= now) {
+		if (!item.booking) {
 			return true;
 		}
-		const durationMs = item.booking.end.getTime() - item.booking.start.getTime();
-		const is24h = durationMs === 24 * 60 * 60 * 1000;
-		return is24h && item.booking.end > now;
+		// Future bookings stay. Past bookings (start in the past) only stay while their window
+		// has not ended yet — covers same-day single-slot bookings and multi-day ranges that
+		// include today. The previous version used an is24h === durationMs check that silently
+		// dropped any multi-day booking starting today.
+		return item.booking.start >= now || item.booking.end > now;
 	});
 
 	if (itemsAfterRemoval.length !== cartInDb.items.length) {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -78,6 +78,11 @@ export const productBaseSchema = () => ({
 				.min(1)
 				.max(24 * 60),
 			maxBookableDays: z.number({ coerce: true }).int().min(0).default(0),
+			allowSameDayBooking: z.boolean({ coerce: true }).default(false),
+			sameDayBookingMaxHour: z
+				.string()
+				.regex(/^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/)
+				.default('14:00'),
 			schedule: z.object({
 				timezone: z.enum(Intl.supportedValuesOf('timeZone') as [string, ...string[]]),
 				monday: z

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -43,6 +43,11 @@
 	import { RangeList } from '$lib/utils/range-list.js';
 	import { vatMultiplier } from '$lib/utils/vat';
 	import { formatBookedDates } from '$lib/utils/formatBookedDates';
+	import {
+		isSameDayInShopTz,
+		sameDayBookingStatus,
+		toShopTzCalendarDayInstant
+	} from '$lib/utils/sameDayBooking';
 
 	const FULL_DAY_MINUTES = 1440;
 
@@ -53,16 +58,34 @@
 	let errorMessage = '';
 	let currentTime = Date.now();
 	const is24HourSlotInit = data.product.bookingSpec?.slotMinutes === FULL_DAY_MINUTES;
-	const searchStart = startOfDay(is24HourSlotInit ? new Date() : addDays(new Date(), 1));
-	const initialDate =
-		eachDayOfInterval({ start: searchStart, end: addDays(searchStart, 60) }).find(
-			(day) => computeDurations(day, data.scheduleEvents).length > 0
-		) ?? searchStart;
-	let selectedDate = initialDate;
+
+	// Computed up front (not reactive) because the day-finder below relies on it via
+	// computeDurations()/computeFreeIntervals() during script initialisation. The cutoff
+	// transition mid-session is intentionally left to the server: a stale tab past the cutoff
+	// will get a typed cartError when the visitor submits, displayed inline via the existing
+	// red banner.
+	const sameDayBlockedReason = data.product.bookingSpec
+		? sameDayBookingStatus(data.product.bookingSpec)
+		: null;
+
+	function findFirstAvailableDate(evts: Array<{ beginsAt: Date; endsAt?: Date }>): Date | null {
+		const searchStart = startOfDay(is24HourSlotInit ? new Date() : addDays(new Date(), 1));
+		return (
+			eachDayOfInterval({ start: searchStart, end: addDays(searchStart, 60) }).find(
+				(day) => computeDurations(day, evts).length > 0
+			) ?? null
+		);
+	}
+
+	// Cart-aware: a slot already in the customer's cart counts as occupied here too, so the
+	// preselection does not land on a day the customer just blocked themselves.
+	const initialEvents = mergeScheduledAndCartEvents(data.scheduleEvents, data.cart);
+	const initialDate: Date | null = findFirstAvailableDate(initialEvents);
+	let selectedDate: Date | null = initialDate;
 	let selectedEndDate: Date | null = is24HourSlotInit ? initialDate : null;
 	let time = '';
 	let durationMinutes = data.product.bookingSpec?.slotMinutes || 0;
-	const { t, locale, formatDistanceLocale } = useI18n();
+	const { t, te, locale, formatDistanceLocale } = useI18n();
 
 	$: is24HourSlot = data.product.bookingSpec?.slotMinutes === FULL_DAY_MINUTES;
 
@@ -76,16 +99,23 @@
 		);
 	}
 
-	$: availableDatesInRange = is24HourSlot
-		? getAvailableDatesInRange(selectedDate, selectedEndDate, events)
-		: [];
+	$: availableDatesInRange =
+		is24HourSlot && selectedDate
+			? getAvailableDatesInRange(selectedDate, selectedEndDate, events)
+			: [];
 
 	$: if (is24HourSlot && selectedDate && data.product.bookingSpec) {
 		durationMinutes = availableDatesInRange.length * data.product.bookingSpec.slotMinutes;
-		time = selectedDate.toISOString();
+		// Encode the picked day as shop-tz midnight so the server reads the same calendar day
+		// the visitor saw on the calendar, regardless of the browser timezone.
+		time = toShopTzCalendarDayInstant(
+			selectedDate,
+			data.product.bookingSpec.schedule.timezone
+		).toISOString();
 	}
 
-	$: selectedRangeDays = selectedEndDate ? differenceInDays(selectedEndDate, selectedDate) + 1 : 1;
+	$: selectedRangeDays =
+		selectedDate && selectedEndDate ? differenceInDays(selectedEndDate, selectedDate) + 1 : 1;
 
 	function mergeScheduledAndCartEvents(
 		scheduledEvents: typeof data.scheduleEvents,
@@ -110,8 +140,8 @@
 
 	$: events = mergeScheduledAndCartEvents(data.scheduleEvents, data.cart);
 
-	$: durations = computeDurations(selectedDate, events);
-	$: times = computeTimes(selectedDate, durationMinutes, events);
+	$: durations = selectedDate ? computeDurations(selectedDate, events) : [];
+	$: times = selectedDate ? computeTimes(selectedDate, durationMinutes, events) : [];
 
 	// For hourly slots, clamp duration to max available. Skip for 24h slots (range-based duration)
 	$: if (
@@ -222,7 +252,15 @@
 			return [];
 		}
 
-		if (!isSameDay(date, now) && date < now) {
+		const tz = spec.schedule.timezone;
+		const isToday = isSameDayInShopTz(date, now, tz);
+
+		if (!isToday && date < now) {
+			return [];
+		}
+
+		// Today is bookable only when the admin has opted in AND the cutoff hour has not passed.
+		if (isToday && sameDayBlockedReason) {
 			return [];
 		}
 
@@ -248,7 +286,7 @@
 			end: new Date(range[1])
 		}));
 
-		if (isSameDay(date, now)) {
+		if (isToday) {
 			if (is24HourSlot) {
 				return freeIntervals;
 			}
@@ -798,7 +836,12 @@
 								loading = false;
 
 								if (result.type === 'error') {
-									errorMessage = result.error.message;
+									const code = result.error.code;
+									const params = result.error.params ?? {};
+									errorMessage =
+										code && te(`cart.error.${code}`)
+											? t(`cart.error.${code}`, params)
+											: result.error.message;
 									return;
 								}
 
@@ -812,10 +855,14 @@
 									: 1;
 								await invalidate(UrlDependency.Cart);
 								addToCart(priceMultiplier);
-								// Reset selection for 24h slot mode after adding to cart
+								// Reset selection for 24h slot mode after adding to cart. Re-run the
+								// "first available day" search so we don't drop the customer back on today
+								// (or yesterday's slot) when same-day booking is forbidden or fully booked.
+								// Leaves the calendar unpreselected if no slot is available within the window.
 								if (is24HourSlot) {
-									selectedDate = startOfDay(new Date());
-									selectedEndDate = startOfDay(new Date());
+									const next = findFirstAvailableDate(events);
+									selectedDate = next;
+									selectedEndDate = next;
 								}
 								document.body.scrollIntoView();
 							};
@@ -885,6 +932,17 @@
 									<p class="text-sm text-gray-600 mb-2">
 										{t('product.booking.selectDateRange')}
 									</p>
+									{#if sameDayBlockedReason === 'cutoffPassed'}
+										<p class="text-sm text-gray-500 mb-2">
+											{t('product.booking.sameDay.cutoffPassed', {
+												maxHour: data.product.bookingSpec?.sameDayBookingMaxHour ?? '14:00'
+											})}
+										</p>
+									{:else if sameDayBlockedReason === 'disabled'}
+										<p class="text-sm text-gray-500 mb-2">
+											{t('product.booking.sameDay.disabled')}
+										</p>
+									{/if}
 									<ScheduleWidgetCalendar
 										schedule={calendarSchedule}
 										bind:selectedDate
@@ -932,7 +990,16 @@
 									<input
 										type="hidden"
 										name="bookedDates"
-										value={availableDatesInRange.map((d) => d.toISOString()).join(',')}
+										value={availableDatesInRange
+											.map((d) =>
+												data.product.bookingSpec
+													? toShopTzCalendarDayInstant(
+															d,
+															data.product.bookingSpec.schedule.timezone
+													  ).toISOString()
+													: d.toISOString()
+											)
+											.join(',')}
 									/>
 								{:else}
 									<!-- Hourly booking mode: single date + duration + time -->
@@ -979,7 +1046,7 @@
 													<option value="" disabled selected
 														>No available time slots for this date</option
 													>
-												{:else}
+												{:else if selectedDate}
 													{#each times as time}
 														<option value={time.date}>
 															<!-- todo: handle timezone here maybe -->


### PR DESCRIPTION
## Summary
Fixes #2590.

### Bug
On all-day bookable products, trying to book today showed the green "added to cart" pop-in but nothing actually landed in the cart — confusing, no error surfaced.

### Behaviour after fix
Same-day bookings become an explicit shop-owner decision on all-day bookable products:

- New admin checkbox **"Allow booking on same day"**, default **off**. When off, today is greyed out in the date picker and can no longer be selected.
- When on, a **"Max hour for same-day booking"** field appears (default **14:00**). The customer can book today up to this hour; past it, today is greyed out again. The cutoff is evaluated in the **shop's timezone**, not the visitor's.
- Both controls only apply to all-day bookings — hourly bookings (coworking rooms, etc.) are unchanged.

If a same-day request still reaches the server (direct API call, stale tab), it is rejected with a translated inline error in the customer's language instead of being silently dropped or shown as a raw error page. New customer-facing and admin labels added in en, fr, de, es-sv, it, nl, pt.

Multi-day ranges that span unavailable days in the middle (introduced in #2243) are unchanged: those days continue to be silently skipped and the customer is only charged for the available days.

### Data model
- `bookingSpec.allowSameDayBooking?: boolean` — default `false`, honoured only when the slot is a full day.
- `bookingSpec.sameDayBookingMaxHour?: string` — `"HH:mm"` in the schedule's timezone, default `"14:00"`, honoured only when `allowSameDayBooking` is `true`.

Both fields are optional; existing bookable products without them behave as `allowSameDayBooking = false` (today not selectable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)