### PR TITLE
🐛 Store order VAT in configured currencies, not SAT (#2492)

### DIFF
--- a/src/lib/server/migrations.test.ts
+++ b/src/lib/server/migrations.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { cleanDb } from './test-utils';
+import { collections, withTransaction } from './database';
+import { migrations } from './migrations';
+
+function migration2492() {
+	const migration = migrations.find((m) => m._id.equals(new ObjectId('6b1f4880e92e590e85af2492')));
+	if (!migration) {
+		throw new Error('migration #2492 not found');
+	}
+	return migration;
+}
+
+describe('migration #2492 — drop single-currency (SAT) amount from order.vat', () => {
+	it('reduces legacy SAT vat entries to {rate, country} against a live database', async () => {
+		await cleanDb();
+
+		const _id = 'legacy-order-2492';
+		// Legacy order: VAT amounts wrongly stored in the internal SAT unit (the bug), while the
+		// correct per-currency amounts are already frozen in currencySnapshot.
+		await collections.orders.insertOne({
+			_id,
+			vat: [
+				{
+					price: { amount: 853, currency: 'SAT' },
+					partialPrice: { amount: 853, currency: 'SAT' },
+					rate: 8.1,
+					country: 'CH'
+				}
+			],
+			currencySnapshot: {
+				main: {
+					totalPrice: { amount: 7.24, currency: 'EUR' },
+					vat: [{ amount: 0.54, currency: 'EUR' }]
+				},
+				priceReference: {
+					totalPrice: { amount: 6.66, currency: 'CHF' },
+					vat: [{ amount: 0.5, currency: 'CHF' }]
+				}
+			}
+		} as never);
+
+		await withTransaction((session) => migration2492().run(session));
+
+		const migrated = await collections.orders.findOne({ _id });
+		// Amount/currency stripped; only the rate breakdown remains.
+		expect(migrated?.vat).toEqual([{ rate: 8.1, country: 'CH' }]);
+		// The per-currency amounts are untouched and still available.
+		expect(migrated?.currencySnapshot.main.vat).toEqual([{ amount: 0.54, currency: 'EUR' }]);
+		expect(migrated?.currencySnapshot.priceReference.vat).toEqual([
+			{ amount: 0.5, currency: 'CHF' }
+		]);
+	});
+
+	it('leaves an already-migrated order untouched (idempotent)', async () => {
+		await cleanDb();
+		const _id = 'already-migrated-2492';
+		await collections.orders.insertOne({
+			_id,
+			vat: [{ rate: 8.1, country: 'CH' }],
+			currencySnapshot: {
+				main: {
+					totalPrice: { amount: 7.24, currency: 'EUR' },
+					vat: [{ amount: 0.54, currency: 'EUR' }]
+				},
+				priceReference: { totalPrice: { amount: 6.66, currency: 'CHF' } }
+			}
+		} as never);
+
+		await withTransaction((session) => migration2492().run(session));
+
+		const after = await collections.orders.findOne({ _id });
+		expect(after?.vat).toEqual([{ rate: 8.1, country: 'CH' }]);
+	});
+});

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -1,8 +1,8 @@
-import { ClientSession, ObjectId } from 'mongodb';
+import { ClientSession, ObjectId, type Filter } from 'mongodb';
 import { collections, withTransaction } from './database';
 import { marked } from 'marked';
 import { env } from '$env/dynamic/private';
-import type { OrderPayment } from '$lib/types/Order';
+import type { Order, OrderPayment } from '$lib/types/Order';
 import { Lock } from './lock';
 import { ORIGIN } from '$lib/server/env-config';
 import type { PosPaymentSubtype } from '$lib/types/PosPaymentSubtype';
@@ -923,6 +923,23 @@ export const migrations = [
 						{ session }
 					);
 				}
+			}
+		}
+	},
+	{
+		_id: new ObjectId('6b1f4880e92e590e85af2492'),
+		name: 'Drop single-currency (SAT) amount from order.vat; amounts live in currencySnapshot (issue #2492)',
+		run: async (session: ClientSession) => {
+			// Old orders stored order.vat[].price/partialPrice in the internal SAT unit. The correct
+			// per-currency amounts are already frozen in currencySnapshot.*.vat, so we only need to
+			// reduce each entry to its {rate, country} breakdown — no rate lookup required.
+			const cursor = collections.orders.find({ 'vat.price': { $exists: true } } as Filter<Order>, {
+				projection: { vat: 1 },
+				session
+			});
+			for await (const order of cursor) {
+				const vat = (order.vat ?? []).map(({ rate, country }) => ({ rate, country }));
+				await collections.orders.updateOne({ _id: order._id }, { $set: { vat } }, { session });
 			}
 		}
 	}

