### PR TITLE
🐛🤖 Let long CTA labels wrap instead of clipping on a single line

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -120,11 +120,11 @@ html:root.dark {
 	}
 
 	.btn {
-		@apply rounded-lg border-0 cursor-pointer px-4 h-10 text-xl flex items-center justify-center font-btn;
+		@apply rounded-lg border-0 cursor-pointer px-4 py-2 min-h-[2.5rem] text-xl flex items-center justify-center text-center font-btn;
 	}
 
 	.btn-xl {
-		@apply h-[60px] text-2xl;
+		@apply min-h-[60px] text-2xl;
 	}
 
 	.btn-red {


### PR DESCRIPTION
## Summary
Buttons using the `.btn` / `.btn-xl` classes had a fixed height (`h-10` / `h-[60px]`), so any label whose text wrapped to two lines got clipped under that single-line bounding box (e.g. "Me rappeler dans 30 jours" on the admin telemetry banner). Swap the fixed height for `min-h-*` with vertical padding and add `text-center` so multi-line labels grow the button and stay centered.

Fixes #2660