### PR TITLE
🆕🤖 Per-product paid-order webhook (#2646)

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,8 @@ ALLOW_LND_RPC=
 ALLOW_DUMPING_WALLET=
 #RISKY! Set to "true" to enable JS injection in the admin in CMS pages
 ALLOW_JS_INJECTION=
+# Set to "true" to enable the per-product outbound webhook fired when an order transitions to paid
+ALLOW_PAID_ORDER_WEBHOOK=
 # Specify in .env.local to enable bitcoin on-chain payments
 # example : http://127.0.0.1:8332
 BITCOIN_RPC_URL=

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -2000,7 +2000,8 @@
 										autocomplete="off"
 										name="paidOrderWebhook.secret"
 										class="form-input"
-										placeholder="Used by the receiver to verify the HMAC-SHA256 signature"
+										minlength={16}
+										placeholder="HMAC-SHA256 key used by the receiver to verify the signature (min. 16 chars)"
 										bind:value={paidOrderWebhookSecret}
 										required
 									/>

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -1996,7 +1996,8 @@
 								<label class="form-label">
 									Shared secret
 									<input
-										type="text"
+										type="password"
+										autocomplete="off"
 										name="paidOrderWebhook.secret"
 										class="form-input"
 										placeholder="Used by the receiver to verify the HMAC-SHA256 signature"

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -64,6 +64,7 @@
 	export let productsWithStock: { _id: string; name: string }[] = [];
 	export let currentBookings: BookingSummary[] = [];
 	export let upcomingBookings: BookingSummary[] = [];
+	export let allowPaidOrderWebhook = false;
 
 	export let product: WithId<PojoObject<Product>> = {
 		_id: '',
@@ -291,6 +292,9 @@
 	}
 	let hasMaximumPrice = !!product.maximumPrice;
 	let hasBooking = !!product.bookingSpec;
+	let hasPaidOrderWebhook = !!product.paidOrderWebhook;
+	let paidOrderWebhookApiRoute = product.paidOrderWebhook?.apiRoute ?? '';
+	let paidOrderWebhookSecret = product.paidOrderWebhook?.secret ?? '';
 	let existingScheduleId =
 		!!product.bookingSpec && !isNew ? productToScheduleId(product._id) : undefined;
 	let availableDateStr = product.availableDate?.toJSON().slice(0, 10);
@@ -1966,6 +1970,42 @@
 								/>
 							</div>
 						</div>
+					</div>
+				{/if}
+
+				{#if allowPaidOrderWebhook}
+					<div>
+						<h4 class="text-lg font-medium text-gray-900 mb-3">Paid-order webhook</h4>
+						<label class="checkbox-label">
+							<input type="checkbox" bind:checked={hasPaidOrderWebhook} class="form-checkbox" />
+							This will trigger an API call once order is paid
+						</label>
+						{#if hasPaidOrderWebhook}
+							<div class="space-y-2 pl-6 mt-2">
+								<label class="form-label">
+									API route
+									<input
+										type="url"
+										name="paidOrderWebhook.apiRoute"
+										class="form-input"
+										placeholder="https://example.com/webhooks/order-paid"
+										bind:value={paidOrderWebhookApiRoute}
+										required
+									/>
+								</label>
+								<label class="form-label">
+									Shared secret
+									<input
+										type="text"
+										name="paidOrderWebhook.secret"
+										class="form-input"
+										placeholder="Used by the receiver to verify the HMAC-SHA256 signature"
+										bind:value={paidOrderWebhookSecret}
+										required
+									/>
+								</label>
+							</div>
+						{/if}
 					</div>
 				{/if}
 			</div>

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -1975,7 +1975,9 @@
 
 				{#if allowPaidOrderWebhook}
 					<div>
-						<h4 class="text-lg font-medium text-gray-900 mb-3">Paid-order webhook</h4>
+						<h4 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-3">
+							Paid-order webhook
+						</h4>
 						<label class="checkbox-label">
 							<input type="checkbox" bind:checked={hasPaidOrderWebhook} class="form-checkbox" />
 							This will trigger an API call once order is paid

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -284,7 +284,11 @@ export async function createIndexes() {
 	);
 }
 
-if (!building) {
+// Not under VITEST: there, `cleanDb()` calls `createIndexes()` explicitly (awaited) after each
+// `dropDatabase()`. This fire-and-forget on-'open' trigger would otherwise re-fire when the pool
+// reopens a connection and race the drop — "Cannot create collection … database is in the process
+// of being dropped" surfaces as an unhandled rejection that fails the whole test run.
+if (!building && !env.VITEST) {
 	client.on('open', () => {
 		createIndexes().catch(console.error);
 	});

--- a/src/lib/server/env-config.ts
+++ b/src/lib/server/env-config.ts
@@ -10,6 +10,8 @@ export const ALLOW_DUMPING_WALLET =
 export const ALLOW_JS_INJECTION =
 	dynPrivateEnv.ALLOW_JS_INJECTION ?? staticPrivateEnv.ALLOW_JS_INJECTION;
 export const ALLOW_LND_RPC = dynPrivateEnv.ALLOW_LND_RPC ?? staticPrivateEnv.ALLOW_LND_RPC;
+export const ALLOW_PAID_ORDER_WEBHOOK =
+	dynPrivateEnv.ALLOW_PAID_ORDER_WEBHOOK ?? staticPrivateEnv.ALLOW_PAID_ORDER_WEBHOOK;
 export const BIP84_XPUB = dynPrivateEnv.BIP84_XPUB ?? staticPrivateEnv.BIP84_XPUB;
 export const BITCOIN_RPC_PASSWORD =
 	dynPrivateEnv.BITCOIN_RPC_PASSWORD ?? staticPrivateEnv.BITCOIN_RPC_PASSWORD;

--- a/src/lib/server/order-paid-webhook.test.ts
+++ b/src/lib/server/order-paid-webhook.test.ts
@@ -8,10 +8,18 @@ vi.mock('./env-config', async (importOriginal) => {
 	return { ...actual, ALLOW_PAID_ORDER_WEBHOOK: 'true' };
 });
 
+// Stub DNS so hostname targets resolve to a public IP (203.0.113.10 = TEST-NET-3, non-private)
+// without hitting the network; individual tests override with mockResolvedValueOnce.
+vi.mock('dns/promises', () => ({
+	lookup: vi.fn(async () => [{ address: '203.0.113.10', family: 4 }])
+}));
+
 import { createHmac } from 'crypto';
+import { lookup } from 'dns/promises';
 import { cleanDb } from './test-utils';
 import { collections } from './database';
 import { firePaidOrderWebhooks, stripPaidOrderWebhook } from './order-paid-webhook';
+import { assertPublicWebhookTarget, isPrivateIp, webhookApiRouteIssue } from './webhook-url-guard';
 import type { Order } from '$lib/types/Order';
 import type { Product } from '$lib/types/Product';
 
@@ -67,6 +75,59 @@ describe('stripPaidOrderWebhook', () => {
 	});
 });
 
+describe('webhook-url-guard', () => {
+	it('isPrivateIp flags private / loopback / link-local / metadata addresses', () => {
+		for (const ip of [
+			'127.0.0.1',
+			'10.0.0.5',
+			'172.16.0.1',
+			'192.168.1.1',
+			'169.254.169.254',
+			'100.64.0.1',
+			'::1',
+			'fe80::1',
+			'fd00::1',
+			'::ffff:127.0.0.1'
+		]) {
+			expect(isPrivateIp(ip), ip).toBe(true);
+		}
+		for (const ip of ['93.184.216.34', '8.8.8.8', '203.0.113.10', '2606:4700::1111']) {
+			expect(isPrivateIp(ip), ip).toBe(false);
+		}
+	});
+
+	it('webhookApiRouteIssue rejects non-https, localhost and private literal IPs', () => {
+		expect(webhookApiRouteIssue('http://example.com/hook')).toMatch(/https/);
+		expect(webhookApiRouteIssue('https://localhost/hook')).toMatch(/localhost|internal/);
+		expect(webhookApiRouteIssue('https://foo.local/hook')).toMatch(/localhost|internal/);
+		expect(webhookApiRouteIssue('https://127.0.0.1/hook')).toMatch(/private|loopback/);
+		expect(webhookApiRouteIssue('https://169.254.169.254/latest/meta-data')).toMatch(
+			/private|loopback/
+		);
+		expect(webhookApiRouteIssue('https://[::1]/hook')).toMatch(/private|loopback/);
+		expect(webhookApiRouteIssue('not a url')).toBe('Invalid URL');
+	});
+
+	it('webhookApiRouteIssue accepts a public https URL', () => {
+		expect(webhookApiRouteIssue('https://receiver.example.com/webhooks/order-paid')).toBeNull();
+	});
+
+	it('assertPublicWebhookTarget rejects a hostname that resolves to a private address (DNS rebinding)', async () => {
+		// dns.lookup is overloaded; the { all: true } form returns LookupAddress[] but vi.mocked
+		// resolves the single-address overload, so cast the array through `never`.
+		vi.mocked(lookup).mockResolvedValueOnce([{ address: '10.0.0.9', family: 4 }] as never);
+		await expect(assertPublicWebhookTarget('https://rebind.example.com/hook')).rejects.toThrow(
+			/private address/
+		);
+	});
+
+	it('assertPublicWebhookTarget resolves for a public host', async () => {
+		await expect(
+			assertPublicWebhookTarget('https://receiver.example.com/hook')
+		).resolves.toBeUndefined();
+	});
+});
+
 describe('firePaidOrderWebhooks', () => {
 	let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -95,6 +156,7 @@ describe('firePaidOrderWebhooks', () => {
 		const [url, opts] = fetchMock.mock.calls[0];
 		expect(url).toBe('https://receiver.test/hook');
 		expect(opts.method).toBe('POST');
+		expect(opts.redirect).toBe('error');
 		expect(opts.headers['Content-Type']).toBe('application/json');
 
 		// Signature must be HMAC-SHA256(secret, rawBody) — the exact contract the receiver verifies.
@@ -124,6 +186,14 @@ describe('firePaidOrderWebhooks', () => {
 		await collections.products.insertOne({ _id: 'plain' } as unknown as Product);
 
 		await firePaidOrderWebhooks(makeOrder([{ product: { _id: 'plain' } }]));
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('skips an unsafe target (SSRF guard) without firing — e.g. a legacy http/localhost hook', async () => {
+		await insertWebhookProduct('wh-product', 'http://localhost:8080/hook', 'legacy-secret-1234');
+
+		await firePaidOrderWebhooks(makeOrder([{ product: { _id: 'wh-product' } }]));
 
 		expect(fetchMock).not.toHaveBeenCalled();
 	});

--- a/src/lib/server/order-paid-webhook.test.ts
+++ b/src/lib/server/order-paid-webhook.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Force the feature flag on for the whole file: env-config freezes the flag at import time, so
+// we spread the real module and override only ALLOW_PAID_ORDER_WEBHOOK (every other consumer —
+// ./database etc. — keeps the real values).
+vi.mock('./env-config', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./env-config')>();
+	return { ...actual, ALLOW_PAID_ORDER_WEBHOOK: 'true' };
+});
+
+import { createHmac } from 'crypto';
+import { cleanDb } from './test-utils';
+import { collections } from './database';
+import { firePaidOrderWebhooks, stripPaidOrderWebhook } from './order-paid-webhook';
+import type { Order } from '$lib/types/Order';
+import type { Product } from '$lib/types/Product';
+
+function makeOrder(
+	items: Array<{ product: { _id: string } }>,
+	overrides: Partial<Order> = {}
+): Order {
+	return {
+		number: 4242,
+		items,
+		notifications: { paymentStatus: { email: 'buyer@example.com', npub: null } },
+		customCheckoutFields: [],
+		...overrides
+	} as unknown as Order;
+}
+
+async function insertWebhookProduct(id: string, apiRoute: string, secret: string) {
+	await collections.products.insertOne({
+		_id: id,
+		paidOrderWebhook: { apiRoute, secret }
+	} as unknown as Product);
+}
+
+describe('stripPaidOrderWebhook', () => {
+	it('removes paidOrderWebhook while preserving every other field', () => {
+		const product = {
+			_id: 'p1',
+			name: 'Widget',
+			paidOrderWebhook: { apiRoute: 'https://x.test/hook', secret: 's3cr3t' }
+		} as unknown as Product;
+
+		const stripped = stripPaidOrderWebhook(product);
+
+		expect(stripped).not.toHaveProperty('paidOrderWebhook');
+		expect(stripped._id).toBe('p1');
+		expect((stripped as { name: string }).name).toBe('Widget');
+	});
+
+	it('does not mutate the input product', () => {
+		const product = {
+			_id: 'p1',
+			paidOrderWebhook: { apiRoute: 'https://x.test/hook', secret: 's3cr3t' }
+		} as unknown as Product;
+
+		stripPaidOrderWebhook(product);
+
+		expect(product.paidOrderWebhook).toEqual({ apiRoute: 'https://x.test/hook', secret: 's3cr3t' });
+	});
+
+	it('returns the same object untouched when there is no webhook', () => {
+		const product = { _id: 'p1', name: 'Widget' } as unknown as Product;
+		expect(stripPaidOrderWebhook(product)).toBe(product);
+	});
+});
+
+describe('firePaidOrderWebhooks', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		await cleanDb();
+		fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('POSTs a correctly HMAC-signed payload to the live product endpoint', async () => {
+		const secret = 'super-secret-key';
+		await insertWebhookProduct('wh-product', 'https://receiver.test/hook', secret);
+
+		await firePaidOrderWebhooks(
+			makeOrder([{ product: { _id: 'wh-product' } }], {
+				billingAddress: { firstName: 'Jane', country: 'FR' },
+				customCheckoutFields: [{ slug: 'company', label: 'Company', value: 'Acme' }]
+			} as unknown as Partial<Order>)
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, opts] = fetchMock.mock.calls[0];
+		expect(url).toBe('https://receiver.test/hook');
+		expect(opts.method).toBe('POST');
+		expect(opts.headers['Content-Type']).toBe('application/json');
+
+		// Signature must be HMAC-SHA256(secret, rawBody) — the exact contract the receiver verifies.
+		const expected = 'sha256=' + createHmac('sha256', secret).update(opts.body).digest('hex');
+		expect(opts.headers['X-Webhook-Signature']).toBe(expected);
+
+		const payload = JSON.parse(opts.body);
+		expect(payload.orderNumber).toBe(4242);
+		expect(payload.contact).toEqual({ email: 'buyer@example.com', npub: null });
+		expect(payload.billingAddress).toEqual({ firstName: 'Jane', country: 'FR' });
+		expect(payload.customCheckoutFields).toEqual([
+			{ slug: 'company', label: 'Company', value: 'Acme' }
+		]);
+	});
+
+	it('never sends the secret in the payload or reads the order snapshot', async () => {
+		const secret = 'do-not-leak';
+		await insertWebhookProduct('wh-product', 'https://receiver.test/hook', secret);
+
+		await firePaidOrderWebhooks(makeOrder([{ product: { _id: 'wh-product' } }]));
+
+		const body = fetchMock.mock.calls[0][1].body;
+		expect(body).not.toContain(secret);
+	});
+
+	it('does not fire for products without a webhook configured', async () => {
+		await collections.products.insertOne({ _id: 'plain' } as unknown as Product);
+
+		await firePaidOrderWebhooks(makeOrder([{ product: { _id: 'plain' } }]));
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('fires once per distinct product even when it appears in several line items', async () => {
+		await insertWebhookProduct('wh-product', 'https://receiver.test/hook', 'k');
+
+		await firePaidOrderWebhooks(
+			makeOrder([{ product: { _id: 'wh-product' } }, { product: { _id: 'wh-product' } }])
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('is fire-and-forget: a rejected fetch does not throw', async () => {
+		fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+		await insertWebhookProduct('wh-product', 'https://receiver.test/hook', 'k');
+
+		await expect(
+			firePaidOrderWebhooks(makeOrder([{ product: { _id: 'wh-product' } }]))
+		).resolves.toBeUndefined();
+	});
+
+	it('is fire-and-forget: a non-2xx response does not throw', async () => {
+		fetchMock.mockResolvedValue({ ok: false, status: 500 });
+		await insertWebhookProduct('wh-product', 'https://receiver.test/hook', 'k');
+
+		await expect(
+			firePaidOrderWebhooks(makeOrder([{ product: { _id: 'wh-product' } }]))
+		).resolves.toBeUndefined();
+	});
+});

--- a/src/lib/server/order-paid-webhook.ts
+++ b/src/lib/server/order-paid-webhook.ts
@@ -1,0 +1,91 @@
+import { createHmac } from 'crypto';
+import { collections } from './database';
+import { ALLOW_PAID_ORDER_WEBHOOK } from './env-config';
+import type { Order } from '$lib/types/Order';
+
+function isPaidOrderWebhookEnabled(): boolean {
+	return ALLOW_PAID_ORDER_WEBHOOK === 'true' || ALLOW_PAID_ORDER_WEBHOOK === '1';
+}
+
+export { isPaidOrderWebhookEnabled };
+
+/**
+ * Per-product outbound webhook fired when an order transitions to paid (see issue #2646).
+ *
+ * Fire-and-forget on purpose (PoC scope): a network or 5xx failure is logged via console.error
+ * but never retried. Each product in the order whose `paidOrderWebhook` is configured triggers
+ * its own POST, signed with HMAC-SHA256(secret, raw body) in `X-Webhook-Signature: sha256=<hex>`.
+ *
+ * The payload shape is documented in the PR description; the receiver verifies the signature
+ * by recomputing HMAC-SHA256 with their own copy of the secret over the raw request body, in
+ * constant time.
+ */
+export async function firePaidOrderWebhooks(order: Order): Promise<void> {
+	if (!isPaidOrderWebhookEnabled()) {
+		return;
+	}
+	const productIds = [...new Set(order.items.map((i) => i.product._id))];
+	if (productIds.length === 0) {
+		return;
+	}
+
+	// Use the *live* product config, not the order's snapshot — admins may have wired up the
+	// webhook after the order was placed and we want the freshest endpoint / secret.
+	const products = await collections.products
+		.find({ _id: { $in: productIds } })
+		.project<{ _id: string; paidOrderWebhook?: { apiRoute: string; secret: string } }>({
+			_id: 1,
+			paidOrderWebhook: 1
+		})
+		.toArray();
+
+	const targets = products.filter(
+		(p): p is { _id: string; paidOrderWebhook: { apiRoute: string; secret: string } } =>
+			!!p.paidOrderWebhook?.apiRoute && !!p.paidOrderWebhook?.secret
+	);
+	if (targets.length === 0) {
+		return;
+	}
+
+	const payload = {
+		timestamp: new Date().toISOString(),
+		orderNumber: order.number,
+		contact: {
+			email: order.notifications.paymentStatus.email ?? null,
+			npub: order.notifications.paymentStatus.npub ?? null
+		},
+		...(order.billingAddress && { billingAddress: order.billingAddress }),
+		customCheckoutFields: (order.customCheckoutFields ?? []).map((f) => ({
+			slug: f.slug,
+			label: f.label,
+			...(f.address ? { address: f.address } : { value: f.value ?? '' })
+		}))
+	};
+	const body = JSON.stringify(payload);
+
+	await Promise.all(
+		targets.map(async ({ _id: productId, paidOrderWebhook: hook }) => {
+			const signature = 'sha256=' + createHmac('sha256', hook.secret).update(body).digest('hex');
+			try {
+				const res = await fetch(hook.apiRoute, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-Webhook-Signature': signature
+					},
+					body
+				});
+				if (!res.ok) {
+					console.error(
+						`[paidOrderWebhook] ${hook.apiRoute} for product ${productId} on order ${order.number} returned ${res.status}`
+					);
+				}
+			} catch (err) {
+				console.error(
+					`[paidOrderWebhook] ${hook.apiRoute} for product ${productId} on order ${order.number} failed:`,
+					err
+				);
+			}
+		})
+	);
+}

--- a/src/lib/server/order-paid-webhook.ts
+++ b/src/lib/server/order-paid-webhook.ts
@@ -1,6 +1,7 @@
 import { createHmac } from 'crypto';
 import { collections } from './database';
 import { ALLOW_PAID_ORDER_WEBHOOK } from './env-config';
+import { assertPublicWebhookTarget } from './webhook-url-guard';
 import type { Order } from '$lib/types/Order';
 
 function isPaidOrderWebhookEnabled(): boolean {
@@ -81,10 +82,22 @@ export async function firePaidOrderWebhooks(order: Order): Promise<void> {
 
 	await Promise.all(
 		targets.map(async ({ _id: productId, paidOrderWebhook: hook }) => {
+			// Defence-in-depth against SSRF: re-vet the target at fire time (catches products saved
+			// before this guard existed, and DNS rebinding) and refuse redirects to another host.
+			try {
+				await assertPublicWebhookTarget(hook.apiRoute);
+			} catch (err) {
+				console.error(
+					`[paidOrderWebhook] refusing unsafe target ${hook.apiRoute} for product ${productId} on order ${order.number}:`,
+					err
+				);
+				return;
+			}
 			const signature = 'sha256=' + createHmac('sha256', hook.secret).update(body).digest('hex');
 			try {
 				const res = await fetch(hook.apiRoute, {
 					method: 'POST',
+					redirect: 'error',
 					headers: {
 						'Content-Type': 'application/json',
 						'X-Webhook-Signature': signature

--- a/src/lib/server/order-paid-webhook.ts
+++ b/src/lib/server/order-paid-webhook.ts
@@ -10,6 +10,22 @@ function isPaidOrderWebhookEnabled(): boolean {
 export { isPaidOrderWebhookEnabled };
 
 /**
+ * The webhook config (notably its shared `secret`) must never be persisted into an order document:
+ * the admin JSON endpoint dumps orders verbatim and they sit in plaintext Mongo. The fire path
+ * re-queries the *live* product for the freshest endpoint/secret, so dropping it from the order
+ * snapshot loses nothing. Returns a shallow copy with `paidOrderWebhook` removed (input untouched
+ * when the field is absent, so non-webhook products keep their identity).
+ */
+export function stripPaidOrderWebhook<T extends { paidOrderWebhook?: unknown }>(product: T): T {
+	if (!product.paidOrderWebhook) {
+		return product;
+	}
+	const copy = { ...product };
+	delete copy.paidOrderWebhook;
+	return copy;
+}
+
+/**
  * Per-product outbound webhook fired when an order transitions to paid (see issue #2646).
  *
  * Fire-and-forget on purpose (PoC scope): a network or 5xx failure is logged via console.error

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -9,7 +9,7 @@ import {
 } from '$lib/types/Order';
 import { ClientSession, ObjectId, type WithId } from 'mongodb';
 import { collections, withTransaction } from './database';
-import { firePaidOrderWebhooks } from './order-paid-webhook';
+import { firePaidOrderWebhooks, stripPaidOrderWebhook } from './order-paid-webhook';
 import {
 	Duration,
 	add,
@@ -160,13 +160,15 @@ export async function onOrderPayment(
 	}
 
 	const paidAt = new Date();
-	// Free payments arrive here with `paidAt` already stamped by addOrderPayment; skip the
-	// `paymentDone` audit log in that case so a subsequent retry (e.g. re-processing the same
-	// paid payment) doesn't double-record the event.
+	// Free payments arrive here with `paidAt` already stamped by addOrderPayment (onOrderPayment
+	// is called twice: addOrderPayment + createOrder). `payment.paidAt` is unset only on the very
+	// first call for a given payment, so this is the reliable "first pending→paid transition"
+	// signal — it dedups the `paymentDone` audit log AND the outbound paid-order webhook below, so
+	// a retry (re-processing the same paid payment) doesn't double-record the event or double-fire
+	// the webhook. (`order.status` can't be used: onOrderPayment rebinds its local `order` from the
+	// DB result and never mutates the caller's copy, so it never observes the flip.)
+	// TODO: remove the double-call itself; this guard papers over it.
 	const alreadyPaid = !!payment.paidAt;
-	// Capture whether the order was already paid before this call so we only fire the
-	// per-product paid-order webhook on the first pending→paid transition.
-	const wasPaidBefore = order.status === 'paid';
 
 	payment.status = 'paid'; // for isOrderFullyPaid
 	payment.paidAt = paidAt;
@@ -455,10 +457,15 @@ export async function onOrderPayment(
 		: await withTransaction(fn);
 
 	// Fire-and-forget per-product paid-order webhook (issue #2646). After the transaction so a
-	// network failure can never roll back the paid status; only on the first transition so
-	// re-processing an already-paid order doesn't double-fire.
-	if (!wasPaidBefore && updated.status === 'paid') {
-		void firePaidOrderWebhooks(updated);
+	// network failure can never roll back the paid status; `!alreadyPaid` fires exactly once per
+	// payment, so re-processing an already-paid order and the free-order double-call don't
+	// double-fire. `.catch()` is mandatory: the helper's product query and Promise.all sit outside
+	// its internal per-target try/catch, so a Mongo hiccup would otherwise be an unhandled
+	// rejection that crashes the process — after the payment is already committed.
+	if (!alreadyPaid && updated.status === 'paid') {
+		void firePaidOrderWebhooks(updated).catch((err) => {
+			console.error('[paidOrderWebhook] failed to fire for order', updated.number, err);
+		});
 	}
 
 	return updated;
@@ -1464,7 +1471,9 @@ export async function createOrder(
 			items: items.map((item, i) => ({
 				_id: item._id,
 				quantity: item.quantity,
-				product: item.product,
+				// Strip the webhook config (shared secret) — orders are dumped verbatim by the admin
+				// JSON endpoint and live in plaintext Mongo; the fire path re-reads the live product.
+				product: stripPaidOrderWebhook(item.product),
 				customPrice: item.customPrice,
 				chosenVariations: item.chosenVariations,
 				depositPercentage: item.depositPercentage,

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -9,6 +9,7 @@ import {
 } from '$lib/types/Order';
 import { ClientSession, ObjectId, type WithId } from 'mongodb';
 import { collections, withTransaction } from './database';
+import { firePaidOrderWebhooks } from './order-paid-webhook';
 import {
 	Duration,
 	add,
@@ -163,6 +164,9 @@ export async function onOrderPayment(
 	// `paymentDone` audit log in that case so a subsequent retry (e.g. re-processing the same
 	// paid payment) doesn't double-record the event.
 	const alreadyPaid = !!payment.paidAt;
+	// Capture whether the order was already paid before this call so we only fire the
+	// per-product paid-order webhook on the first pending→paid transition.
+	const wasPaidBefore = order.status === 'paid';
 
 	payment.status = 'paid'; // for isOrderFullyPaid
 	payment.paidAt = paidAt;
@@ -446,7 +450,18 @@ export async function onOrderPayment(
 
 		return ret.value;
 	};
-	return params?.providedSession ? await fn(params.providedSession) : await withTransaction(fn);
+	const updated = params?.providedSession
+		? await fn(params.providedSession)
+		: await withTransaction(fn);
+
+	// Fire-and-forget per-product paid-order webhook (issue #2646). After the transaction so a
+	// network failure can never roll back the paid status; only on the first transition so
+	// re-processing an already-paid order doesn't double-fire.
+	if (!wasPaidBefore && updated.status === 'paid') {
+		void firePaidOrderWebhooks(updated);
+	}
+
+	return updated;
 }
 
 export async function onOrderPaymentFailed(

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -151,6 +151,7 @@ export async function onOrderPayment(
 		tapToPay?: { expiresAt: Date };
 		providedSession?: ClientSession;
 		cashbackAmount?: Price;
+		firstPaidTransition?: boolean;
 	}
 ): Promise<Order> {
 	const invoiceNumber = ((await lastInvoiceNumber()) ?? 0) + 1;
@@ -459,10 +460,13 @@ export async function onOrderPayment(
 	// Fire-and-forget per-product paid-order webhook (issue #2646). After the transaction so a
 	// network failure can never roll back the paid status; `!alreadyPaid` fires exactly once per
 	// payment, so re-processing an already-paid order and the free-order double-call don't
-	// double-fire. `.catch()` is mandatory: the helper's product query and Promise.all sit outside
-	// its internal per-target try/catch, so a Mongo hiccup would otherwise be an unhandled
-	// rejection that crashes the process — after the payment is already committed.
-	if (!alreadyPaid && updated.status === 'paid') {
+	// double-fire. `firstPaidTransition` overrides the guard for free payments: `addOrderPayment`
+	// pre-stamps `paidAt` at creation for `paymentMethod === 'free'`, so `alreadyPaid` reads true
+	// on the very first call and the naked guard would swallow the webhook (issue #2647 review).
+	// `.catch()` is mandatory: the helper's product query and Promise.all sit outside its internal
+	// per-target try/catch, so a Mongo hiccup would otherwise be an unhandled rejection that
+	// crashes the process — after the payment is already committed.
+	if ((!alreadyPaid || params?.firstPaidTransition) && updated.status === 'paid') {
 		void firePaidOrderWebhooks(updated).catch((err) => {
 			console.error('[paidOrderWebhook] failed to fire for order', updated.number, err);
 		});
@@ -2148,7 +2152,10 @@ export async function addOrderPayment(
 	// free payments creating as 'paid'
 	if (isFreePayment) {
 		order.payments.push(payment);
-		await onOrderPayment(order, payment, payment.price, { providedSession: opts?.session });
+		await onOrderPayment(order, payment, payment.price, {
+			providedSession: opts?.session,
+			firstPaidTransition: true
+		});
 	}
 
 	return payment;

--- a/src/lib/server/webhook-url-guard.ts
+++ b/src/lib/server/webhook-url-guard.ts
@@ -1,0 +1,92 @@
+import { lookup } from 'dns/promises';
+import { isIP } from 'net';
+
+/**
+ * Private / loopback / link-local / ULA / CGNAT + cloud-metadata ranges a paid-order webhook must
+ * never reach — otherwise the be-BOP server is a blind-SSRF proxy into internal infrastructure
+ * (an admin, or a compromised admin session on a multi-tenant SaaS, could point `apiRoute` at
+ * `169.254.169.254`, `localhost`, or an internal service).
+ */
+export function isPrivateIp(ip: string): boolean {
+	let addr = ip;
+	if (addr.toLowerCase().startsWith('::ffff:')) {
+		addr = addr.slice('::ffff:'.length); // IPv4-mapped IPv6 → treat as its v4 form
+	}
+	const kind = isIP(addr);
+	if (kind === 4) {
+		const [a, b] = addr.split('.').map(Number);
+		return (
+			a === 0 ||
+			a === 10 ||
+			a === 127 ||
+			(a === 169 && b === 254) || // link-local + AWS/GCP/Azure metadata 169.254.169.254
+			(a === 172 && b >= 16 && b <= 31) ||
+			(a === 192 && b === 168) ||
+			(a === 100 && b >= 64 && b <= 127) // CGNAT (RFC 6598)
+		);
+	}
+	if (kind === 6) {
+		const lower = addr.toLowerCase();
+		return (
+			lower === '::1' || // loopback
+			lower === '::' ||
+			lower.startsWith('fe80') || // link-local
+			lower.startsWith('fc') || // unique-local
+			lower.startsWith('fd')
+		);
+	}
+	return false;
+}
+
+/**
+ * Static, dependency-light checks (no DNS): protocol + literal-host. Returns a human-readable
+ * reason when `rawUrl` is unusable as a webhook target, or `null` when it passes. Used at save
+ * time for immediate admin feedback; DNS-resolved-IP checks run at fire time (see
+ * {@link assertPublicWebhookTarget}) so a host that resolves public at save can't rebind to a
+ * private address at fire time.
+ */
+export function webhookApiRouteIssue(rawUrl: string): string | null {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		return 'Invalid URL';
+	}
+	if (url.protocol !== 'https:') {
+		return 'Webhook URL must use https:// (the payload carries buyer PII)';
+	}
+	const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+	if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) {
+		return 'Webhook URL must not target localhost or the internal network';
+	}
+	if (isIP(host) && isPrivateIp(host)) {
+		return 'Webhook URL must not target a private, loopback or link-local address';
+	}
+	return null;
+}
+
+/**
+ * Fire-time guard: re-runs the static checks, then resolves the hostname and rejects if any
+ * resolved address is private — this is the layer that defeats DNS rebinding (public at save,
+ * private at fire). Throws with the reason when unsafe.
+ *
+ * Note: a small TOCTOU window remains between this lookup and `fetch`'s own resolution; combined
+ * with `redirect: 'error'` on the fetch it closes the practical blind-SSRF paths for a PoC.
+ * Pinning the resolved IP at connect time would remove the window entirely.
+ */
+export async function assertPublicWebhookTarget(rawUrl: string): Promise<void> {
+	const issue = webhookApiRouteIssue(rawUrl);
+	if (issue) {
+		throw new Error(issue);
+	}
+	const host = new URL(rawUrl).hostname.replace(/^\[|\]$/g, '');
+	if (isIP(host)) {
+		return; // literal IP already vetted by webhookApiRouteIssue
+	}
+	const resolved = await lookup(host, { all: true });
+	for (const { address } of resolved) {
+		if (isPrivateIp(address)) {
+			throw new Error(`Webhook host ${host} resolves to a private address (${address})`);
+		}
+	}
+}

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -160,6 +160,16 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 		beginsAt: Date;
 		endsAt: Date;
 	};
+	/**
+	 * Optional outbound webhook fired once the order containing this product transitions to
+	 * paid. Receiver verifies the request via an HMAC-SHA256 signature of the raw body using
+	 * `secret` as the key, transmitted in `X-Webhook-Signature: sha256=<hex>`. Fire-and-forget:
+	 * a network or 5xx failure is logged but not retried (issue #2646 is a PoC).
+	 */
+	paidOrderWebhook?: {
+		apiRoute: string;
+		secret: string;
+	};
 }
 
 export type BasicProductFrontend = Pick<Product, '_id' | 'price' | 'name' | 'variationLabels'>;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/+layout.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+layout.server.ts
@@ -2,6 +2,7 @@ import { adminPrefix } from '$lib/server/admin.js';
 import { isBitcoinConfigured } from '$lib/server/bitcoind';
 import { collections } from '$lib/server/database.js';
 import { isLndConfigured } from '$lib/server/lnd.js';
+import { isPaidOrderWebhookEnabled } from '$lib/server/order-paid-webhook';
 import { paymentMethods } from '$lib/server/payment-methods.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { s3IsConfigured } from '$lib/server/s3.js';
@@ -81,6 +82,7 @@ export async function load({ locals }) {
 		adminPrefix: adminPrefix(),
 		isBitcoinConfigured,
 		isLndConfigured: isLndConfigured(),
+		allowPaidOrderWebhook: isPaidOrderWebhookEnabled(),
 		s3IsConfigured: !!s3IsConfigured(),
 		disabledAdminEntries: runtimeConfig.disabledAdminEntries,
 		backOfficeBookmarks: locals.user

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -26,6 +26,7 @@ import { AnyBulkWriteOperation, ObjectId } from 'mongodb';
 import { isUniqueConstraintError } from '$lib/server/utils/isUniqueConstraintError';
 import { defaultSchedule, productToScheduleId } from '$lib/types/Schedule';
 import { enrichWithOrderNumbers } from '$lib/server/orders';
+import { isPaidOrderWebhookEnabled } from '$lib/server/order-paid-webhook';
 import type { Picture } from '$lib/types/Picture';
 import { logAccountingEvent, employeeFromLocals } from '$lib/server/accounting-log';
 
@@ -123,6 +124,10 @@ export const actions: Actions = {
 				availableDate: formData.get('availableDate') || undefined,
 				tagIds: JSON.parse(String(formData.get('tagIds'))).map((x: { value: string }) => x.value)
 			});
+
+		if (parsed.paidOrderWebhook && !isPaidOrderWebhookEnabled()) {
+			throw error(403, 'Paid-order webhook feature is disabled');
+		}
 
 		if (product.type !== 'resource') {
 			delete parsed.availableDate;
@@ -298,7 +303,8 @@ export const actions: Actions = {
 							stockReference: {
 								productId: parsed.stockReferenceProductId
 							}
-						})
+						}),
+						...(parsed.paidOrderWebhook && { paidOrderWebhook: parsed.paidOrderWebhook })
 					},
 					$unset: {
 						...(!parsed.customPreorderText && { customPreorderText: '' }),
@@ -321,7 +327,8 @@ export const actions: Actions = {
 						...(!parsed.hasSellDisclaimer && { sellDisclaimer: '' }),
 						...(!parsed.payWhatYouWant && { recommendedPWYWAmount: '' }),
 						...(!parsed.bookingSpec && { bookingSpec: '' }),
-						...(!parsed.hasMaximumPrice && { maximumPrice: '' })
+						...(!parsed.hasMaximumPrice && { maximumPrice: '' }),
+						...(!parsed.paidOrderWebhook && { paidOrderWebhook: '' })
 					}
 				}
 			);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
@@ -47,6 +47,7 @@
 	availablePaymentMethods={data.availablePaymentMethods}
 	currentBookings={data.currentBookings}
 	upcomingBookings={data.upcomingBookings}
+	allowPaidOrderWebhook={data.allowPaidOrderWebhook}
 />
 
 <h2 class="text-2xl my-4">Photos</h2>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -10,6 +10,7 @@ import { error, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import { ObjectId } from 'mongodb';
 import { ORIGIN } from '$lib/server/env-config';
+import { isPaidOrderWebhookEnabled } from '$lib/server/order-paid-webhook';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import type { Product } from '$lib/types/Product';
 import { Kind } from 'nostr-tools';
@@ -98,6 +99,10 @@ export const actions: Actions = {
 
 		if (await collections.products.countDocuments({ _id: parsed.slug })) {
 			throw error(409, 'Product with same slug already exists');
+		}
+
+		if (parsed.paidOrderWebhook && !isPaidOrderWebhookEnabled()) {
+			throw error(403, 'Paid-order webhook feature is disabled');
 		}
 
 		const priceAmount = parsed.free
@@ -215,6 +220,7 @@ export const actions: Actions = {
 							...(parsed.restrictPaymentMethods && {
 								paymentMethods: parsed.paymentMethods ?? []
 							}),
+							...(parsed.paidOrderWebhook && { paidOrderWebhook: parsed.paidOrderWebhook }),
 							actionSettings: {
 								eShop: {
 									visible: parsed.eshopVisible,
@@ -357,6 +363,10 @@ export const actions: Actions = {
 			throw error(409, 'Product with same slug already exists');
 		}
 
+		if (parsed.paidOrderWebhook && !isPaidOrderWebhookEnabled()) {
+			throw error(403, 'Paid-order webhook feature is disabled');
+		}
+
 		if (!parsed.availableDate) {
 			parsed.preorder = false;
 		}
@@ -444,6 +454,7 @@ export const actions: Actions = {
 					...(parsed.restrictPaymentMethods && {
 						paymentMethods: parsed.paymentMethods ?? []
 					}),
+					...(parsed.paidOrderWebhook && { paidOrderWebhook: parsed.paidOrderWebhook }),
 					tagIds: product.tagIds,
 					cta: product.cta,
 					externalResources: product.externalResources,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
@@ -23,6 +23,7 @@
 	defaultActionSettings={data.productActionSettings}
 	vatProfiles={data.vatProfiles}
 	availablePaymentMethods={data.availablePaymentMethods}
+	allowPaidOrderWebhook={data.allowPaidOrderWebhook}
 />
 
 {#if data.pictures?.length}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -8,6 +8,7 @@ import { deliveryFeesSchema } from '../config/delivery/schema';
 import { MAX_CONTENT_LIMIT } from '$lib/types/CmsPage';
 import { zodObjectId } from '$lib/server/zod';
 import { paymentMethods, type PaymentMethod } from '$lib/server/payment-methods';
+import { webhookApiRouteIssue } from '$lib/server/webhook-url-guard';
 
 export const productBaseSchema = () => ({
 	name: z.string().trim().min(1).max(MAX_NAME_LIMIT),
@@ -265,8 +266,20 @@ export const productBaseSchema = () => ({
 	hideDiscountExpiration: z.boolean({ coerce: true }).default(false),
 	paidOrderWebhook: z
 		.object({
-			apiRoute: z.string().trim().url(),
-			secret: z.string().trim().min(1)
+			apiRoute: z
+				.string()
+				.trim()
+				.url()
+				.max(2048)
+				.superRefine((val, ctx) => {
+					// Block SSRF/PII-cleartext targets at save time (https-only, no private/loopback host).
+					const issue = webhookApiRouteIssue(val);
+					if (issue) {
+						ctx.addIssue({ code: z.ZodIssueCode.custom, message: issue });
+					}
+				}),
+			// The secret is the HMAC key: a 1-char key makes forged signatures brute-forceable.
+			secret: z.string().trim().min(16).max(256)
 		})
 		.optional()
 });

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -262,5 +262,11 @@ export const productBaseSchema = () => ({
 	sellDisclaimerTitle: z.string().trim().max(60).optional(),
 	sellDisclaimerReason: z.string().trim().max(10_000).optional(),
 	hideFromSEO: z.boolean({ coerce: true }).default(false),
-	hideDiscountExpiration: z.boolean({ coerce: true }).default(false)
+	hideDiscountExpiration: z.boolean({ coerce: true }).default(false),
+	paidOrderWebhook: z
+		.object({
+			apiRoute: z.string().trim().url(),
+			secret: z.string().trim().min(1)
+		})
+		.optional()
 });


### PR DESCRIPTION
## Summary
PoC for #2646.

### Behaviour after fix
A new optional checkbox on `/admin/product/new` and `/admin/product/{id}` — *"This will trigger an API call once order is paid"*. When ticked, the operator fills in an API route URL and a shared secret; once an order containing this product transitions to paid, be-BOP fires a single signed POST to the configured route. Each webhook-enabled product in the order gets its own call. PoC scope: fire-and-forget, no retry.

The receiver verifies the request by recomputing `HMAC-SHA256(secret, raw body)` and comparing in constant time against `X-Webhook-Signature: sha256=<hex>`.

Payload sample:
```json
{
  "timestamp": "2026-06-27T12:34:56.789Z",
  "orderNumber": 12345,
  "contact": { "email": "buyer@example.com", "npub": null },
  "customCheckoutFields": [
    { "slug": "company-name", "label": "Company name", "value": "Acme Inc." },
    { "slug": "billing-address", "label": "Billing address", "address": { "firstName": "Jane", "lastName": "Doe", "address": "12 rue de la Paix", "zip": "75002", "city": "Paris", "country": "FR", "state": null, "companyName": null, "vatNumber": null, "phone": null } }
  ]
}
```

### Data model
- `Product.paidOrderWebhook?: { apiRoute: string; secret: string }` — optional; absent / removed when the operator unticks the checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)