--- a/src/lib/server/order.test.ts
+++ b/src/lib/server/order.test.ts
@@ -9,6 +9,7 @@ import {
 } from './seed/product';
 import { addOrderPayment, createOrder, lastInvoiceNumber, onOrderPayment } from './orders';
 import { orderAmountWithNoPaymentsCreated } from '$lib/types/Order';
+import { runtimeConfig } from './runtime-config';
 
 describe('order', () => {
 	beforeEach(async () => {
@@ -55,6 +56,19 @@ describe('order', () => {
 			expect(order?.currencySnapshot?.main.totalReceived).toBeDefined();
 			expect(order?.currencySnapshot?.priceReference.totalReceived).toBeDefined();
 			expect(order?.currencySnapshot?.secondary?.totalReceived).toBeDefined();
+
+			// Issue #2492: order.vat holds only the {rate, country} breakdown — never a monetary
+			// amount, and never the internal SAT unit. Amounts live in currencySnapshot.*.vat, in a
+			// real (main) currency. Guarded so it also holds for VAT-free orders.
+			for (const entry of order?.vat ?? []) {
+				expect(entry).not.toHaveProperty('price');
+				expect(entry).not.toHaveProperty('partialPrice');
+				expect(entry).toMatchObject({ rate: expect.any(Number), country: expect.any(String) });
+			}
+			for (const amount of order?.currencySnapshot?.main.vat ?? []) {
+				expect(amount.currency).not.toBe('SAT');
+				expect(amount.currency).toBe(runtimeConfig.mainCurrency);
+			}
 		});
 
 		it('should increase the invoice number each time', async () => {

--- a/src/lib/server/orderVatSnapshot.test.ts
+++ b/src/lib/server/orderVatSnapshot.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { orderVatAccountingSnapshot } from './orderVatSnapshot';
+import type { Order } from '$lib/types/Order';
+
+// Minimal order carrying only what the snapshot reads. Mirrors the issue #2492 scenario:
+// main/accounting in EUR, priceReference in CHF, secondary in BTC — and NEVER SAT.
+function makeOrder(overrides: Partial<Order['currencySnapshot']> = {}): Order {
+	const currencySnapshot = {
+		main: {
+			totalPrice: { amount: 7.24, currency: 'EUR' },
+			vat: [{ amount: 0.54, currency: 'EUR' }]
+		},
+		priceReference: {
+			totalPrice: { amount: 6.66, currency: 'CHF' },
+			vat: [{ amount: 0.5, currency: 'CHF' }]
+		},
+		secondary: {
+			totalPrice: { amount: 0.00012, currency: 'BTC' },
+			vat: [{ amount: 0.0000089, currency: 'BTC' }]
+		},
+		accounting: {
+			totalPrice: { amount: 7.24, currency: 'EUR' },
+			vat: [{ amount: 0.54, currency: 'EUR' }]
+		},
+		...overrides
+	} as Order['currencySnapshot'];
+
+	return {
+		vat: [{ rate: 8.1, country: 'CH' }],
+		currencySnapshot
+	} as unknown as Order;
+}
+
+describe('orderVatAccountingSnapshot', () => {
+	it('snapshots VAT in every configured currency, never SAT', () => {
+		const snap = orderVatAccountingSnapshot(makeOrder());
+
+		expect(snap.rates).toEqual([{ rate: 8.1, country: 'CH' }]);
+		expect(snap.main).toEqual([{ amount: 0.54, currency: 'EUR' }]);
+		expect(snap.priceReference).toEqual([{ amount: 0.5, currency: 'CHF' }]);
+		expect(snap.secondary).toEqual([{ amount: 0.0000089, currency: 'BTC' }]);
+		expect(snap.accounting).toEqual([{ amount: 0.54, currency: 'EUR' }]);
+
+		// No amount is ever expressed in the internal SAT unit.
+		const currencies = [snap.main, snap.priceReference, snap.secondary, snap.accounting]
+			.flat()
+			.map((p) => p?.currency);
+		expect(currencies).not.toContain('SAT');
+	});
+
+	it('omits secondary/accounting when the shop has not configured them', () => {
+		const order = makeOrder();
+		delete (order.currencySnapshot as { secondary?: unknown }).secondary;
+		delete (order.currencySnapshot as { accounting?: unknown }).accounting;
+
+		const snap = orderVatAccountingSnapshot(order);
+
+		expect(snap).not.toHaveProperty('secondary');
+		expect(snap).not.toHaveProperty('accounting');
+		// main and priceReference are always present.
+		expect(snap.main).toBeDefined();
+		expect(snap.priceReference).toBeDefined();
+	});
+});

--- a/src/lib/server/orderVatSnapshot.test.ts
+++ b/src/lib/server/orderVatSnapshot.test.ts
@@ -1,18 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { orderVatAccountingSnapshot } from './orderVatSnapshot';
+import { orderCurrencyAmounts, orderVatAccountingSnapshot } from './orderVatSnapshot';
 import type { Order } from '$lib/types/Order';
 
 // Minimal order carrying only what the snapshot reads. Mirrors the issue #2492 scenario:
 // main/accounting in EUR, priceReference in CHF, secondary in BTC — and NEVER SAT.
-function makeOrder(overrides: Partial<Order['currencySnapshot']> = {}): Order {
+function makeOrder(): Order {
 	const currencySnapshot = {
 		main: {
 			totalPrice: { amount: 7.24, currency: 'EUR' },
-			vat: [{ amount: 0.54, currency: 'EUR' }]
+			vat: [{ amount: 0.54, currency: 'EUR' }],
+			discount: { amount: 1, currency: 'EUR' }
 		},
 		priceReference: {
 			totalPrice: { amount: 6.66, currency: 'CHF' },
-			vat: [{ amount: 0.5, currency: 'CHF' }]
+			vat: [{ amount: 0.5, currency: 'CHF' }],
+			discount: { amount: 0.92, currency: 'CHF' }
 		},
 		secondary: {
 			totalPrice: { amount: 0.00012, currency: 'BTC' },
@@ -21,8 +23,7 @@ function makeOrder(overrides: Partial<Order['currencySnapshot']> = {}): Order {
 		accounting: {
 			totalPrice: { amount: 7.24, currency: 'EUR' },
 			vat: [{ amount: 0.54, currency: 'EUR' }]
-		},
-		...overrides
+		}
 	} as Order['currencySnapshot'];
 
 	return {
@@ -41,7 +42,6 @@ describe('orderVatAccountingSnapshot', () => {
 		expect(snap.secondary).toEqual([{ amount: 0.0000089, currency: 'BTC' }]);
 		expect(snap.accounting).toEqual([{ amount: 0.54, currency: 'EUR' }]);
 
-		// No amount is ever expressed in the internal SAT unit.
 		const currencies = [snap.main, snap.priceReference, snap.secondary, snap.accounting]
 			.flat()
 			.map((p) => p?.currency);
@@ -57,8 +57,45 @@ describe('orderVatAccountingSnapshot', () => {
 
 		expect(snap).not.toHaveProperty('secondary');
 		expect(snap).not.toHaveProperty('accounting');
-		// main and priceReference are always present.
 		expect(snap.main).toBeDefined();
 		expect(snap.priceReference).toBeDefined();
+	});
+
+	it('reports no rate rows when there are no per-currency VAT amounts', () => {
+		const order = makeOrder();
+		// Rate rows present but no snapshotted amounts (e.g. a zero-total-VAT order).
+		delete (order.currencySnapshot.main as { vat?: unknown }).vat;
+		delete (order.currencySnapshot.priceReference as { vat?: unknown }).vat;
+		delete (order.currencySnapshot.secondary as { vat?: unknown }).vat;
+		delete (order.currencySnapshot.accounting as { vat?: unknown }).vat;
+
+		const snap = orderVatAccountingSnapshot(order);
+
+		expect(snap.rates).toEqual([]);
+		expect(snap).not.toHaveProperty('main');
+		expect(snap).not.toHaveProperty('priceReference');
+	});
+});
+
+describe('orderCurrencyAmounts', () => {
+	it('projects a field across every configured currency', () => {
+		const totals = orderCurrencyAmounts(makeOrder(), (entry) => entry.totalPrice);
+
+		expect(totals).toEqual({
+			main: { amount: 7.24, currency: 'EUR' },
+			priceReference: { amount: 6.66, currency: 'CHF' },
+			secondary: { amount: 0.00012, currency: 'BTC' },
+			accounting: { amount: 7.24, currency: 'EUR' }
+		});
+	});
+
+	it('omits currencies where the field is absent (e.g. no discount)', () => {
+		// secondary/accounting in makeOrder() carry no discount.
+		const discounts = orderCurrencyAmounts(makeOrder(), (entry) => entry.discount);
+
+		expect(discounts).toEqual({
+			main: { amount: 1, currency: 'EUR' },
+			priceReference: { amount: 0.92, currency: 'CHF' }
+		});
 	});
 });

--- a/src/lib/server/orderVatSnapshot.ts
+++ b/src/lib/server/orderVatSnapshot.ts
@@ -1,0 +1,19 @@
+import type { Order } from '$lib/types/Order';
+
+/**
+ * VAT snapshot for accounting logs (issue #2492): the per-rate breakdown plus the amounts in every
+ * configured currency — never the internal SAT unit. `main`/`priceReference` are always present;
+ * `secondary`/`accounting` only when the shop configured them.
+ *
+ * Pure (Order type only, no DB) so it can be unit-tested without a database.
+ */
+export function orderVatAccountingSnapshot(order: Order) {
+	const cs = order.currencySnapshot;
+	return {
+		rates: (order.vat ?? []).map(({ rate, country }) => ({ rate, country })),
+		main: cs.main.vat,
+		priceReference: cs.priceReference.vat,
+		...(cs.secondary?.vat && { secondary: cs.secondary.vat }),
+		...(cs.accounting?.vat && { accounting: cs.accounting.vat })
+	};
+}

--- a/src/lib/server/orderVatSnapshot.ts
+++ b/src/lib/server/orderVatSnapshot.ts
@@ -1,19 +1,50 @@
 import type { Order } from '$lib/types/Order';
 
+type SnapshotEntry = Order['currencySnapshot']['main'];
+type CurrencyRole = 'main' | 'priceReference' | 'secondary' | 'accounting';
+
 /**
- * VAT snapshot for accounting logs (issue #2492): the per-rate breakdown plus the amounts in every
- * configured currency — never the internal SAT unit. `main`/`priceReference` are always present;
- * `secondary`/`accounting` only when the shop configured them.
+ * Project a monetary field of every configured currency snapshot into a per-currency map
+ * (issue #2492) — never the internal SAT unit. `main`/`priceReference` are always in the snapshot;
+ * `secondary`/`accounting` only when the shop configured them. A currency is omitted when the
+ * field is absent for it (e.g. no discount).
+ */
+export function orderCurrencyAmounts<T>(
+	order: Order,
+	pick: (entry: SnapshotEntry) => T | undefined
+): Partial<Record<CurrencyRole, T>> {
+	const cs = order.currencySnapshot;
+	const entries: Array<[CurrencyRole, SnapshotEntry | undefined]> = [
+		['main', cs.main],
+		['priceReference', cs.priceReference],
+		['secondary', cs.secondary],
+		['accounting', cs.accounting]
+	];
+	const out: Partial<Record<CurrencyRole, T>> = {};
+	for (const [role, entry] of entries) {
+		if (!entry) {
+			continue;
+		}
+		const value = pick(entry);
+		if (value !== undefined) {
+			out[role] = value;
+		}
+	}
+	return out;
+}
+
+/**
+ * VAT snapshot for accounting logs (issue #2492): the per-rate breakdown plus the VAT amount in
+ * every configured currency. The `rates` breakdown is only reported when matching per-currency
+ * amounts exist, so a rate row never appears without its amounts.
  *
  * Pure (Order type only, no DB) so it can be unit-tested without a database.
  */
 export function orderVatAccountingSnapshot(order: Order) {
-	const cs = order.currencySnapshot;
+	const amounts = orderCurrencyAmounts(order, (entry) => entry.vat);
 	return {
-		rates: (order.vat ?? []).map(({ rate, country }) => ({ rate, country })),
-		main: cs.main.vat,
-		priceReference: cs.priceReference.vat,
-		...(cs.secondary?.vat && { secondary: cs.secondary.vat }),
-		...(cs.accounting?.vat && { accounting: cs.accounting.vat })
+		rates:
+			'main' in amounts ? (order.vat ?? []).map(({ rate, country }) => ({ rate, country })) : [],
+		...amounts
 	};
 }

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -87,7 +87,7 @@ import type { PaidSubscription } from '$lib/types/PaidSubscription';
 import { resolveProcessor } from './sdk/pp';
 import { pojo } from './pojo';
 import { logAccountingEvent } from './accounting-log';
-import { orderVatAccountingSnapshot } from './orderVatSnapshot';
+import { orderCurrencyAmounts, orderVatAccountingSnapshot } from './orderVatSnapshot';
 
 export async function conflictingTapToPayOrder(orderId: string): Promise<string | null> {
 	const other = await collections.orders.findOne({
@@ -424,7 +424,7 @@ export async function onOrderPayment(
 						vat: orderVatAccountingSnapshot(order),
 						...(order.discount && { discount: order.discount }),
 						...(order.currencySnapshot?.main?.discount && {
-							discountAmount: order.currencySnapshot.main.discount
+							discountAmount: orderCurrencyAmounts(order, (entry) => entry.discount)
 						})
 					},
 					objectId: order._id.toString(),
@@ -2138,10 +2138,10 @@ export async function addOrderPayment(
 					method: paymentMethod,
 					paymentId: payment._id.toString(),
 					vat: orderVatAccountingSnapshot(order),
-					totalPrice: order.currencySnapshot?.main?.totalPrice,
+					totalPrice: orderCurrencyAmounts(order, (entry) => entry.totalPrice),
 					...(order.discount && { discount: order.discount }),
 					...(order.currencySnapshot?.main?.discount && {
-						discountAmount: order.currencySnapshot.main.discount
+						discountAmount: orderCurrencyAmounts(order, (entry) => entry.discount)
 					})
 				},
 				objectId: order._id.toString(),

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -87,6 +87,7 @@ import type { PaidSubscription } from '$lib/types/PaidSubscription';
 import { resolveProcessor } from './sdk/pp';
 import { pojo } from './pojo';
 import { logAccountingEvent } from './accounting-log';
+import { orderVatAccountingSnapshot } from './orderVatSnapshot';
 
 export async function conflictingTapToPayOrder(orderId: string): Promise<string | null> {
 	const other = await collections.orders.findOne({
@@ -420,7 +421,7 @@ export async function onOrderPayment(
 						paymentId: payment._id.toString(),
 						invoiceNumber,
 						received,
-						vat: order.vat,
+						vat: orderVatAccountingSnapshot(order),
 						...(order.discount && { discount: order.discount }),
 						...(order.currencySnapshot?.main?.discount && {
 							discountAmount: order.currencySnapshot.main.discount
@@ -1559,7 +1560,11 @@ export async function createOrder(
 			})),
 			...(params.shippingAddress && { shippingAddress: params.shippingAddress }),
 			...(billingAddress && { billingAddress: billingAddress }),
-			...(priceInfo.vat.length && { vat: priceInfo.vat }),
+			...(priceInfo.vat.length && {
+				// Store only the per-rate breakdown; amounts are snapshotted per configured currency
+				// in currencySnapshot.*.vat (issue #2492), never in the internal SAT unit.
+				vat: priceInfo.vat.map(({ rate, country }) => ({ rate, country }))
+			}),
 			...(shippingPrice
 				? {
 						shippingPrice
@@ -2132,7 +2137,7 @@ export async function addOrderPayment(
 				after: {
 					method: paymentMethod,
 					paymentId: payment._id.toString(),
-					vat: order.vat,
+					vat: orderVatAccountingSnapshot(order),
 					totalPrice: order.currencySnapshot?.main?.totalPrice,
 					...(order.discount && { discount: order.discount }),
 					...(order.currencySnapshot?.main?.discount && {

--- a/src/lib/types/Order.ts
+++ b/src/lib/types/Order.ts
@@ -291,8 +291,12 @@ export interface Order extends Timestamps {
 		currency: Currency;
 	};
 
+	/**
+	 * Per-rate VAT breakdown metadata. The monetary amounts live in
+	 * `currencySnapshot.{main,priceReference,secondary,accounting}.vat[]` (index-aligned),
+	 * snapshotted in every configured currency — see issue #2492.
+	 */
 	vat?: Array<{
-		price: Price;
 		rate: number;
 		country: CountryAlpha2;
 	}>;

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -210,10 +210,6 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 		sellerIdentity: order.sellerIdentity,
 		vat: order.vat?.map((item) => ({
 			country: item.country,
-			price: {
-				amount: item.price.amount,
-				currency: item.price.currency
-			},
 			rate: item.rate
 		})),
 		shippingAddress: order.shippingAddress,


### PR DESCRIPTION
## Summary

Fixes #2492 — VAT was stored in the internal **SAT** unit on the order document, regardless of the shop's main/billing/accounting currency.

Root cause: pricing is computed in `UNDERLYING_CURRENCY = 'SAT'`, and `createOrder` stored that raw array straight into `order.vat`. The correctly-converted per-currency amounts were already sitting in `currencySnapshot.*.vat` — only the top-level `order.vat` (and the accounting log that read it) were wrong.

## Behaviour after fix

- **`order.vat[]` now holds only the `{ rate, country }` breakdown** — no monetary amount, never SAT. The amounts live where every other order amount lives: `currencySnapshot.{main,priceReference,secondary,accounting}.vat[]` (index-aligned with the rate breakdown), each in its real currency.
- **Accounting logs (`paymentDone` / `paymentCall`) now snapshot VAT — and `totalPrice` / `discountAmount` — in every configured currency** via a small pure helper (`orderCurrencyAmounts`), instead of a single main-currency (or SAT) value. `main`/`priceReference` always; `secondary`/`accounting` only when the shop configured them.
- A **migration** rewrites historical orders: it strips the legacy SAT `price`/`partialPrice` from `order.vat[]`. No exchange-rate lookup needed — each order's `currencySnapshot` already froze the correct per-currency amounts at order time. Past accounting-log rows are left immutable (audit records).

Display was already correct (`OrderSummary` / receipt read `currencySnapshot.main.vat`), so there's no UI change.

## Before / after — `/admin/order/{id}/json`

**Before** — `order.vat` amounts in SAT:

```json
"vat": [
  { "country": "CH", "rate": 8.1,
    "price":        { "amount": 853, "currency": "SAT" },
    "partialPrice": { "amount": 853, "currency": "SAT" } }
]
```

**After** — rate breakdown only; amounts per configured currency in `currencySnapshot`:

```json
"vat": [ { "rate": 8.1, "country": "CH" } ],
"currencySnapshot": {
  "main":           { "totalPrice": { "amount": 7.2415, "currency": "EUR", "precision": 4 }, "vat": [ { "amount": 0.54, "currency": "EUR" } ] },
  "priceReference": { "totalPrice": { "amount": 6.66,   "currency": "CHF", "precision": 4 }, "vat": [ { "amount": 0.5,  "currency": "CHF" } ] },
  "secondary":      { "totalPrice": { "amount": 0.00012394, "currency": "BTC", "precision": 8 }, "vat": [ { "amount": 0.0000089, "currency": "BTC" } ] },
  "accounting":     { "totalPrice": { "amount": 7.2415, "currency": "EUR", "precision": 4 }, "vat": [ { "amount": 0.54, "currency": "EUR" } ] }
}
```

## Data model

- `Order.vat?: Array<{ rate: number; country: CountryAlpha2 }>` — was `{ price: Price; rate; country }`.
- Accounting-log `after.vat` / `after.totalPrice` / `after.discountAmount` change from a single `Price` to a per-currency object `{ main, priceReference, secondary?, accounting? }` (the log's `after` is free-form; nothing parses these fields — the CSV/JSON exports just `JSON.stringify` the record).

## Tests

- Pure unit tests for the helpers (`orderVatSnapshot.test.ts`): VAT across every configured currency, `secondary`/`accounting` omission, the empty-rates edge, and `orderCurrencyAmounts` projection.
- A regression assertion in the DB-backed `order.test.ts` (order.vat never carries an amount; `currencySnapshot.main.vat` is in `mainCurrency`, never SAT).
- A **live migration test** (`migrations.test.ts`) run against MongoDB: a legacy SAT-shaped order is reduced to `{ rate, country }` with the per-currency amounts preserved, and it's idempotent.

Verified locally against a live MongoDB (`npm run check`, eslint, prettier, and the above tests all green); the before/after JSON above is the actual local output for the reported order id.