### PR TITLE
🐛🤖 Enable Z-ticket management by default on new be-BOP seeding

### DIFF
--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -334,7 +334,7 @@ const baseConfig = {
 		removeBebobLogo: false
 	},
 	posSession: {
-		enabled: false,
+		enabled: true,
 		allowXTicketEditing: false,
 		cashDeltaJustificationMandatory: false,
 		lockItemsAfterMidTicket: true,


### PR DESCRIPTION
## Summary
On a fresh be-BOP install, "Forbid use of /pos/touch when PoS Session is not opened" ships enabled while "Enable Z-ticket management" ships disabled — the shop can't open the POS until an admin manually flips the Z-ticket toggle. Enable Z-ticket management by default at seeding so the POS is usable straight after install; existing shops keep whatever value already sits in their DB.

Mongo field: `runtimeConfig.posSession.enabled` now defaults to `true`.

Fixes #2658