### PR TITLE
🆕🤖 Subscription pricing schedule — unified free trial + calendar discount

### DIFF
--- a/src/lib/components/PaymentMethodSelector.svelte
+++ b/src/lib/components/PaymentMethodSelector.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { useI18n } from '$lib/i18n';
+	import type { PaymentMethod } from '$lib/server/payment-methods';
+
+	export let methods: PaymentMethod[];
+	export let value: PaymentMethod | '' = '';
+	export let name = 'paymentMethod';
+	export let posSubtypes: Array<{ slug: string; name: string }> | undefined = undefined;
+	export let required = true;
+
+	const { t } = useI18n();
+</script>
+
+<label class="form-label col-span-6">
+	{t('checkout.payment.method')}
+
+	<div class="grid grid-cols-2 gap-4 items-center">
+		<select {name} class="form-input" bind:value disabled={methods.length === 0} {required}>
+			{#each methods as method}
+				<option value={method}>
+					{t('checkout.paymentMethod.' + method)}
+				</option>
+			{/each}
+		</select>
+		{#if methods.length === 0}
+			<p class="text-red-400">{t('checkout.paymentMethod.unavailable')}</p>
+		{/if}
+	</div>
+</label>
+{#if value === 'point-of-sale' && posSubtypes?.length}
+	<label class="form-label col-span-6">
+		<span>Payment Type</span>
+		<select name="posSubtype" class="form-input" required>
+			{#each posSubtypes as subtype}
+				<option value={subtype.slug}>
+					{subtype.name}
+				</option>
+			{/each}
+		</select>
+	</label>
+{/if}

--- a/src/lib/components/PaymentMethodSelector.svelte
+++ b/src/lib/components/PaymentMethodSelector.svelte
@@ -9,6 +9,14 @@
 	export let required = true;
 
 	const { t } = useI18n();
+
+	// Same pattern as checkout: auto-select the first eligible method when the parent seeds an
+	// unusable value (`''` on first mount, or a method that just dropped off the eligible list
+	// because the shop disabled it, etc.). Keeps POS operators one click ahead — they hit the
+	// screen already primed on their default method.
+	$: if (methods.length > 0 && !methods.includes(value as PaymentMethod)) {
+		value = methods[0];
+	}
 </script>
 
 <label class="form-label col-span-6">

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -485,120 +485,6 @@
 							{/each}
 						</select>
 					</label>
-
-					<div class="border-t border-gray-200 pt-4">
-						<h3 class="text-lg font-semibold">Pricing phases (promotional schedule)</h3>
-						<p class="text-sm text-gray-600 mt-1 mb-3">
-							Optional. Each phase is billed as a separate period at a fixed VAT-excluded price. The
-							first phase is billed at initial purchase, then one phase per renewal. Once the
-							schedule is exhausted, the subscription reverts to the base price and duration set
-							above. Each buyer identity (email or npub) can benefit from the schedule only once for
-							this product.
-						</p>
-
-						{#each pricingSchedule as phase, i}
-							<div class="border border-gray-300 rounded p-3 mb-2">
-								<div class="flex items-center justify-between mb-2">
-									<span class="font-semibold">Phase {i + 1}</span>
-									<div class="flex gap-1">
-										<button
-											type="button"
-											class="btn btn-gray"
-											disabled={i === 0}
-											on:click={() => movePricingPhase(i, -1)}
-											title="Move up">↑</button
-										>
-										<button
-											type="button"
-											class="btn btn-gray"
-											disabled={i === pricingSchedule.length - 1}
-											on:click={() => movePricingPhase(i, 1)}
-											title="Move down">↓</button
-										>
-										<button
-											type="button"
-											class="btn btn-red"
-											on:click={() => removePricingPhase(i)}
-											title="Delete">🗑</button
-										>
-									</div>
-								</div>
-
-								<div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-									<label class="form-label">
-										Duration
-										<div class="flex gap-1">
-											<input
-												type="number"
-												min="1"
-												step="1"
-												class="form-input w-20"
-												name="pricingSchedule[{i}].value"
-												bind:value={phase.value}
-												required
-											/>
-											<select
-												class="form-input"
-												name="pricingSchedule[{i}].unit"
-												bind:value={phase.unit}
-												required
-											>
-												{#each SUBSCRIPTION_DURATIONS as d}
-													<option value={d}>{d}</option>
-												{/each}
-											</select>
-										</div>
-									</label>
-
-									<label class="form-label">
-										Price (VAT excluded)
-										<input
-											type="number"
-											min="0"
-											step="any"
-											class="form-input"
-											name="pricingSchedule[{i}].priceAmount"
-											bind:value={phase.priceAmount}
-											required
-										/>
-										<span class="text-xs text-gray-500 mt-1 block">
-											Free trial = 0. Currency inherited from the product.
-										</span>
-									</label>
-
-									<label class="form-label">
-										Reminder before end
-										<div class="flex gap-1">
-											<input
-												type="number"
-												min="0"
-												step="1"
-												class="form-input w-20"
-												name="pricingSchedule[{i}].reminderValue"
-												bind:value={phase.reminderValue}
-												required
-											/>
-											<select
-												class="form-input"
-												name="pricingSchedule[{i}].reminderUnit"
-												bind:value={phase.reminderUnit}
-												required
-											>
-												{#each SUBSCRIPTION_DURATIONS as d}
-													<option value={d}>{d}</option>
-												{/each}
-											</select>
-										</div>
-										<span class="text-xs text-gray-500 mt-1 block">0 = no reminder</span>
-									</label>
-								</div>
-							</div>
-						{/each}
-
-						<button type="button" class="btn btn-black" on:click={addPricingPhase}>
-							+ Add phase
-						</button>
-					</div>
 				{/if}
 
 				<label class="w-full block">
@@ -1082,6 +968,122 @@
 							type="button"
 						>
 							Add variation
+						</button>
+					</div>
+				{/if}
+
+				{#if product.type === 'subscription'}
+					<div class="border-t border-gray-200 pt-4">
+						<h3 class="text-lg font-semibold">Pricing phases (promotional schedule)</h3>
+						<p class="text-sm text-gray-600 mt-1 mb-3">
+							Optional. Each phase is billed as a separate period at a fixed VAT-excluded price. The
+							first phase is billed at initial purchase, then one phase per renewal. Once the
+							schedule is exhausted, the subscription reverts to the base price and duration set
+							above. Each buyer identity (email or npub) can benefit from the schedule only once for
+							this product.
+						</p>
+
+						{#each pricingSchedule as phase, i}
+							<div class="border border-gray-300 rounded p-3 mb-2">
+								<div class="flex items-center justify-between mb-2">
+									<span class="font-semibold">Phase {i + 1}</span>
+									<div class="flex gap-1">
+										<button
+											type="button"
+											class="btn btn-gray"
+											disabled={i === 0}
+											on:click={() => movePricingPhase(i, -1)}
+											title="Move up">↑</button
+										>
+										<button
+											type="button"
+											class="btn btn-gray"
+											disabled={i === pricingSchedule.length - 1}
+											on:click={() => movePricingPhase(i, 1)}
+											title="Move down">↓</button
+										>
+										<button
+											type="button"
+											class="btn btn-red"
+											on:click={() => removePricingPhase(i)}
+											title="Delete">🗑</button
+										>
+									</div>
+								</div>
+
+								<div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+									<label class="form-label">
+										Duration
+										<div class="flex gap-1">
+											<input
+												type="number"
+												min="1"
+												step="1"
+												class="form-input w-20"
+												name="pricingSchedule[{i}].value"
+												bind:value={phase.value}
+												required
+											/>
+											<select
+												class="form-input"
+												name="pricingSchedule[{i}].unit"
+												bind:value={phase.unit}
+												required
+											>
+												{#each SUBSCRIPTION_DURATIONS as d}
+													<option value={d}>{d}</option>
+												{/each}
+											</select>
+										</div>
+									</label>
+
+									<label class="form-label">
+										Price (VAT excluded)
+										<input
+											type="number"
+											min="0"
+											step="any"
+											class="form-input"
+											name="pricingSchedule[{i}].priceAmount"
+											bind:value={phase.priceAmount}
+											required
+										/>
+										<span class="text-xs text-gray-500 mt-1 block">
+											Free trial = 0. Currency inherited from the product.
+										</span>
+									</label>
+
+									<label class="form-label">
+										Reminder before end
+										<div class="flex gap-1">
+											<input
+												type="number"
+												min="0"
+												step="1"
+												class="form-input w-20"
+												name="pricingSchedule[{i}].reminderValue"
+												bind:value={phase.reminderValue}
+												required
+											/>
+											<select
+												class="form-input"
+												name="pricingSchedule[{i}].reminderUnit"
+												bind:value={phase.reminderUnit}
+												required
+											>
+												{#each SUBSCRIPTION_DURATIONS as d}
+													<option value={d}>{d}</option>
+												{/each}
+											</select>
+										</div>
+										<span class="text-xs text-gray-500 mt-1 block">0 = no reminder</span>
+									</label>
+								</div>
+							</div>
+						{/each}
+
+						<button type="button" class="btn btn-black" on:click={addPricingPhase}>
+							+ Add phase
 						</button>
 					</div>
 				{/if}

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -102,9 +102,9 @@
 	let vatProfileId = product.vatProfileId || '';
 	let subscriptionDuration = product.subscriptionDuration || '';
 	let subscriptionReminderSeconds: number | '' = product.subscriptionReminderSeconds || '';
-	let pricingSchedule: NonNullable<Product['pricingSchedule']> = (product.pricingSchedule ?? []).map(
-		(p) => ({ ...p })
-	);
+	let pricingSchedule: NonNullable<Product['pricingSchedule']> = (
+		product.pricingSchedule ?? []
+	).map((p) => ({ ...p }));
 	function addPricingPhase() {
 		pricingSchedule = [
 			...pricingSchedule,
@@ -489,11 +489,11 @@
 					<div class="border-t border-gray-200 pt-4">
 						<h3 class="text-lg font-semibold">Pricing phases (promotional schedule)</h3>
 						<p class="text-sm text-gray-600 mt-1 mb-3">
-							Optional. Each phase is billed as a separate period at a fixed VAT-excluded price.
-							The first phase is billed at initial purchase, then one phase per renewal. Once the
+							Optional. Each phase is billed as a separate period at a fixed VAT-excluded price. The
+							first phase is billed at initial purchase, then one phase per renewal. Once the
 							schedule is exhausted, the subscription reverts to the base price and duration set
-							above. Each buyer identity (email or npub) can benefit from the schedule only once
-							for this product.
+							above. Each buyer identity (email or npub) can benefit from the schedule only once for
+							this product.
 						</p>
 
 						{#each pricingSchedule as phase, i}

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -102,6 +102,27 @@
 	let vatProfileId = product.vatProfileId || '';
 	let subscriptionDuration = product.subscriptionDuration || '';
 	let subscriptionReminderSeconds: number | '' = product.subscriptionReminderSeconds || '';
+	let pricingSchedule: NonNullable<Product['pricingSchedule']> = (product.pricingSchedule ?? []).map(
+		(p) => ({ ...p })
+	);
+	function addPricingPhase() {
+		pricingSchedule = [
+			...pricingSchedule,
+			{ value: 1, unit: 'month', priceAmount: 0, reminderValue: 7, reminderUnit: 'day' }
+		];
+	}
+	function removePricingPhase(i: number) {
+		pricingSchedule = pricingSchedule.filter((_, idx) => idx !== i);
+	}
+	function movePricingPhase(i: number, dir: -1 | 1) {
+		const j = i + dir;
+		if (j < 0 || j >= pricingSchedule.length) {
+			return;
+		}
+		const copy = [...pricingSchedule];
+		[copy[i], copy[j]] = [copy[j], copy[i]];
+		pricingSchedule = copy;
+	}
 	let formElement: HTMLFormElement;
 	let variationInput: HTMLInputElement[] = [];
 	let disableDateChange = !isNew;
@@ -464,6 +485,120 @@
 							{/each}
 						</select>
 					</label>
+
+					<div class="border-t border-gray-200 pt-4">
+						<h3 class="text-lg font-semibold">Pricing phases (promotional schedule)</h3>
+						<p class="text-sm text-gray-600 mt-1 mb-3">
+							Optional. Each phase is billed as a separate period at a fixed VAT-excluded price.
+							The first phase is billed at initial purchase, then one phase per renewal. Once the
+							schedule is exhausted, the subscription reverts to the base price and duration set
+							above. Each buyer identity (email or npub) can benefit from the schedule only once
+							for this product.
+						</p>
+
+						{#each pricingSchedule as phase, i}
+							<div class="border border-gray-300 rounded p-3 mb-2">
+								<div class="flex items-center justify-between mb-2">
+									<span class="font-semibold">Phase {i + 1}</span>
+									<div class="flex gap-1">
+										<button
+											type="button"
+											class="btn btn-gray"
+											disabled={i === 0}
+											on:click={() => movePricingPhase(i, -1)}
+											title="Move up">↑</button
+										>
+										<button
+											type="button"
+											class="btn btn-gray"
+											disabled={i === pricingSchedule.length - 1}
+											on:click={() => movePricingPhase(i, 1)}
+											title="Move down">↓</button
+										>
+										<button
+											type="button"
+											class="btn btn-red"
+											on:click={() => removePricingPhase(i)}
+											title="Delete">🗑</button
+										>
+									</div>
+								</div>
+
+								<div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+									<label class="form-label">
+										Duration
+										<div class="flex gap-1">
+											<input
+												type="number"
+												min="1"
+												step="1"
+												class="form-input w-20"
+												name="pricingSchedule[{i}].value"
+												bind:value={phase.value}
+												required
+											/>
+											<select
+												class="form-input"
+												name="pricingSchedule[{i}].unit"
+												bind:value={phase.unit}
+												required
+											>
+												{#each SUBSCRIPTION_DURATIONS as d}
+													<option value={d}>{d}</option>
+												{/each}
+											</select>
+										</div>
+									</label>
+
+									<label class="form-label">
+										Price (VAT excluded)
+										<input
+											type="number"
+											min="0"
+											step="any"
+											class="form-input"
+											name="pricingSchedule[{i}].priceAmount"
+											bind:value={phase.priceAmount}
+											required
+										/>
+										<span class="text-xs text-gray-500 mt-1 block">
+											Free trial = 0. Currency inherited from the product.
+										</span>
+									</label>
+
+									<label class="form-label">
+										Reminder before end
+										<div class="flex gap-1">
+											<input
+												type="number"
+												min="0"
+												step="1"
+												class="form-input w-20"
+												name="pricingSchedule[{i}].reminderValue"
+												bind:value={phase.reminderValue}
+												required
+											/>
+											<select
+												class="form-input"
+												name="pricingSchedule[{i}].reminderUnit"
+												bind:value={phase.reminderUnit}
+												required
+											>
+												{#each SUBSCRIPTION_DURATIONS as d}
+													<option value={d}>{d}</option>
+												{/each}
+											</select>
+										</div>
+										<span class="text-xs text-gray-500 mt-1 block">0 = no reminder</span>
+									</label>
+								</div>
+							</div>
+						{/each}
+
+						<button type="button" class="btn btn-black" on:click={addPricingPhase}>
+							+ Add phase
+						</button>
+					</div>
 				{/if}
 
 				<label class="w-full block">

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -41,7 +41,12 @@
 	import { formatDuration } from '$lib/utils/formatDuration';
 	import { formatDistance } from 'date-fns';
 	import { computeVatRate } from '$lib/utils/vat';
-	import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
+	import {
+		SUBSCRIPTION_DURATIONS,
+		subscriptionUnitToSeconds
+	} from '$lib/types/SubscriptionDuration';
+
+	const MAX_PHASE_REMINDER_SECONDS = 7 * 24 * 60 * 60;
 
 	const { t } = useI18n();
 
@@ -984,6 +989,13 @@
 						</p>
 
 						{#each pricingSchedule as phase, i}
+							{@const maxReminderSeconds = Math.min(
+								MAX_PHASE_REMINDER_SECONDS,
+								subscriptionUnitToSeconds(1, phase.unit)
+							)}
+							{@const maxReminderValue = Math.floor(
+								maxReminderSeconds / subscriptionUnitToSeconds(1, phase.reminderUnit)
+							)}
 							<div class="border border-gray-300 rounded p-3 mb-2">
 								<div class="flex items-center justify-between mb-2">
 									<span class="font-semibold">Phase {i + 1}</span>
@@ -1061,6 +1073,7 @@
 												min="0"
 												step="1"
 												class="form-input w-20"
+												max={maxReminderValue}
 												name="pricingSchedule[{i}].reminderValue"
 												bind:value={phase.reminderValue}
 												required

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -1032,6 +1032,7 @@
 												min="1"
 												step="1"
 												class="form-input w-20"
+												max="10"
 												name="pricingSchedule[{i}].value"
 												bind:value={phase.value}
 												required
@@ -1095,7 +1096,12 @@
 							</div>
 						{/each}
 
-						<button type="button" class="btn btn-black" on:click={addPricingPhase}>
+						<button
+							type="button"
+							class="btn btn-black"
+							on:click={addPricingPhase}
+							disabled={pricingSchedule.length >= 10}
+						>
 							+ Add phase
 						</button>
 					</div>

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -1085,7 +1085,7 @@
 												bind:value={phase.reminderUnit}
 												required
 											>
-												{#each SUBSCRIPTION_DURATIONS as d}
+												{#each ['day', 'hour'] as d}
 													<option value={d}>{d}</option>
 												{/each}
 											</select>

--- a/src/lib/server/cart.ts
+++ b/src/lib/server/cart.ts
@@ -288,6 +288,24 @@ export async function addToCartInDb(
 		cartError('VARIATION_INVALID', 'error matching on variations choice');
 	}
 
+	// Subscription pricing schedule: when a fresh purchase (no prior subscription for this
+	// buyer identity) hits a product with a schedule, price the cart line at phase 1 so cart,
+	// checkout and order totals all agree. Renewals never come through addToCart — they call
+	// createOrder directly, which resolves the phase from the subscription snapshot there.
+	if (product.type === 'subscription' && product.pricingSchedule?.length) {
+		const existingSub = await collections.paidSubscriptions.findOne(
+			{ ...userQuery(params.user), productId: product._id },
+			{ projection: { _id: 1 } }
+		);
+		if (!existingSub) {
+			const phase = product.pricingSchedule[0];
+			params.customPrice = {
+				amount: phase.priceAmount,
+				currency: product.price.currency
+			};
+		}
+	}
+
 	if (existingItem && !product.standalone && !product.bookingSpec) {
 		existingItem.quantity = params.totalQuantity ? quantity : existingItem.quantity + quantity;
 
@@ -302,6 +320,9 @@ export async function addToCartInDb(
 
 		if (product.type === 'subscription') {
 			existingItem.quantity = 1;
+			if (params.customPrice) {
+				existingItem.customPrice = params.customPrice;
+			}
 		}
 		existingItem.reservedUntil = addMinutes(new Date(), runtimeConfig.reserveStockInMinutes);
 	} else {

--- a/src/lib/server/locks/subscription-lock.ts
+++ b/src/lib/server/locks/subscription-lock.ts
@@ -20,11 +20,12 @@ async function isSubscriptionDueForReminder(
 	subscription: PaidSubscription,
 	now: Date
 ): Promise<boolean> {
-	// While the schedule still has phases to bill, the reminder offset comes from the current
-	// phase's snapshot. Past-schedule (or legacy subscriptions with no snapshot) fall back to
-	// the product-level reminder.
-	const activePhase =
-		subscription.pricingScheduleSnapshot?.phases[subscription.pricingScheduleCursor ?? 0];
+	// The cursor points at the phase to bill on the *next* renewal, so the phase that funded
+	// the *current* period (up to paidUntil) is at `cursor - 1`. Its reminder offset is what
+	// counts for "how long before paidUntil to warn the customer". Past-schedule (or legacy
+	// subscriptions with no snapshot) fall back to the product-level reminder.
+	const currentPhaseIndex = (subscription.pricingScheduleCursor ?? 0) - 1;
+	const activePhase = subscription.pricingScheduleSnapshot?.phases[currentPhaseIndex];
 	if (activePhase) {
 		const reminderSeconds = subscriptionUnitToSeconds(
 			activePhase.reminderValue,

--- a/src/lib/server/locks/subscription-lock.ts
+++ b/src/lib/server/locks/subscription-lock.ts
@@ -9,7 +9,7 @@ import { ORIGIN } from '$lib/server/env-config';
 import { Kind } from 'nostr-tools';
 import { queueEmail } from '../email';
 import type { PaidSubscription } from '$lib/types/PaidSubscription';
-import { resolveSubscriptionReminderSeconds } from '../subscriptions';
+import { resolveSubscriptionReminderSeconds, subscriptionUnitToSeconds } from '../subscriptions';
 
 /** Per-product reminder is capped at the same 7 days as the global (see
  * admin/config and product-schema), so this window always catches every
@@ -20,6 +20,21 @@ async function isSubscriptionDueForReminder(
 	subscription: PaidSubscription,
 	now: Date
 ): Promise<boolean> {
+	// While the schedule still has phases to bill, the reminder offset comes from the current
+	// phase's snapshot. Past-schedule (or legacy subscriptions with no snapshot) fall back to
+	// the product-level reminder.
+	const activePhase =
+		subscription.pricingScheduleSnapshot?.phases[subscription.pricingScheduleCursor ?? 0];
+	if (activePhase) {
+		const reminderSeconds = subscriptionUnitToSeconds(
+			activePhase.reminderValue,
+			activePhase.reminderUnit
+		);
+		if (reminderSeconds === 0) {
+			return false;
+		}
+		return subSeconds(subscription.paidUntil, reminderSeconds) <= now;
+	}
 	const product = await collections.products.findOne(
 		{ _id: subscription.productId },
 		{ projection: { subscriptionReminderSeconds: 1 } }

--- a/src/lib/server/locks/subscription-lock.ts
+++ b/src/lib/server/locks/subscription-lock.ts
@@ -9,7 +9,7 @@ import { ORIGIN } from '$lib/server/env-config';
 import { Kind } from 'nostr-tools';
 import { queueEmail } from '../email';
 import type { PaidSubscription } from '$lib/types/PaidSubscription';
-import { resolveSubscriptionReminderSeconds, subscriptionUnitToSeconds } from '../subscriptions';
+import { currentFundingReminderSeconds } from '../subscriptions';
 
 /** Per-product reminder is capped at the same 7 days as the global (see
  * admin/config and product-schema), so this window always catches every
@@ -20,22 +20,6 @@ async function isSubscriptionDueForReminder(
 	subscription: PaidSubscription,
 	now: Date
 ): Promise<boolean> {
-	// The cursor points at the phase to bill on the *next* renewal, so the phase that funded
-	// the *current* period (up to paidUntil) is at `cursor - 1`. Its reminder offset is what
-	// counts for "how long before paidUntil to warn the customer". Past-schedule (or legacy
-	// subscriptions with no snapshot) fall back to the product-level reminder.
-	const currentPhaseIndex = (subscription.pricingScheduleCursor ?? 0) - 1;
-	const activePhase = subscription.pricingScheduleSnapshot?.phases[currentPhaseIndex];
-	if (activePhase) {
-		const reminderSeconds = subscriptionUnitToSeconds(
-			activePhase.reminderValue,
-			activePhase.reminderUnit
-		);
-		if (reminderSeconds === 0) {
-			return false;
-		}
-		return subSeconds(subscription.paidUntil, reminderSeconds) <= now;
-	}
 	const product = await collections.products.findOne(
 		{ _id: subscription.productId },
 		{ projection: { subscriptionReminderSeconds: 1 } }
@@ -43,7 +27,11 @@ async function isSubscriptionDueForReminder(
 	if (!product) {
 		return false;
 	}
-	return subSeconds(subscription.paidUntil, resolveSubscriptionReminderSeconds(product)) <= now;
+	const reminderSeconds = currentFundingReminderSeconds(subscription, product);
+	if (reminderSeconds === 0) {
+		return false;
+	}
+	return subSeconds(subscription.paidUntil, reminderSeconds) <= now;
 }
 
 const lock = new Lock('paid-subscriptions');

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -2233,8 +2233,14 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 						paidUntil: newPaidUntil,
 						updatedAt: new Date(),
 						notifications: [],
+						// Cursor advances on *every* renewal (in-schedule or post-schedule) so a
+						// past-schedule subscription lets `cursor - 1` overshoot `phases.length`,
+						// at which point `currentFundingReminderSeconds` falls back to the
+						// product-level reminder as documented. Skip when the sub is being
+						// reactivated from `cancelledAt`, because the cursor is `$unset` below
+						// and MongoDB rejects a $set/$unset collision on the same key.
+						...(!existing.cancelledAt && { pricingScheduleCursor: currentCursor + 1 }),
 						...(activePhase && {
-							pricingScheduleCursor: currentCursor + 1,
 							[`pricingScheduleSnapshot.phases.${currentCursor}.status`]: 'paid',
 							[`pricingScheduleSnapshot.phases.${currentCursor}.orderId`]: order._id
 						}),

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -160,9 +160,9 @@ export async function onOrderPayment(
 	}
 
 	const paidAt = new Date();
-	// For free payments, onOrderPayment is called twice (addOrderPayment + createOrder).
-	// This guard prevents duplicate audit log entries but does not fix the double-call itself.
-	// TODO: remove after fixing the double-call bug
+	// Free payments arrive here with `paidAt` already stamped by addOrderPayment; skip the
+	// `paymentDone` audit log in that case so a subsequent retry (e.g. re-processing the same
+	// paid payment) doesn't double-record the event.
 	const alreadyPaid = !!payment.paidAt;
 
 	payment.status = 'paid'; // for isOrderFullyPaid
@@ -1832,9 +1832,6 @@ export async function createOrder(
 			if (product.stock) {
 				await refreshAvailableStockInDb(product._id, session);
 			}
-		}
-		if (orderPayment?.method === 'free') {
-			await onOrderPayment(order, orderPayment, orderPayment.price, { providedSession: session });
 		}
 	});
 

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -2294,8 +2294,11 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 
 			// Fresh subscriber: if the product carries a schedule, snapshot it and bill phase 0.
 			// The cursor is set to 1 because phase 0 was just paid by this very order.
+			// Read the extension from the snapshot rather than the product config: the snapshot
+			// is expanded into unit cycles (a "3 months" phase becomes 3 monthly entries), so
+			// phase 0 always covers a single billing cycle.
 			const snapshot = buildPricingScheduleSnapshot(subscription.product);
-			const firstPhase = subscription.product.pricingSchedule?.[0];
+			const firstPhase = snapshot?.phases[0];
 			const extension = firstPhase
 				? pricingPhaseDuration(firstPhase.value, firstPhase.unit)
 				: getSubscriptionDuration(subscription.product);

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -25,10 +25,12 @@ import {
 import { runtimeConfig } from './runtime-config';
 import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
 import {
+	buildPricingScheduleSnapshot,
 	freeProductsForUser,
 	generateSubscriptionNumber,
 	resolveSubscriptionDuration,
-	resolveSubscriptionReminderSeconds
+	resolveSubscriptionReminderSeconds,
+	subscriptionUnitToSeconds
 } from './subscriptions';
 import {
 	checkProductVariationsIntegrity,
@@ -895,6 +897,40 @@ export async function createOrder(
 		// POS per-item manual discount has highest priority — preserve it via ??=
 		item.discountPercentage ??= bestAutoDiscount?.discountByProduct.get(item.product._id);
 	}
+
+	// Subscription pricing schedule: override the billed amount with the current phase price
+	// so `computePriceInfo` and downstream totals reflect it. The active phase comes from the
+	// existing subscription's snapshot (renewal path); otherwise the product's own schedule
+	// kicks in at initial purchase. Legacy subs and products without a schedule are unaffected.
+	for (const item of items) {
+		if (item.product.type !== 'subscription') {
+			continue;
+		}
+		const existing = await collections.paidSubscriptions.findOne(
+			{ ...userQuery(params.user), productId: item.product._id },
+			{
+				projection: { pricingScheduleSnapshot: 1, pricingScheduleCursor: 1 },
+				session: params.session
+			}
+		);
+		if (existing?.pricingScheduleSnapshot && !existing.cancelledAt) {
+			const cursor = existing.pricingScheduleCursor ?? 0;
+			const phase = existing.pricingScheduleSnapshot.phases[cursor];
+			if (phase) {
+				item.customPrice = {
+					amount: phase.priceAmount,
+					currency: existing.pricingScheduleSnapshot.currency
+				};
+			}
+		} else if (!existing && item.product.pricingSchedule?.length) {
+			const phase = item.product.pricingSchedule[0];
+			item.customPrice = {
+				amount: phase.priceAmount,
+				currency: item.product.price.currency
+			};
+		}
+	}
+
 	const priceInfo = computePriceInfo(items, {
 		bebopCountry: runtimeConfig.vatCountry,
 		deliveryFees: shippingPrice,
@@ -993,16 +1029,27 @@ export async function createOrder(
 			);
 		}
 
-		const existingSubscription = await collections.paidSubscriptions.findOne({
-			...userQuery(params.user),
-			productId: product._id
-		});
+		const existingSubscription = await collections.paidSubscriptions.findOne(
+			{
+				...userQuery(params.user),
+				productId: product._id
+			},
+			{ session: params.session }
+		);
 
 		if (existingSubscription) {
-			if (
-				subSeconds(existingSubscription.paidUntil, resolveSubscriptionReminderSeconds(product)) >
-				new Date()
-			) {
+			// Renewal is due when we cross the current-phase reminder offset (from snapshot) or
+			// the product-level reminder (post-schedule, cancelled or legacy).
+			const activePhase = existingSubscription.cancelledAt
+				? undefined
+				: existingSubscription.pricingScheduleSnapshot?.phases[
+						existingSubscription.pricingScheduleCursor ?? 0
+				  ];
+			const reminderSeconds = activePhase
+				? subscriptionUnitToSeconds(activePhase.reminderValue, activePhase.reminderUnit)
+				: resolveSubscriptionReminderSeconds(product);
+
+			if (subSeconds(existingSubscription.paidUntil, reminderSeconds) > new Date()) {
 				throw error(
 					400,
 					'You already have an active subscription for this product: ' +
@@ -2126,20 +2173,41 @@ function getSubscriptionDuration(product: {
 	return durations[resolveSubscriptionDuration(product)];
 }
 
+function pricingPhaseDuration(value: number, unit: SubscriptionDuration): Duration {
+	switch (unit) {
+		case 'hour':
+			return { hours: value };
+		case 'day':
+			return { days: value };
+		case 'week':
+			return { weeks: value };
+		case 'month':
+			return { months: value };
+		case 'year':
+			return { years: value };
+	}
+}
+
 async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSession) {
 	const subscriptionProducts = order.items.filter((item) => item.product.type === 'subscription');
 	const existingSubscriptions = await collections.paidSubscriptions
-		.find({
-			...userQuery(order.user),
-			productId: { $in: order.items.map((item) => item.product._id) }
-		})
+		.find(
+			{
+				...userQuery(order.user),
+				productId: { $in: order.items.map((item) => item.product._id) }
+			},
+			{ session }
+		)
 		.toArray();
 	const discounts = await collections.discounts
-		.find({
-			subscriptionIds: {
-				$in: subscriptionProducts.map((sub) => sub.product._id)
-			}
-		})
+		.find(
+			{
+				subscriptionIds: {
+					$in: subscriptionProducts.map((sub) => sub.product._id)
+				}
+			},
+			{ session }
+		)
 		.toArray();
 	for (const subscription of subscriptionProducts) {
 		const discountsForSubscription = discounts.filter((discount) =>
@@ -2153,10 +2221,19 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 			for (const discount of discountsForSubscription) {
 				addDiscountFreeProducts(discount, updatedFreeProductsById);
 			}
-			const newPaidUntil = add(
-				max([existing.paidUntil, new Date()]),
-				getSubscriptionDuration(subscription.product)
-			);
+
+			// Advance through the snapshot when this subscription still has phases to consume
+			// AND was not cancelled. Cancellation burns the schedule: on re-activation, billing
+			// reverts to the product's normal cycle and the snapshot is cleared so the phases
+			// don't resume on future renewals. Legacy subs (no snapshot) fall through naturally.
+			const currentCursor = existing.pricingScheduleCursor ?? 0;
+			const activePhase = existing.cancelledAt
+				? undefined
+				: existing.pricingScheduleSnapshot?.phases[currentCursor];
+			const extension = activePhase
+				? pricingPhaseDuration(activePhase.value, activePhase.unit)
+				: getSubscriptionDuration(subscription.product);
+			const newPaidUntil = add(max([existing.paidUntil, new Date()]), extension);
 
 			const archivedNotifications = existing.notifications.map((notif) => ({
 				...notif,
@@ -2170,6 +2247,7 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 						paidUntil: newPaidUntil,
 						updatedAt: new Date(),
 						notifications: [],
+						...(activePhase && { pricingScheduleCursor: currentCursor + 1 }),
 						...(Object.keys(updatedFreeProductsById).length !== 0 && {
 							freeProductsById: updatedFreeProductsById
 						})
@@ -2179,7 +2257,14 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 							notificationHistory: { $each: archivedNotifications }
 						}
 					}),
-					$unset: { cancelledAt: 1 }
+					$unset: {
+						cancelledAt: 1,
+						...(existing.cancelledAt &&
+							existing.pricingScheduleSnapshot && {
+								pricingScheduleSnapshot: 1,
+								pricingScheduleCursor: 1
+							})
+					}
 				},
 				{ session }
 			);
@@ -2206,16 +2291,26 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 			for (const discount of discountsForSubscription) {
 				addDiscountFreeProducts(discount, freeProductsById);
 			}
+
+			// Fresh subscriber: if the product carries a schedule, snapshot it and bill phase 0.
+			// The cursor is set to 1 because phase 0 was just paid by this very order.
+			const snapshot = buildPricingScheduleSnapshot(subscription.product);
+			const firstPhase = subscription.product.pricingSchedule?.[0];
+			const extension = firstPhase
+				? pricingPhaseDuration(firstPhase.value, firstPhase.unit)
+				: getSubscriptionDuration(subscription.product);
+
 			await collections.paidSubscriptions.insertOne(
 				{
 					_id: crypto.randomUUID(),
 					number: await generateSubscriptionNumber(),
 					user: order.user,
 					productId: subscription.product._id,
-					paidUntil: add(new Date(), getSubscriptionDuration(subscription.product)),
+					paidUntil: add(new Date(), extension),
 					createdAt: new Date(),
 					updatedAt: new Date(),
 					notifications: [],
+					...(snapshot && { pricingScheduleSnapshot: snapshot, pricingScheduleCursor: 1 }),
 					...(Object.keys(freeProductsById).length !== 0 && { freeProductsById })
 				},
 				{ session }

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -26,11 +26,10 @@ import { runtimeConfig } from './runtime-config';
 import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
 import {
 	buildPricingScheduleSnapshot,
+	currentFundingReminderSeconds,
 	freeProductsForUser,
 	generateSubscriptionNumber,
-	resolveSubscriptionDuration,
-	resolveSubscriptionReminderSeconds,
-	subscriptionUnitToSeconds
+	resolveSubscriptionDuration
 } from './subscriptions';
 import {
 	checkProductVariationsIntegrity,
@@ -1038,17 +1037,7 @@ export async function createOrder(
 		);
 
 		if (existingSubscription) {
-			// Renewal is due when we cross the current-phase reminder offset (from snapshot) or
-			// the product-level reminder (post-schedule, cancelled or legacy).
-			const activePhase = existingSubscription.cancelledAt
-				? undefined
-				: existingSubscription.pricingScheduleSnapshot?.phases[
-						existingSubscription.pricingScheduleCursor ?? 0
-				  ];
-			const reminderSeconds = activePhase
-				? subscriptionUnitToSeconds(activePhase.reminderValue, activePhase.reminderUnit)
-				: resolveSubscriptionReminderSeconds(product);
-
+			const reminderSeconds = currentFundingReminderSeconds(existingSubscription, product);
 			if (subSeconds(existingSubscription.paidUntil, reminderSeconds) > new Date()) {
 				throw error(
 					400,

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -2226,20 +2226,29 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 				forPaidUntil: existing.paidUntil
 			}));
 
+			// Optimistic filter on cursor: two racing renewals both read `currentCursor`, so we
+			// require the write-time cursor to still match what we read. If a concurrent renewal
+			// won, `modifiedCount === 0` and the assert below throws — the second payment gets
+			// surfaced as a failed renewal instead of silently corrupting the schedule state.
+			// Only applied to scheduled, non-cancelled subs: legacy subs have no cursor to gate
+			// on, and cancelled reactivations `$unset` the cursor below (no read-modify-write).
+			const guardCursor = !!existing.pricingScheduleSnapshot && !existing.cancelledAt;
 			const result = await collections.paidSubscriptions.updateOne(
-				{ _id: existing._id },
+				{
+					_id: existing._id,
+					...(guardCursor && { pricingScheduleCursor: currentCursor })
+				},
 				{
 					$set: {
 						paidUntil: newPaidUntil,
 						updatedAt: new Date(),
 						notifications: [],
-						// Cursor advances on *every* renewal (in-schedule or post-schedule) so a
-						// past-schedule subscription lets `cursor - 1` overshoot `phases.length`,
-						// at which point `currentFundingReminderSeconds` falls back to the
-						// product-level reminder as documented. Skip when the sub is being
-						// reactivated from `cancelledAt`, because the cursor is `$unset` below
-						// and MongoDB rejects a $set/$unset collision on the same key.
-						...(!existing.cancelledAt && { pricingScheduleCursor: currentCursor + 1 }),
+						// Cursor advances on *every* schedule-carrying renewal (in-schedule or
+						// past-schedule) so `cursor - 1` overshoots `phases.length` for exhausted
+						// subs, at which point `currentFundingReminderSeconds` falls back to the
+						// product-level reminder as documented. Skip on legacy no-schedule subs
+						// (nothing to advance) and on cancelled reactivations (`$unset` below).
+						...(guardCursor && { pricingScheduleCursor: currentCursor + 1 }),
 						...(activePhase && {
 							[`pricingScheduleSnapshot.phases.${currentCursor}.status`]: 'paid',
 							[`pricingScheduleSnapshot.phases.${currentCursor}.orderId`]: order._id

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -2244,7 +2244,11 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 						paidUntil: newPaidUntil,
 						updatedAt: new Date(),
 						notifications: [],
-						...(activePhase && { pricingScheduleCursor: currentCursor + 1 }),
+						...(activePhase && {
+							pricingScheduleCursor: currentCursor + 1,
+							[`pricingScheduleSnapshot.phases.${currentCursor}.status`]: 'paid',
+							[`pricingScheduleSnapshot.phases.${currentCursor}.orderId`]: order._id
+						}),
 						...(Object.keys(updatedFreeProductsById).length !== 0 && {
 							freeProductsById: updatedFreeProductsById
 						})
@@ -2299,6 +2303,11 @@ async function applyOrderSubscriptionsDiscounts(order: Order, session: ClientSes
 			const extension = firstPhase
 				? pricingPhaseDuration(firstPhase.value, firstPhase.unit)
 				: getSubscriptionDuration(subscription.product);
+			// Phase 0 is paid by this very order; stamp it directly on the snapshot so a customer
+			// visiting the subscription can trace the first cycle back to the funding order.
+			if (snapshot) {
+				snapshot.phases[0] = { ...snapshot.phases[0], status: 'paid', orderId: order._id };
+			}
 
 			await collections.paidSubscriptions.insertOne(
 				{

--- a/src/lib/server/subscriptions.ts
+++ b/src/lib/server/subscriptions.ts
@@ -53,7 +53,10 @@ export async function freeProductsForUser(
 
 /**
  * Builds the snapshot stored on `PaidSubscription` at first payment for a product with a
- * schedule. Captures both the phases and the currency at that moment.
+ * schedule. Each configured phase `{ value: N, unit, priceAmount, … }` is expanded into N
+ * unit cycles `{ value: 1, unit, priceAmount, … }`, so the runtime bills one cycle per
+ * renewal (e.g. a "3 months at 21 CHF" phase becomes 3 monthly billings of 21 CHF).
+ * The cursor on the subscription therefore always points at a single billing cycle.
  */
 export function buildPricingScheduleSnapshot(
 	product: Pick<Product, 'pricingSchedule' | 'price'>
@@ -63,7 +66,15 @@ export function buildPricingScheduleSnapshot(
 	}
 	return {
 		currency: product.price.currency,
-		phases: product.pricingSchedule.map((p) => ({ ...p }))
+		phases: product.pricingSchedule.flatMap((p) =>
+			Array.from({ length: p.value }, () => ({
+				value: 1,
+				unit: p.unit,
+				priceAmount: p.priceAmount,
+				reminderValue: p.reminderValue,
+				reminderUnit: p.reminderUnit
+			}))
+		)
 	};
 }
 

--- a/src/lib/server/subscriptions.ts
+++ b/src/lib/server/subscriptions.ts
@@ -1,4 +1,5 @@
 import type { PaidSubscription } from '$lib/types/PaidSubscription';
+import type { Product } from '$lib/types/Product';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
 import { collections } from './database';
@@ -48,6 +49,41 @@ export async function freeProductsForUser(
 		}
 		return acc;
 	}, {});
+}
+
+/**
+ * Builds the snapshot stored on `PaidSubscription` at first payment for a product with a
+ * schedule. Captures both the phases and the currency at that moment.
+ */
+export function buildPricingScheduleSnapshot(
+	product: Pick<Product, 'pricingSchedule' | 'price'>
+): PaidSubscription['pricingScheduleSnapshot'] {
+	if (!product.pricingSchedule?.length) {
+		return undefined;
+	}
+	return {
+		currency: product.price.currency,
+		phases: product.pricingSchedule.map((p) => ({ ...p }))
+	};
+}
+
+/**
+ * Converts a `value + unit` couple (from a phase or reminder) into a plain number of
+ * seconds. Used both to extend `paidUntil` at renewal and to compute reminder offsets.
+ */
+export function subscriptionUnitToSeconds(value: number, unit: SubscriptionDuration): number {
+	switch (unit) {
+		case 'year':
+			return value * 365 * 24 * 60 * 60;
+		case 'month':
+			return value * 30 * 24 * 60 * 60;
+		case 'week':
+			return value * 7 * 24 * 60 * 60;
+		case 'day':
+			return value * 24 * 60 * 60;
+		case 'hour':
+			return value * 60 * 60;
+	}
 }
 
 export async function generateSubscriptionNumber(): Promise<number> {

--- a/src/lib/server/subscriptions.ts
+++ b/src/lib/server/subscriptions.ts
@@ -1,7 +1,10 @@
 import type { PaidSubscription } from '$lib/types/PaidSubscription';
 import type { Product } from '$lib/types/Product';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
-import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
+import {
+	subscriptionUnitToSeconds,
+	type SubscriptionDuration
+} from '$lib/types/SubscriptionDuration';
 import { collections } from './database';
 import { runtimeConfig } from './runtime-config';
 import { userQuery } from './user';
@@ -78,24 +81,7 @@ export function buildPricingScheduleSnapshot(
 	};
 }
 
-/**
- * Converts a `value + unit` couple (from a phase or reminder) into a plain number of
- * seconds. Used both to extend `paidUntil` at renewal and to compute reminder offsets.
- */
-export function subscriptionUnitToSeconds(value: number, unit: SubscriptionDuration): number {
-	switch (unit) {
-		case 'year':
-			return value * 365 * 24 * 60 * 60;
-		case 'month':
-			return value * 30 * 24 * 60 * 60;
-		case 'week':
-			return value * 7 * 24 * 60 * 60;
-		case 'day':
-			return value * 24 * 60 * 60;
-		case 'hour':
-			return value * 60 * 60;
-	}
-}
+export { subscriptionUnitToSeconds };
 
 export async function generateSubscriptionNumber(): Promise<number> {
 	const res = await collections.runtimeConfig.findOneAndUpdate(

--- a/src/lib/server/subscriptions.ts
+++ b/src/lib/server/subscriptions.ts
@@ -28,6 +28,33 @@ export function resolveSubscriptionReminderSeconds(product: {
 	return product.subscriptionReminderSeconds || runtimeConfig.subscriptionReminderSeconds;
 }
 
+/**
+ * Single source of truth for "how long before paidUntil should we start allowing renewal /
+ * sending the reminder email / letting `createOrder` accept the retry?". Cursor points at the
+ * *next* phase to bill, so the phase that funded the current period sits at `cursor - 1` in
+ * the snapshot; cancelled, legacy (no snapshot), and past-schedule subs fall back to the
+ * product-level offset. All three consumers (cron in subscription-lock.ts, canRenew in the
+ * /subscription/{id} loader, the renewal gate in orders.ts) must call this — computing
+ * "current phase" independently is what let the offsets drift previously.
+ */
+export function currentFundingReminderSeconds(
+	subscription: Pick<
+		PaidSubscription,
+		'pricingScheduleSnapshot' | 'pricingScheduleCursor' | 'cancelledAt'
+	>,
+	product: { subscriptionReminderSeconds?: number }
+): number {
+	if (subscription.cancelledAt) {
+		return resolveSubscriptionReminderSeconds(product);
+	}
+	const currentPhaseIndex = (subscription.pricingScheduleCursor ?? 0) - 1;
+	const phase = subscription.pricingScheduleSnapshot?.phases[currentPhaseIndex];
+	if (!phase) {
+		return resolveSubscriptionReminderSeconds(product);
+	}
+	return subscriptionUnitToSeconds(phase.reminderValue, phase.reminderUnit);
+}
+
 export async function freeProductsForUser(
 	user: UserIdentifier,
 	products: string[]

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -1079,6 +1079,13 @@
 		"lastPayment": "Last payment",
 		"listTitle": "Your subscriptions",
 		"noSubscriptions": "You have no subscriptions yet.",
+		"nextBilling": "Next billing: {amount} {currency}",
+		"payment": {
+			"currentMethod": "Renewal will use {method}",
+			"previousUnavailable": "The previous payment method ({method}) can't be used for the next renewal. Choose another one below.",
+			"chooseMethod": "Payment method",
+			"change": "Change payment method"
+		},
 		"singleTitle": "Subscription #{number}",
 		"status": {
 			"active": "active",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -1081,6 +1081,16 @@
 		"noSubscriptions": "You have no subscriptions yet.",
 		"nextBilling": "Next billing: {amount} {currency}",
 		"canRenewFrom": "You'll be able to renew from <0></0>.",
+		"amountFree": "Free",
+		"upcomingPhases": {
+			"title": "Upcoming phases",
+			"range": "from {start} to {end}",
+			"after": "from {start}"
+		},
+		"orderHistory": {
+			"title": "Order history",
+			"downloadInvoice": "Download invoice"
+		},
 		"payment": {
 			"currentMethod": "Renewal will use {method}",
 			"previousUnavailable": "The previous payment method ({method}) can't be used for the next renewal. Choose another one below.",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -1080,6 +1080,7 @@
 		"listTitle": "Your subscriptions",
 		"noSubscriptions": "You have no subscriptions yet.",
 		"nextBilling": "Next billing: {amount} {currency}",
+		"canRenewFrom": "You'll be able to renew from <0></0>.",
 		"payment": {
 			"currentMethod": "Renewal will use {method}",
 			"previousUnavailable": "The previous payment method ({method}) can't be used for the next renewal. Choose another one below.",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -973,6 +973,17 @@
 			"month": "Renews every month",
 			"year": "Renews every year"
 		},
+		"pricingSchedule": {
+			"intro": "This subscription has multiple billing phases:",
+			"then": "then"
+		},
+		"pricingScheduleUnit": {
+			"hour": { "one": "hour", "other": "hours" },
+			"day": { "one": "day", "other": "days" },
+			"week": { "one": "week", "other": "weeks" },
+			"month": { "one": "month", "other": "months" },
+			"year": { "one": "year", "other": "years" }
+		},
 		"type": {
 			"deposit": "On deposit",
 			"digitalResource": "Digital Resource",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -1078,6 +1078,7 @@
 		"listTitle": "Vos abonnements",
 		"noSubscriptions": "Vous n'avez pas encore d'abonnements.",
 		"nextBilling": "Prochaine facturation : {amount} {currency}",
+		"canRenewFrom": "Vous pourrez renouveler à partir du <0></0>.",
 		"payment": {
 			"currentMethod": "Le renouvellement utilisera {method}",
 			"previousUnavailable": "Le précédent mode de paiement ({method}) ne peut plus être utilisé pour ce renouvellement. Choisissez-en un autre ci-dessous.",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -971,6 +971,17 @@
 			"month": "Renouvelé chaque mois",
 			"year": "Renouvelé chaque année"
 		},
+		"pricingSchedule": {
+			"intro": "Cette souscription possède plusieurs phases de facturation :",
+			"then": "puis"
+		},
+		"pricingScheduleUnit": {
+			"hour": { "one": "heure", "other": "heures" },
+			"day": { "one": "jour", "other": "jours" },
+			"week": { "one": "semaine", "other": "semaines" },
+			"month": { "one": "mois", "other": "mois" },
+			"year": { "one": "an", "other": "ans" }
+		},
 		"type": {
 			"deposit": "Sur acompte",
 			"digitalResource": "Ressource numérique",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -1077,6 +1077,13 @@
 		"lastPayment": "Dernier paiement",
 		"listTitle": "Vos abonnements",
 		"noSubscriptions": "Vous n'avez pas encore d'abonnements.",
+		"nextBilling": "Prochaine facturation : {amount} {currency}",
+		"payment": {
+			"currentMethod": "Le renouvellement utilisera {method}",
+			"previousUnavailable": "Le précédent mode de paiement ({method}) ne peut plus être utilisé pour ce renouvellement. Choisissez-en un autre ci-dessous.",
+			"chooseMethod": "Mode de paiement",
+			"change": "Changer de mode de paiement"
+		},
 		"singleTitle": "Abonnement #{number}",
 		"status": {
 			"active": "actif",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -1079,6 +1079,16 @@
 		"noSubscriptions": "Vous n'avez pas encore d'abonnements.",
 		"nextBilling": "Prochaine facturation : {amount} {currency}",
 		"canRenewFrom": "Vous pourrez renouveler à partir du <0></0>.",
+		"amountFree": "Gratuit",
+		"upcomingPhases": {
+			"title": "Prochaines phases",
+			"range": "du {start} au {end}",
+			"after": "à partir du {start}"
+		},
+		"orderHistory": {
+			"title": "Historique des commandes",
+			"downloadInvoice": "Télécharger la facture"
+		},
 		"payment": {
 			"currentMethod": "Le renouvellement utilisera {method}",
 			"previousUnavailable": "Le précédent mode de paiement ({method}) ne peut plus être utilisé pour ce renouvellement. Choisissez-en un autre ci-dessous.",

--- a/src/lib/types/PaidSubscription.ts
+++ b/src/lib/types/PaidSubscription.ts
@@ -3,6 +3,8 @@
  */
 
 import type { ObjectId } from 'mongodb';
+import type { Currency } from './Currency';
+import type { SubscriptionDuration } from './SubscriptionDuration';
 import type { Timestamps } from './Timestamps';
 import type { UserIdentifier } from './UserIdentifier';
 
@@ -35,4 +37,26 @@ export interface PaidSubscription extends Timestamps {
 
 	cancelledAt?: Date;
 	freeProductsById?: Record<string, { available: number; total: number; used: number }>;
+
+	/**
+	 * Snapshot of the product's `pricingSchedule` at subscription creation time. Locks the tariff
+	 * for the buyer even if the product's schedule or base price changes afterwards.
+	 */
+	pricingScheduleSnapshot?: {
+		currency: Currency;
+		phases: Array<{
+			value: number;
+			unit: SubscriptionDuration;
+			priceAmount: number;
+			reminderValue: number;
+			reminderUnit: SubscriptionDuration;
+		}>;
+	};
+
+	/**
+	 * Index of the next phase to bill. After the initial purchase (phase 0 paid), this is `1`.
+	 * When it reaches `phases.length`, the schedule is exhausted and renewals fall back to the
+	 * product's current live price on its normal cycle.
+	 */
+	pricingScheduleCursor?: number;
 }

--- a/src/lib/types/PaidSubscription.ts
+++ b/src/lib/types/PaidSubscription.ts
@@ -50,6 +50,14 @@ export interface PaidSubscription extends Timestamps {
 			priceAmount: number;
 			reminderValue: number;
 			reminderUnit: SubscriptionDuration;
+			/**
+			 * Absence = still due (pending). Set to `paid` when the order that funded the phase
+			 * settles; kept together with `orderId` so the customer can trace each billing back
+			 * to the order that paid it (and, later on, so the reminder cron can distinguish a
+			 * legitimately-past-schedule sub from one whose renewal simply hasn't happened yet).
+			 */
+			status?: 'paid';
+			orderId?: string;
 		}>;
 	};
 

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -54,6 +54,13 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 	type: 'subscription' | 'resource' | 'donation';
 	subscriptionDuration?: SubscriptionDuration;
 	subscriptionReminderSeconds?: number;
+	pricingSchedule?: Array<{
+		value: number;
+		unit: SubscriptionDuration;
+		priceAmount: number;
+		reminderValue: number;
+		reminderUnit: SubscriptionDuration;
+	}>;
 	shipping: boolean;
 	deliveryFees?: DeliveryFees;
 	requireSpecificDeliveryFee?: boolean;

--- a/src/lib/types/SubscriptionDuration.ts
+++ b/src/lib/types/SubscriptionDuration.ts
@@ -1,2 +1,23 @@
 export const SUBSCRIPTION_DURATIONS = ['year', 'month', 'week', 'day', 'hour'] as const;
 export type SubscriptionDuration = (typeof SUBSCRIPTION_DURATIONS)[number];
+
+/**
+ * Client- and server-safe converter from a `value + unit` couple (used in phase durations
+ * and reminder offsets) to a plain number of seconds. Kept next to the type so admin form
+ * bounds and server-side schema validation compute the same cap without duplicating the
+ * mapping.
+ */
+export function subscriptionUnitToSeconds(value: number, unit: SubscriptionDuration): number {
+	switch (unit) {
+		case 'year':
+			return value * 365 * 24 * 60 * 60;
+		case 'month':
+			return value * 30 * 24 * 60 * 60;
+		case 'week':
+			return value * 7 * 24 * 60 * 60;
+		case 'day':
+			return value * 24 * 60 * 60;
+		case 'hour':
+			return value * 60 * 60;
+	}
+}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -270,6 +270,10 @@ export const actions: Actions = {
 						...(typeof parsed.subscriptionReminderSeconds === 'number' && {
 							subscriptionReminderSeconds: parsed.subscriptionReminderSeconds
 						}),
+						...(product.type === 'subscription' &&
+							parsed.pricingSchedule.length > 0 && {
+								pricingSchedule: parsed.pricingSchedule
+							}),
 						...(parsed.restrictPaymentMethods && {
 							paymentMethods: parsed.paymentMethods ?? []
 						}),
@@ -308,6 +312,9 @@ export const actions: Actions = {
 						...(!parsed.subscriptionDuration && { subscriptionDuration: '' }),
 						...(typeof parsed.subscriptionReminderSeconds !== 'number' && {
 							subscriptionReminderSeconds: ''
+						}),
+						...((product.type !== 'subscription' || parsed.pricingSchedule.length === 0) && {
+							pricingSchedule: ''
 						}),
 						...(!parsed.restrictPaymentMethods && { paymentMethods: '' }),
 						...(!hasVariations && { variations: '', variationLabels: '' }),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -256,6 +256,10 @@ export const actions: Actions = {
 							...(typeof parsed.subscriptionReminderSeconds === 'number' && {
 								subscriptionReminderSeconds: parsed.subscriptionReminderSeconds
 							}),
+							...(parsed.type === 'subscription' &&
+								parsed.pricingSchedule.length > 0 && {
+									pricingSchedule: parsed.pricingSchedule
+								}),
 							hasSellDisclaimer: parsed.hasSellDisclaimer,
 							...(parsed.hasSellDisclaimer &&
 								parsed.sellDisclaimerTitle &&
@@ -471,6 +475,10 @@ export const actions: Actions = {
 					...(typeof parsed.subscriptionReminderSeconds === 'number' && {
 						subscriptionReminderSeconds: parsed.subscriptionReminderSeconds
 					}),
+					...(product.type === 'subscription' &&
+						parsed.pricingSchedule.length > 0 && {
+							pricingSchedule: parsed.pricingSchedule
+						}),
 					hideFromSEO: parsed.hideFromSEO,
 					translations: product.translations
 				},

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -183,6 +183,18 @@ export const productBaseSchema = () => ({
 				.max(24 * 60 * 60 * 7)
 		])
 		.optional(),
+	pricingSchedule: z
+		.array(
+			z.object({
+				value: z.number({ coerce: true }).int().min(1),
+				unit: z.enum(SUBSCRIPTION_DURATIONS),
+				priceAmount: z.number({ coerce: true }).min(0),
+				reminderValue: z.number({ coerce: true }).int().min(0),
+				reminderUnit: z.enum(SUBSCRIPTION_DURATIONS)
+			})
+		)
+		.optional()
+		.default([]),
 	cta: z
 		.array(
 			z.object({

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -1,6 +1,8 @@
 import { CURRENCIES } from '$lib/types/Currency';
 import { MAX_NAME_LIMIT, MAX_SHORT_DESCRIPTION_LIMIT } from '$lib/types/Product';
-import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
+import { SUBSCRIPTION_DURATIONS, subscriptionUnitToSeconds } from '$lib/types/SubscriptionDuration';
+
+const MAX_PHASE_REMINDER_SECONDS = 7 * 24 * 60 * 60;
 import { z } from 'zod';
 import { deliveryFeesSchema } from '../config/delivery/schema';
 import { MAX_CONTENT_LIMIT } from '$lib/types/CmsPage';
@@ -185,13 +187,27 @@ export const productBaseSchema = () => ({
 		.optional(),
 	pricingSchedule: z
 		.array(
-			z.object({
-				value: z.number({ coerce: true }).int().min(1),
-				unit: z.enum(SUBSCRIPTION_DURATIONS),
-				priceAmount: z.number({ coerce: true }).min(0),
-				reminderValue: z.number({ coerce: true }).int().min(0),
-				reminderUnit: z.enum(SUBSCRIPTION_DURATIONS)
-			})
+			z
+				.object({
+					value: z.number({ coerce: true }).int().min(1),
+					unit: z.enum(SUBSCRIPTION_DURATIONS),
+					priceAmount: z.number({ coerce: true }).min(0),
+					reminderValue: z.number({ coerce: true }).int().min(0),
+					reminderUnit: z.enum(SUBSCRIPTION_DURATIONS)
+				})
+				.refine(
+					(phase) => {
+						const reminderSeconds = subscriptionUnitToSeconds(
+							phase.reminderValue,
+							phase.reminderUnit
+						);
+						const cycleSeconds = subscriptionUnitToSeconds(1, phase.unit);
+						return reminderSeconds <= Math.min(MAX_PHASE_REMINDER_SECONDS, cycleSeconds);
+					},
+					{
+						message: 'Phase reminder must be at most 7 days and not exceed the phase cycle duration'
+					}
+				)
 		)
 		.optional()
 		.default([]),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -189,7 +189,7 @@ export const productBaseSchema = () => ({
 		.array(
 			z
 				.object({
-					value: z.number({ coerce: true }).int().min(1),
+					value: z.number({ coerce: true }).int().min(1).max(10),
 					unit: z.enum(SUBSCRIPTION_DURATIONS),
 					priceAmount: z.number({ coerce: true }).min(0),
 					reminderValue: z.number({ coerce: true }).int().min(0),
@@ -209,6 +209,7 @@ export const productBaseSchema = () => ({
 					}
 				)
 		)
+		.max(10)
 		.optional()
 		.default([]),
 	cta: z

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -193,7 +193,10 @@ export const productBaseSchema = () => ({
 					unit: z.enum(SUBSCRIPTION_DURATIONS),
 					priceAmount: z.number({ coerce: true }).min(0),
 					reminderValue: z.number({ coerce: true }).int().min(0),
-					reminderUnit: z.enum(SUBSCRIPTION_DURATIONS)
+					// `week`, `month`, `year` never yield a legal reminder under the 7-day cap
+					// (their smallest value already exceeds it), so we don't offer them at all.
+					// Coherent vocabulary: the dropdown mirrors what the cap actually allows.
+					reminderUnit: z.enum(['day', 'hour'])
 				})
 				.refine(
 					(phase) => {

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -115,6 +115,7 @@ async function fetchProduct(
 	| 'stockReference'
 	| 'tagIds'
 	| 'subscriptionDuration'
+	| 'pricingSchedule'
 > | null> {
 	return collections.products.findOne<ReturnType<Awaited<typeof fetchProduct>>>(
 		{ _id: productId },
@@ -166,7 +167,8 @@ async function fetchProduct(
 				vatProfileId: 1,
 				stockReference: 1,
 				tagIds: 1,
-				subscriptionDuration: 1
+				subscriptionDuration: 1,
+				pricingSchedule: 1
 			}
 		}
 	);

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -749,6 +749,25 @@
 					<SubscriptionDurationLabel duration={data.product.subscriptionDuration} />
 				{/if}
 
+				{#if data.product.type === 'subscription' && data.product.pricingSchedule?.length && data.product.subscriptionDuration}
+					<span class="inline-flex items-center gap-1 text-sm text-gray-600">
+						{t('product.pricingSchedule.intro')}<br />
+						{#each data.product.pricingSchedule as phase, i}
+							- {i === 0 ? '' : t('product.pricingSchedule.then') + ' '}{phase.value}
+							{t('product.pricingScheduleUnit.' + phase.unit, { count: phase.value })} : {phase.priceAmount}
+							{data.product.price.currency} / {t('product.pricingScheduleUnit.' + phase.unit, {
+								count: 1
+							})}<br />
+						{/each}
+						- {t('product.pricingSchedule.then')}
+						{data.product.price.amount}
+						{data.product.price.currency} / {t(
+							'product.pricingScheduleUnit.' + data.product.subscriptionDuration,
+							{ count: 1 }
+						)}
+					</span>
+				{/if}
+
 				{#if freeProductsAvailable}
 					<hr class="border-gray-300" />
 					<h3 class="text-[22px]">

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -6,7 +6,8 @@ import {
 } from '$lib/server/orders';
 import {
 	resolveSubscriptionDuration,
-	resolveSubscriptionReminderSeconds
+	resolveSubscriptionReminderSeconds,
+	subscriptionUnitToSeconds
 } from '$lib/server/subscriptions';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { userQuery } from '$lib/server/user.js';
@@ -48,10 +49,15 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		{ sort: { createdAt: 1 } }
 	);
 
-	const canRenewAfter = subSeconds(
-		subscription.paidUntil,
-		resolveSubscriptionReminderSeconds(product)
-	);
+	// While the schedule still has phases to bill, honour the current phase's reminder.
+	// Past-schedule, cancelled or legacy subs fall back to the product-level reminder.
+	const activePhase = subscription.cancelledAt
+		? undefined
+		: subscription.pricingScheduleSnapshot?.phases[subscription.pricingScheduleCursor ?? 0];
+	const canRenewReminderSeconds = activePhase
+		? subscriptionUnitToSeconds(activePhase.reminderValue, activePhase.reminderUnit)
+		: resolveSubscriptionReminderSeconds(product);
+	const canRenewAfter = subSeconds(subscription.paidUntil, canRenewReminderSeconds);
 
 	return {
 		subscription: {

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -157,6 +157,7 @@ export const actions: Actions = {
 					locale: locals.language,
 					user: subscription.user,
 					shippingAddress: lastOrder.shippingAddress,
+					billingAddress: lastOrder.billingAddress ?? lastOrder.shippingAddress ?? undefined,
 					userVatCountry:
 						lastOrder.shippingAddress?.country ||
 						locals.countryCode ||

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -176,16 +176,18 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		postScheduleStart = start;
 	}
 
-	// Order history for this subscription. Bound by `createdAt >= subscription.createdAt` so a
-	// prior cancelled subscription for the same product doesn't leak into the current one's
-	// history. Ordered oldest → newest so the first phase's funding order shows up on top.
+	// Order history for this subscription. `createdAt >= subscription.createdAt - 60s` keeps a
+	// prior cancelled subscription's orders out (those are typically hours+ away) while giving
+	// enough slack for the initial-purchase order that is inserted a few ms *before* the
+	// subscription record in the same `onOrderPayment` transaction. Ordered oldest → newest so
+	// the first phase's funding order shows up on top.
 	const paidOrders = await collections.orders
 		.find(
 			{
 				'items.product._id': subscription.productId,
 				'payments.status': 'paid',
 				...userQuery(subscription.user),
-				createdAt: { $gte: subscription.createdAt }
+				createdAt: { $gte: subSeconds(subscription.createdAt, 60) }
 			},
 			{
 				sort: { createdAt: 1 },

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -11,8 +11,11 @@ import {
 } from '$lib/server/subscriptions';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { userQuery } from '$lib/server/user.js';
+import { paymentMethods, type PaymentMethod } from '$lib/server/payment-methods';
+import { toSatoshis } from '$lib/utils/toSatoshis';
 import { error, fail, redirect } from '@sveltejs/kit';
 import { subHours, subSeconds } from 'date-fns';
+import { z } from 'zod';
 import type { Actions } from './$types';
 
 export async function load({ params, locals }: { params: { id: string }; locals: App.Locals }) {
@@ -33,7 +36,9 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 				_id: 1,
 				name: { $ifNull: [`$translations.${locals.language}.name`, '$name'] },
 				subscriptionDuration: 1,
-				subscriptionReminderSeconds: 1
+				subscriptionReminderSeconds: 1,
+				price: 1,
+				paymentMethods: 1
 			}
 		}
 	);
@@ -41,6 +46,41 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 	if (!product) {
 		throw error(500, 'Product associated to subscription not found');
 	}
+
+	// Look up the customer's last paid payment for this subscription: its method is the default
+	// we'll reuse on the next renewal, unless it's no longer eligible (e.g. was 'free' and next
+	// billing is non-zero, or the method has since been disabled shop-wide).
+	const lastPaidOrder = await collections.orders.findOne(
+		{
+			'items.product._id': product._id,
+			'payments.status': 'paid',
+			...userQuery(subscription.user)
+		},
+		{ sort: { createdAt: -1 }, projection: { payments: 1 } }
+	);
+	const lastPaidMethod = lastPaidOrder?.payments.find((p) => p.status === 'paid')?.method as
+		| PaymentMethod
+		| undefined;
+
+	// Compute the amount the customer will be billed on the next renewal so we can filter out
+	// 'free' when non-zero (and vice versa). While the schedule still has phases to bill, the
+	// next billing is the phase at `cursor`; once exhausted, it's the product's live price.
+	const nextPhaseIndex = subscription.pricingScheduleCursor ?? 0;
+	const nextPhase = subscription.pricingScheduleSnapshot?.phases[nextPhaseIndex];
+	const nextBillingAmount = nextPhase ? nextPhase.priceAmount : product.price.amount;
+	const nextBillingCurrency = nextPhase
+		? subscription.pricingScheduleSnapshot?.currency ?? product.price.currency
+		: product.price.currency;
+	const nextBillingSatoshis = toSatoshis(nextBillingAmount, nextBillingCurrency);
+
+	const initialMethods = paymentMethods({
+		hasPosOptions: locals.user?.hasPosOptions,
+		totalSatoshis: nextBillingSatoshis
+	});
+	const eligibleMethods = product.paymentMethods
+		? initialMethods.filter((m) => product.paymentMethods?.includes(m))
+		: initialMethods;
+	const lastPaidMethodStillEligible = !!lastPaidMethod && eligibleMethods.includes(lastPaidMethod);
 
 	const picture = await collections.pictures.findOne(
 		{
@@ -76,12 +116,21 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 			subscriptionDuration: resolveSubscriptionDuration(product)
 		},
 		picture: picture ?? undefined,
-		canRenew: canRenewAfter < new Date()
+		canRenew: canRenewAfter < new Date(),
+		nextBilling: {
+			amount: nextBillingAmount,
+			currency: nextBillingCurrency
+		},
+		payment: {
+			lastPaidMethod,
+			lastPaidMethodStillEligible,
+			eligibleMethods
+		}
 	};
 }
 
 export const actions: Actions = {
-	renew: async ({ params, locals }) => {
+	renew: async ({ params, locals, request }) => {
 		const subscription = await collections.paidSubscriptions.findOne({
 			_id: params.id
 		});
@@ -127,6 +176,45 @@ export const actions: Actions = {
 			);
 		}
 
+		// Recompute eligible methods here (rather than trusting the client form) so a customer
+		// can't smuggle an ineligible method past the check by editing the request. Fall back to
+		// the last paid method when the form doesn't submit one and it's still eligible.
+		const nextPhaseIndex = subscription.pricingScheduleCursor ?? 0;
+		const nextPhase = subscription.pricingScheduleSnapshot?.phases[nextPhaseIndex];
+		const nextBillingSatoshis = toSatoshis(
+			nextPhase ? nextPhase.priceAmount : product.price.amount,
+			nextPhase
+				? subscription.pricingScheduleSnapshot?.currency ?? product.price.currency
+				: product.price.currency
+		);
+		const initialMethods = paymentMethods({
+			hasPosOptions: locals.user?.hasPosOptions,
+			totalSatoshis: nextBillingSatoshis
+		});
+		const eligibleMethods = product.paymentMethods
+			? initialMethods.filter((m) => product.paymentMethods?.includes(m))
+			: initialMethods;
+		if (eligibleMethods.length === 0) {
+			throw error(500, 'No payment method available for the next renewal on this subscription');
+		}
+		const submitted = Object.fromEntries(await request.formData());
+		const parsed = z
+			.object({
+				paymentMethod: z.enum([eligibleMethods[0], ...eligibleMethods.slice(1)]).optional()
+			})
+			.safeParse(submitted);
+		if (!parsed.success) {
+			throw error(400, 'Chosen payment method is not available for this renewal');
+		}
+		const chosenMethod =
+			parsed.data.paymentMethod ??
+			(eligibleMethods.includes(paidPayment.method as PaymentMethod)
+				? paidPayment.method
+				: undefined);
+		if (!chosenMethod) {
+			throw error(400, 'A payment method must be chosen to renew this subscription');
+		}
+
 		const existingPendingOrder = await collections.orders.findOne(
 			{
 				'items.product._id': product._id,
@@ -152,7 +240,7 @@ export const actions: Actions = {
 						product
 					}
 				],
-				paidPayment.method,
+				chosenMethod,
 				{
 					locale: locals.language,
 					user: subscription.user,

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -139,7 +139,13 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 	// share the same (unit, priceAmount) come from a single configured phase — collapse them
 	// back into date ranges so the customer sees "du 09/07 au 09/10 : 21 CHF" instead of three
 	// identical monthly lines.
-	const upcomingPhases: Array<{ start: Date; end: Date; amount: number; currency: string }> = [];
+	const upcomingPhases: Array<{
+		start: Date;
+		end: Date;
+		amount: number;
+		currency: string;
+		unit: SubscriptionDuration;
+	}> = [];
 	let postScheduleStart = subscription.paidUntil;
 	if (subscription.pricingScheduleSnapshot) {
 		const phases = subscription.pricingScheduleSnapshot.phases;
@@ -157,7 +163,13 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 			}
 			const cyclesInRun = runEnd - i + 1;
 			const end = add(start, phaseDurationObj(cyclesInRun, phases[i].unit));
-			upcomingPhases.push({ start, end, amount: phases[i].priceAmount, currency });
+			upcomingPhases.push({
+				start,
+				end,
+				amount: phases[i].priceAmount,
+				currency,
+				unit: phases[i].unit
+			});
 			start = end;
 			i = runEnd + 1;
 		}

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -14,9 +14,30 @@ import { userQuery } from '$lib/server/user.js';
 import { paymentMethods, type PaymentMethod } from '$lib/server/payment-methods';
 import { toSatoshis } from '$lib/utils/toSatoshis';
 import { error, fail, redirect } from '@sveltejs/kit';
-import { subHours, subSeconds } from 'date-fns';
+import { add, subHours, subSeconds } from 'date-fns';
 import { z } from 'zod';
 import type { Actions } from './$types';
+import type { SubscriptionDuration } from '$lib/types/SubscriptionDuration';
+
+/**
+ * Local mirror of orders.ts::pricingPhaseDuration for calendar-accurate date arithmetic on
+ * upcoming phase ranges (`date-fns/add` handles month/year wrap-around correctly, whereas a
+ * plain seconds delta would drift on 30/31-day months and leap years).
+ */
+function phaseDurationObj(value: number, unit: SubscriptionDuration) {
+	switch (unit) {
+		case 'hour':
+			return { hours: value };
+		case 'day':
+			return { days: value };
+		case 'week':
+			return { weeks: value };
+		case 'month':
+			return { months: value };
+		case 'year':
+			return { years: value };
+	}
+}
 
 export async function load({ params, locals }: { params: { id: string }; locals: App.Locals }) {
 	const subscription = await collections.paidSubscriptions.findOne({
@@ -114,6 +135,63 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		: resolveSubscriptionReminderSeconds(product);
 	const canRenewAfter = subSeconds(subscription.paidUntil, canRenewReminderSeconds);
 
+	// Build the "prochaines phases" panel: consecutive un-billed cycles in the snapshot that
+	// share the same (unit, priceAmount) come from a single configured phase — collapse them
+	// back into date ranges so the customer sees "du 09/07 au 09/10 : 21 CHF" instead of three
+	// identical monthly lines.
+	const upcomingPhases: Array<{ start: Date; end: Date; amount: number; currency: string }> = [];
+	let postScheduleStart = subscription.paidUntil;
+	if (subscription.pricingScheduleSnapshot) {
+		const phases = subscription.pricingScheduleSnapshot.phases;
+		const currency = subscription.pricingScheduleSnapshot.currency;
+		let i = subscription.pricingScheduleCursor ?? 0;
+		let start = subscription.paidUntil;
+		while (i < phases.length) {
+			let runEnd = i;
+			while (
+				runEnd + 1 < phases.length &&
+				phases[runEnd + 1].unit === phases[i].unit &&
+				phases[runEnd + 1].priceAmount === phases[i].priceAmount
+			) {
+				runEnd++;
+			}
+			const cyclesInRun = runEnd - i + 1;
+			const end = add(start, phaseDurationObj(cyclesInRun, phases[i].unit));
+			upcomingPhases.push({ start, end, amount: phases[i].priceAmount, currency });
+			start = end;
+			i = runEnd + 1;
+		}
+		postScheduleStart = start;
+	}
+
+	// Order history for this subscription. Bound by `createdAt >= subscription.createdAt` so a
+	// prior cancelled subscription for the same product doesn't leak into the current one's
+	// history. Ordered oldest → newest so the first phase's funding order shows up on top.
+	const paidOrders = await collections.orders
+		.find(
+			{
+				'items.product._id': subscription.productId,
+				'payments.status': 'paid',
+				...userQuery(subscription.user),
+				createdAt: { $gte: subscription.createdAt }
+			},
+			{
+				sort: { createdAt: 1 },
+				projection: { _id: 1, number: 1, currencySnapshot: 1, payments: 1 }
+			}
+		)
+		.toArray();
+	const orderHistory = paidOrders.map((order) => {
+		const paidPayment = order.payments.find((p) => p.status === 'paid');
+		return {
+			_id: order._id,
+			number: order.number,
+			amount: order.currencySnapshot?.main?.totalPrice?.amount ?? 0,
+			currency: order.currencySnapshot?.main?.totalPrice?.currency ?? '',
+			paidPaymentId: paidPayment?._id.toString()
+		};
+	});
+
 	return {
 		subscription: {
 			createdAt: subscription.createdAt,
@@ -125,11 +203,18 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		product: {
 			_id: product._id,
 			name: product.name,
-			subscriptionDuration: resolveSubscriptionDuration(product)
+			subscriptionDuration: resolveSubscriptionDuration(product),
+			priceAmount: product.price.amount,
+			priceCurrency: product.price.currency
 		},
 		picture: picture ?? undefined,
 		canRenew: canRenewAfter < new Date(),
 		canRenewAfter,
+		snapshot: subscription.pricingScheduleSnapshot,
+		cursor: subscription.pricingScheduleCursor ?? 0,
+		upcomingPhases,
+		postScheduleStart,
+		orderHistory,
 		nextBilling: {
 			amount: nextBillingAmount,
 			currency: nextBillingCurrency

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -49,11 +49,14 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		{ sort: { createdAt: 1 } }
 	);
 
-	// While the schedule still has phases to bill, honour the current phase's reminder.
+	// The cursor points at the phase to bill on the *next* renewal, so the phase that funded
+	// the *current* period sits at `cursor - 1`. Its reminder offset is what canRenew must
+	// use so the "renew" button appears at the same moment the reminder email is sent.
 	// Past-schedule, cancelled or legacy subs fall back to the product-level reminder.
+	const currentPhaseIndex = (subscription.pricingScheduleCursor ?? 0) - 1;
 	const activePhase = subscription.cancelledAt
 		? undefined
-		: subscription.pricingScheduleSnapshot?.phases[subscription.pricingScheduleCursor ?? 0];
+		: subscription.pricingScheduleSnapshot?.phases[currentPhaseIndex];
 	const canRenewReminderSeconds = activePhase
 		? subscriptionUnitToSeconds(activePhase.reminderValue, activePhase.reminderUnit)
 		: resolveSubscriptionReminderSeconds(product);

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -82,6 +82,18 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		: initialMethods;
 	const lastPaidMethodStillEligible = !!lastPaidMethod && eligibleMethods.includes(lastPaidMethod);
 
+	// The shared PaymentMethodSelector renders a POS subtype dropdown whenever `point-of-sale`
+	// is chosen, so ship the same list the checkout page uses. Cheap enough to fetch even when
+	// POS isn't in the eligible methods (the selector hides the dropdown in that case).
+	const posSubtypes = eligibleMethods.includes('point-of-sale')
+		? (
+				await collections.posPaymentSubtypes
+					.find({ disabled: { $ne: true } })
+					.sort({ sortOrder: 1 })
+					.toArray()
+		  ).map((s) => ({ slug: s.slug, name: s.name }))
+		: [];
+
 	const picture = await collections.pictures.findOne(
 		{
 			productId: product._id
@@ -117,6 +129,7 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		},
 		picture: picture ?? undefined,
 		canRenew: canRenewAfter < new Date(),
+		canRenewAfter,
 		nextBilling: {
 			amount: nextBillingAmount,
 			currency: nextBillingCurrency
@@ -124,7 +137,8 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		payment: {
 			lastPaidMethod,
 			lastPaidMethodStillEligible,
-			eligibleMethods
+			eligibleMethods,
+			posSubtypes
 		}
 	};
 }
@@ -200,7 +214,8 @@ export const actions: Actions = {
 		const submitted = Object.fromEntries(await request.formData());
 		const parsed = z
 			.object({
-				paymentMethod: z.enum([eligibleMethods[0], ...eligibleMethods.slice(1)]).optional()
+				paymentMethod: z.enum([eligibleMethods[0], ...eligibleMethods.slice(1)]).optional(),
+				posSubtype: z.string().optional()
 			})
 			.safeParse(submitted);
 		if (!parsed.success) {
@@ -214,6 +229,10 @@ export const actions: Actions = {
 		if (!chosenMethod) {
 			throw error(400, 'A payment method must be chosen to renew this subscription');
 		}
+		const chosenPosSubtype =
+			chosenMethod === 'point-of-sale' && parsed.data.posSubtype
+				? parsed.data.posSubtype
+				: undefined;
 
 		const existingPendingOrder = await collections.orders.findOne(
 			{
@@ -246,6 +265,7 @@ export const actions: Actions = {
 					user: subscription.user,
 					shippingAddress: lastOrder.shippingAddress,
 					billingAddress: lastOrder.billingAddress ?? lastOrder.shippingAddress ?? undefined,
+					...(chosenPosSubtype && { posSubtype: chosenPosSubtype }),
 					userVatCountry:
 						lastOrder.shippingAddress?.country ||
 						locals.countryCode ||

--- a/src/routes/(app)/subscription/[id]/+page.server.ts
+++ b/src/routes/(app)/subscription/[id]/+page.server.ts
@@ -5,9 +5,8 @@ import {
 	PaymentGenerationError
 } from '$lib/server/orders';
 import {
-	resolveSubscriptionDuration,
-	resolveSubscriptionReminderSeconds,
-	subscriptionUnitToSeconds
+	currentFundingReminderSeconds,
+	resolveSubscriptionDuration
 } from '$lib/server/subscriptions';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { userQuery } from '$lib/server/user.js';
@@ -122,18 +121,10 @@ export async function load({ params, locals }: { params: { id: string }; locals:
 		{ sort: { createdAt: 1 } }
 	);
 
-	// The cursor points at the phase to bill on the *next* renewal, so the phase that funded
-	// the *current* period sits at `cursor - 1`. Its reminder offset is what canRenew must
-	// use so the "renew" button appears at the same moment the reminder email is sent.
-	// Past-schedule, cancelled or legacy subs fall back to the product-level reminder.
-	const currentPhaseIndex = (subscription.pricingScheduleCursor ?? 0) - 1;
-	const activePhase = subscription.cancelledAt
-		? undefined
-		: subscription.pricingScheduleSnapshot?.phases[currentPhaseIndex];
-	const canRenewReminderSeconds = activePhase
-		? subscriptionUnitToSeconds(activePhase.reminderValue, activePhase.reminderUnit)
-		: resolveSubscriptionReminderSeconds(product);
-	const canRenewAfter = subSeconds(subscription.paidUntil, canRenewReminderSeconds);
+	const canRenewAfter = subSeconds(
+		subscription.paidUntil,
+		currentFundingReminderSeconds(subscription, product)
+	);
 
 	// Build the "prochaines phases" panel: consecutive un-billed cycles in the snapshot that
 	// share the same (unit, priceAmount) come from a single configured phase — collapse them

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -8,6 +8,12 @@
 
 	export let data;
 	export let form;
+
+	let changingMethod = !data.payment.lastPaidMethodStillEligible;
+	let chosenMethod: string =
+		data.payment.lastPaidMethodStillEligible && data.payment.lastPaidMethod
+			? data.payment.lastPaidMethod
+			: '';
 </script>
 
 <main class="mx-auto max-w-7xl py-10 px-6 flex flex-col gap-4 items-start">
@@ -56,10 +62,51 @@
 
 	<SubscriptionDurationLabel duration={data.product.subscriptionDuration} />
 
-	<form action="?/renew" method="post">
+	<p class="text-sm text-gray-600">
+		{t('subscription.nextBilling', {
+			amount: data.nextBilling.amount,
+			currency: data.nextBilling.currency
+		})}
+	</p>
+
+	<form action="?/renew" method="post" class="flex flex-col gap-3 items-start">
+		{#if data.payment.lastPaidMethod && data.payment.lastPaidMethodStillEligible && !changingMethod}
+			<p class="text-sm text-gray-600">
+				{t('subscription.payment.currentMethod', {
+					method: t('checkout.paymentMethod.' + data.payment.lastPaidMethod)
+				})}
+			</p>
+			<button
+				type="button"
+				class="text-sm underline text-gray-700"
+				on:click={() => (changingMethod = true)}
+			>
+				{t('subscription.payment.change')}
+			</button>
+		{:else}
+			{#if data.payment.lastPaidMethod && !data.payment.lastPaidMethodStillEligible}
+				<p class="text-sm text-orange-700">
+					{t('subscription.payment.previousUnavailable', {
+						method: t('checkout.paymentMethod.' + data.payment.lastPaidMethod)
+					})}
+				</p>
+			{/if}
+			<fieldset class="flex flex-col gap-1">
+				<legend class="text-sm font-medium">{t('subscription.payment.chooseMethod')}</legend>
+				{#each data.payment.eligibleMethods as method}
+					<label class="flex items-center gap-2 text-sm">
+						<input type="radio" name="paymentMethod" value={method} bind:group={chosenMethod} />
+						{t('checkout.paymentMethod.' + method)}
+					</label>
+				{/each}
+			</fieldset>
+		{/if}
+
 		<button
 			class="btn btn-black"
-			disabled={!data.canRenew}
+			disabled={!data.canRenew ||
+				(!data.payment.lastPaidMethodStillEligible && !chosenMethod) ||
+				(changingMethod && !chosenMethod)}
 			title={data.canRenew ? '' : t('subscription.cantRenew')}>{t('subscription.cta.renew')}</button
 		>
 	</form>

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+	import PaymentMethodSelector from '$lib/components/PaymentMethodSelector.svelte';
 	import ProductItem from '$lib/components/ProductItem.svelte';
 	import SubscriptionDurationLabel from '$lib/components/SubscriptionDurationLabel.svelte';
 	import Trans from '$lib/components/Trans.svelte';
 	import { useI18n } from '$lib/i18n';
+	import type { PaymentMethod } from '$lib/server/payment-methods';
 
 	const { t, locale } = useI18n();
 
@@ -10,7 +12,7 @@
 	export let form;
 
 	let changingMethod = !data.payment.lastPaidMethodStillEligible;
-	let chosenMethod: string =
+	let chosenMethod: PaymentMethod | '' =
 		data.payment.lastPaidMethodStillEligible && data.payment.lastPaidMethod
 			? data.payment.lastPaidMethod
 			: '';
@@ -69,7 +71,7 @@
 		})}
 	</p>
 
-	<form action="?/renew" method="post" class="flex flex-col gap-3 items-start">
+	<form action="?/renew" method="post" class="flex flex-col gap-3 items-start w-full max-w-md">
 		{#if data.payment.lastPaidMethod && data.payment.lastPaidMethodStillEligible && !changingMethod}
 			<p class="text-sm text-gray-600">
 				{t('subscription.payment.currentMethod', {
@@ -91,15 +93,21 @@
 					})}
 				</p>
 			{/if}
-			<fieldset class="flex flex-col gap-1">
-				<legend class="text-sm font-medium">{t('subscription.payment.chooseMethod')}</legend>
-				{#each data.payment.eligibleMethods as method}
-					<label class="flex items-center gap-2 text-sm">
-						<input type="radio" name="paymentMethod" value={method} bind:group={chosenMethod} />
-						{t('checkout.paymentMethod.' + method)}
-					</label>
-				{/each}
-			</fieldset>
+			<PaymentMethodSelector
+				methods={data.payment.eligibleMethods}
+				bind:value={chosenMethod}
+				posSubtypes={data.payment.posSubtypes}
+			/>
+		{/if}
+
+		{#if !data.canRenew}
+			<p class="text-sm text-gray-600">
+				<Trans key="subscription.canRenewFrom"
+					><time datetime={data.canRenewAfter.toJSON()} slot="0"
+						>{new Date(data.canRenewAfter).toLocaleString($locale)}</time
+					></Trans
+				>
+			</p>
 		{/if}
 
 		<button

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -128,7 +128,10 @@
 							end: new Date(phase.end).toLocaleDateString($locale)
 						})} : {phase.amount === 0
 							? t('subscription.amountFree')
-							: `${phase.amount} ${phase.currency}`}
+							: `${phase.amount} ${phase.currency} / ${t(
+									'product.pricingScheduleUnit.' + phase.unit,
+									{ count: 1 }
+							  )}`}
 					</li>
 				{/each}
 				<li>
@@ -136,7 +139,10 @@
 						start: new Date(data.postScheduleStart).toLocaleDateString($locale)
 					})} : {data.product.priceAmount === 0
 						? t('subscription.amountFree')
-						: `${data.product.priceAmount} ${data.product.priceCurrency}`}
+						: `${data.product.priceAmount} ${data.product.priceCurrency} / ${t(
+								'product.pricingScheduleUnit.' + data.product.subscriptionDuration,
+								{ count: 1 }
+						  )}`}
 				</li>
 			</ul>
 		</section>

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -116,4 +116,56 @@
 			</p>
 		{/if}
 	</form>
+
+	{#if data.upcomingPhases.length || data.snapshot}
+		<section class="w-full max-w-md flex flex-col gap-1">
+			<h2 class="text-lg font-medium">{t('subscription.upcomingPhases.title')}</h2>
+			<ul class="text-sm text-gray-700 flex flex-col gap-1">
+				{#each data.upcomingPhases as phase}
+					<li>
+						- {t('subscription.upcomingPhases.range', {
+							start: new Date(phase.start).toLocaleDateString($locale),
+							end: new Date(phase.end).toLocaleDateString($locale)
+						})} : {phase.amount === 0
+							? t('subscription.amountFree')
+							: `${phase.amount} ${phase.currency}`}
+					</li>
+				{/each}
+				<li>
+					- {t('subscription.upcomingPhases.after', {
+						start: new Date(data.postScheduleStart).toLocaleDateString($locale)
+					})} : {data.product.priceAmount === 0
+						? t('subscription.amountFree')
+						: `${data.product.priceAmount} ${data.product.priceCurrency}`}
+				</li>
+			</ul>
+		</section>
+	{/if}
+
+	{#if data.orderHistory.length}
+		<section class="w-full max-w-md flex flex-col gap-1">
+			<h2 class="text-lg font-medium">{t('subscription.orderHistory.title')}</h2>
+			<ul class="text-sm text-gray-700 flex flex-col gap-1">
+				{#each data.orderHistory as order}
+					<li>
+						- <a href="/order/{order._id}" target="_blank" rel="noreferrer" class="underline"
+							>#{order.number}</a
+						>
+						- {order.amount === 0
+							? t('subscription.amountFree')
+							: `${order.amount} ${order.currency}`}
+						{#if order.paidPaymentId}
+							-
+							<a
+								href="/order/{order._id}/payment/{order.paidPaymentId}/receipt"
+								target="_blank"
+								rel="noreferrer"
+								class="underline">{t('subscription.orderHistory.downloadInvoice')}</a
+							>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
 </main>

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -72,35 +72,41 @@
 	</p>
 
 	<form action="?/renew" method="post" class="flex flex-col gap-3 items-start w-full max-w-md">
-		{#if data.payment.lastPaidMethod && data.payment.lastPaidMethodStillEligible && !changingMethod}
-			<p class="text-sm text-gray-600">
-				{t('subscription.payment.currentMethod', {
-					method: t('checkout.paymentMethod.' + data.payment.lastPaidMethod)
-				})}
-			</p>
-			<button
-				type="button"
-				class="text-sm underline text-gray-700"
-				on:click={() => (changingMethod = true)}
-			>
-				{t('subscription.payment.change')}
-			</button>
-		{:else}
-			{#if data.payment.lastPaidMethod && !data.payment.lastPaidMethodStillEligible}
-				<p class="text-sm text-orange-700">
-					{t('subscription.payment.previousUnavailable', {
+		{#if data.canRenew}
+			{#if data.payment.lastPaidMethod && data.payment.lastPaidMethodStillEligible && !changingMethod}
+				<p class="text-sm text-gray-600">
+					{t('subscription.payment.currentMethod', {
 						method: t('checkout.paymentMethod.' + data.payment.lastPaidMethod)
 					})}
 				</p>
+				<button
+					type="button"
+					class="text-sm underline text-gray-700"
+					on:click={() => (changingMethod = true)}
+				>
+					{t('subscription.payment.change')}
+				</button>
+			{:else}
+				{#if data.payment.lastPaidMethod && !data.payment.lastPaidMethodStillEligible}
+					<p class="text-sm text-orange-700">
+						{t('subscription.payment.previousUnavailable', {
+							method: t('checkout.paymentMethod.' + data.payment.lastPaidMethod)
+						})}
+					</p>
+				{/if}
+				<PaymentMethodSelector
+					methods={data.payment.eligibleMethods}
+					bind:value={chosenMethod}
+					posSubtypes={data.payment.posSubtypes}
+				/>
 			{/if}
-			<PaymentMethodSelector
-				methods={data.payment.eligibleMethods}
-				bind:value={chosenMethod}
-				posSubtypes={data.payment.posSubtypes}
-			/>
-		{/if}
 
-		{#if !data.canRenew}
+			<button
+				class="btn btn-black"
+				disabled={(!data.payment.lastPaidMethodStillEligible && !chosenMethod) ||
+					(changingMethod && !chosenMethod)}>{t('subscription.cta.renew')}</button
+			>
+		{:else}
 			<p class="text-sm text-gray-600">
 				<Trans key="subscription.canRenewFrom"
 					><time datetime={data.canRenewAfter.toJSON()} slot="0"
@@ -109,13 +115,5 @@
 				>
 			</p>
 		{/if}
-
-		<button
-			class="btn btn-black"
-			disabled={!data.canRenew ||
-				(!data.payment.lastPaidMethodStillEligible && !chosenMethod) ||
-				(changingMethod && !chosenMethod)}
-			title={data.canRenew ? '' : t('subscription.cantRenew')}>{t('subscription.cta.renew')}</button
-		>
 	</form>
 </main>

--- a/src/routes/(app)/subscription/[id]/+page.svelte
+++ b/src/routes/(app)/subscription/[id]/+page.svelte
@@ -16,6 +16,7 @@
 		data.payment.lastPaidMethodStillEligible && data.payment.lastPaidMethod
 			? data.payment.lastPaidMethod
 			: '';
+	let submitting = false;
 </script>
 
 <main class="mx-auto max-w-7xl py-10 px-6 flex flex-col gap-4 items-start">
@@ -71,7 +72,12 @@
 		})}
 	</p>
 
-	<form action="?/renew" method="post" class="flex flex-col gap-3 items-start w-full max-w-md">
+	<form
+		action="?/renew"
+		method="post"
+		class="flex flex-col gap-3 items-start w-full max-w-md"
+		on:submit={() => (submitting = true)}
+	>
 		{#if data.canRenew}
 			{#if data.payment.lastPaidMethod && data.payment.lastPaidMethodStillEligible && !changingMethod}
 				<p class="text-sm text-gray-600">
@@ -103,7 +109,8 @@
 
 			<button
 				class="btn btn-black"
-				disabled={(!data.payment.lastPaidMethodStillEligible && !chosenMethod) ||
+				disabled={submitting ||
+					(!data.payment.lastPaidMethodStillEligible && !chosenMethod) ||
 					(changingMethod && !chosenMethod)}>{t('subscription.cta.renew')}</button
 			>
 		{:else}


### PR DESCRIPTION
## Summary

Attach an optional promotional schedule to a subscription product. Each configured phase `{ value: N, unit, priceAmount, reminderValue, reminderUnit }` expands into N unit cycles at first payment: "3 months at 21 CHF" bills 21 CHF monthly for 3 months. Phase 0 is billed at initial purchase (a free trial is just a phase at price 0), each renewal advances the cursor by one cycle, and once the schedule is exhausted the subscription reverts to the product's base price and cycle.

Each buyer identity (email or npub) benefits from the schedule only once per product: the snapshot is frozen on the subscription at first payment and cannot be replayed. Cancellation burns the schedule. Reminder timing comes from the phase that funded the *current* period; past-schedule or legacy subs fall back to the product-level reminder. Each phase entry also stores `status` and `orderId` once billed, so a subscription record carries a full trace of which order paid which cycle.

## Renewal flow

`/subscription/{id}` now:
- Shows the amount of the next renewal, the payment method the last paid order used, and gates the "Renew" CTA on whether that method is still eligible. When the previous method is `'free'` and the next phase is non-zero, or when the shop has since disabled it, the customer picks a new one from the intersection of `runtimeConfig` payment methods and the product's own restriction (Closes #2114).
- Uses a new shared `PaymentMethodSelector.svelte` component that mirrors the checkout's dropdown (label + select + POS subtype sub-select + fallback). The checkout can migrate to it later without behavioural drift.
- Hides the payment controls entirely when the subscription isn't due yet and surfaces the exact date after which it will be renewable.
- Lists **upcoming phases** (date range + price, "Gratuit" / "Free" for zero-priced ones, ending with an "à partir du {date} : {price}" line for post-schedule) and **order history** for this subscription (new-tab link to the order + direct link to the payment receipt / invoice download). Closes #2602 (the `/order` → `/subscription` nav link is deferred as low value).

## Also fixed

- Free orders fired `onOrderPayment` twice (`addOrderPayment` already fires it internally), double-incrementing the pricing cursor and over-extending `paidUntil` on any free subscribe.
- Cart lines for fresh subscription purchases were priced at the product's nominal amount instead of the first phase's price, so a free trial produced an already-paid order that crashed the payment flow with "Order already fully paid".
- Reminder cron and `canRenew` computation read the *next* phase's reminder instead of the one funding the current period, so a fresh subscribe to a 1-week trial followed by a 7-day-reminder monthly phase mailed the customer instantly.
- Subscription renewals never passed `billingAddress` to `createOrder`, so shops with `isBillingAddressMandatory` couldn't renew (legacy bug from #727).

## Data model

- `Product.pricingSchedule` (optional): array of `{ value, unit, priceAmount, reminderValue, reminderUnit }`
- `PaidSubscription.pricingScheduleSnapshot` (optional): `{ currency, phases }` — expanded snapshot at first payment; each phase carries `status?: 'paid'` and `orderId?: string` once billed
- `PaidSubscription.pricingScheduleCursor` (optional): index of the next phase/cycle to bill

Closes #2651
Closes #2114
Closes #2602