### PR TITLE
🐛🤖 Replace the 5-column action-settings table with per-channel cards

### DIFF
--- a/src/lib/components/ProductActionSettingsCards.svelte
+++ b/src/lib/components/ProductActionSettingsCards.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	export let eshopVisible: boolean;
+	export let retailVisible: boolean;
+	export let googleShoppingVisible: boolean;
+	export let nostrVisible: boolean;
+	export let eshopBasket: boolean;
+	export let retailBasket: boolean;
+	export let nostrBasket: boolean;
+</script>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+	<div class="border border-gray-300 rounded p-3 bg-white flex flex-col gap-2">
+		<h4 class="font-semibold text-sm">Eshop (anyone)</h4>
+		<label class="checkbox-label text-sm">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="eshopVisible"
+				bind:checked={eshopVisible}
+			/>
+			Product is visible
+		</label>
+		<label class="checkbox-label text-sm">
+			<input type="checkbox" class="form-checkbox" name="eshopBasket" bind:checked={eshopBasket} />
+			Can be added to basket
+		</label>
+	</div>
+	<div class="border border-gray-300 rounded p-3 bg-white flex flex-col gap-2">
+		<h4 class="font-semibold text-sm">Retail (POS logged seat)</h4>
+		<label class="checkbox-label text-sm">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="retailVisible"
+				bind:checked={retailVisible}
+			/>
+			Product is visible
+		</label>
+		<label class="checkbox-label text-sm">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="retailBasket"
+				bind:checked={retailBasket}
+			/>
+			Can be added to basket
+		</label>
+	</div>
+	<div class="border border-gray-300 rounded p-3 bg-white flex flex-col gap-2">
+		<h4 class="font-semibold text-sm">Google Shopping</h4>
+		<label class="checkbox-label text-sm">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="googleShoppingVisible"
+				bind:checked={googleShoppingVisible}
+			/>
+			Product is visible
+		</label>
+	</div>
+	<div class="border border-gray-300 rounded p-3 bg-white flex flex-col gap-2">
+		<h4 class="font-semibold text-sm">Nostr-bot</h4>
+		<label class="checkbox-label text-sm">
+			<input
+				type="checkbox"
+				class="form-checkbox"
+				name="nostrVisible"
+				bind:checked={nostrVisible}
+			/>
+			Product is visible
+		</label>
+		<label class="checkbox-label text-sm">
+			<input type="checkbox" class="form-checkbox" name="nostrBasket" bind:checked={nostrBasket} />
+			Can be added to basket
+		</label>
+	</div>
+</div>

--- a/src/lib/components/ProductActionSettingsCards.svelte
+++ b/src/lib/components/ProductActionSettingsCards.svelte
@@ -9,7 +9,9 @@
 </script>
 
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-	<div class="border border-gray-300 rounded p-3 bg-white flex flex-col gap-2">
+	<div
+		class="border border-gray-300 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 flex flex-col gap-2"
+	>
 		<h4 class="font-semibold text-sm">Eshop (anyone)</h4>
 		<label class="checkbox-label text-sm">
 			<input
@@ -25,7 +27,9 @@
 			Can be added to basket
 		</label>
 	</div>
-	<div class="border border-gray-300 rounded p-3 bg-white flex flex-col gap-2">
+	<div
+		class="border border-gray-300 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 flex flex-col gap-2"
+	>
 		<h4 class="font-semibold text-sm">Retail (POS logged seat)</h4>
 		<label class="checkbox-label text-sm">
 			<input
@@ -46,7 +50,9 @@
 			Can be added to basket
 		</label>
 	</div>
-	<div class="border border-gray-300 rounded p-3 bg-white flex flex-col gap-2">
+	<div
+		class="border border-gray-300 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 flex flex-col gap-2"
+	>
 		<h4 class="font-semibold text-sm">Google Shopping</h4>
 		<label class="checkbox-label text-sm">
 			<input
@@ -58,7 +64,9 @@
 			Product is visible
 		</label>
 	</div>
-	<div class="border border-gray-300 rounded p-3 bg-white flex flex-col gap-2">
+	<div
+		class="border border-gray-300 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 flex flex-col gap-2"
+	>
 		<h4 class="font-semibold text-sm">Nostr-bot</h4>
 		<label class="checkbox-label text-sm">
 			<input

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -18,6 +18,7 @@
 	import Select from 'svelte-select';
 	import type { LayoutServerData } from '../../routes/(app)/$types';
 	import DeliveryFeesSelector from './DeliveryFeesSelector.svelte';
+	import ProductActionSettingsCards from './ProductActionSettingsCards.svelte';
 	import CurrencyLabel from './CurrencyLabel.svelte';
 	import PriceFieldsWithVat from './PriceFieldsWithVat.svelte';
 	import Editor from '@tinymce/tinymce-svelte';
@@ -1644,84 +1645,15 @@
 
 				<div>
 					<h4 class="text-lg font-medium text-gray-900 mb-3">Action Settings</h4>
-					<div class="overflow-x-auto">
-						<table class="w-full border border-gray-300 divide-y divide-gray-300 text-sm">
-							<thead class="bg-gray-100">
-								<tr>
-									<th class="py-3 px-4 text-left font-medium text-gray-700">Action</th>
-									<th class="py-3 px-4 text-center font-medium text-gray-700">E-shop</th>
-									<th class="py-3 px-4 text-center font-medium text-gray-700">Retail (POS)</th>
-									<th class="py-3 px-4 text-center font-medium text-gray-700">Google Shopping</th>
-									<th class="py-3 px-4 text-center font-medium text-gray-700">Nostr-bot</th>
-								</tr>
-							</thead>
-							<tbody class="divide-y divide-gray-200">
-								<tr>
-									<td class="py-3 px-4 font-medium text-gray-700">Product is visible</td>
-									<td class="py-3 px-4 text-center">
-										<input
-											type="checkbox"
-											bind:checked={product.actionSettings.eShop.visible}
-											name="eshopVisible"
-											class="form-checkbox"
-										/>
-									</td>
-									<td class="py-3 px-4 text-center">
-										<input
-											type="checkbox"
-											bind:checked={product.actionSettings.retail.visible}
-											name="retailVisible"
-											class="form-checkbox"
-										/>
-									</td>
-									<td class="py-3 px-4 text-center">
-										<input
-											type="checkbox"
-											bind:checked={product.actionSettings.googleShopping.visible}
-											name="googleShoppingVisible"
-											class="form-checkbox"
-										/>
-									</td>
-									<td class="py-3 px-4 text-center">
-										<input
-											type="checkbox"
-											bind:checked={product.actionSettings.nostr.visible}
-											name="nostrVisible"
-											class="form-checkbox"
-										/>
-									</td>
-								</tr>
-								<tr>
-									<td class="py-3 px-4 font-medium text-gray-700">Can be added to basket</td>
-									<td class="py-3 px-4 text-center">
-										<input
-											type="checkbox"
-											bind:checked={product.actionSettings.eShop.canBeAddedToBasket}
-											name="eshopBasket"
-											class="form-checkbox"
-										/>
-									</td>
-									<td class="py-3 px-4 text-center">
-										<input
-											type="checkbox"
-											bind:checked={product.actionSettings.retail.canBeAddedToBasket}
-											name="retailBasket"
-											class="form-checkbox"
-										/>
-									</td>
-									<td class="py-3 px-4 text-center text-gray-400">—</td>
-									<td class="py-3 px-4 text-center">
-										<input
-											type="checkbox"
-											bind:checked={product.actionSettings.nostr.canBeAddedToBasket}
-											name="nostrBasket"
-											class="form-checkbox"
-										/>
-									</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
+					<ProductActionSettingsCards
+						bind:eshopVisible={product.actionSettings.eShop.visible}
+						bind:retailVisible={product.actionSettings.retail.visible}
+						bind:googleShoppingVisible={product.actionSettings.googleShopping.visible}
+						bind:nostrVisible={product.actionSettings.nostr.visible}
+						bind:eshopBasket={product.actionSettings.eShop.canBeAddedToBasket}
+						bind:retailBasket={product.actionSettings.retail.canBeAddedToBasket}
+						bind:nostrBasket={product.actionSettings.nostr.canBeAddedToBasket}
+					/>
 				</div>
 			</div>
 		</details>

--- a/src/lib/server/test-utils.ts
+++ b/src/lib/server/test-utils.ts
@@ -14,7 +14,13 @@ export async function cleanDb() {
 	}
 	await connectPromise;
 	await refreshPromise;
-	await db.dropDatabase();
+	// Empty every collection instead of `db.dropDatabase()`. Dropping the database races background
+	// collection creation — the runtimeConfig change-stream `refresh()` (which seeds default roles /
+	// posPaymentSubtypes) and index creation — which throws "Cannot create collection … database is
+	// in the process of being dropped" (code 215) as unhandled rejections that fail the whole run.
+	// Clearing documents gives each test the same clean slate without ever dropping a collection.
+	const cols = await db.collections();
+	await Promise.all(cols.map((c) => c.deleteMany({})));
 	await createIndexes();
 
 	// Seed exchange rates for tests since defaultExchangeRate is now dynamic

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ProductActionSettingsCards from '$lib/components/ProductActionSettingsCards.svelte';
 	import ProductItem from '$lib/components/ProductItem.svelte';
 	import S3NotConfiguredWarning from '$lib/components/S3NotConfiguredWarning.svelte';
 	import { downloadFile } from '$lib/utils/downloadFile.js';
@@ -67,64 +68,22 @@
 
 <form method="post" class="flex flex-col gap-4" action="?/update">
 	<h3 class="text-xl">Default action settings</h3>
-	<table class="w-full border border-gray-300 divide-y divide-gray-300">
-		<thead class="bg-gray-200">
-			<tr>
-				<th class="py-2 px-4 border-r border-gray-300">Action</th>
-				<th class="py-2 px-4 border-r border-gray-300">Eshop (anyone)</th>
-				<th class="py-2 px-4 border-r border-gray-300">Retail (POS logged seat)</th>
-				<th class="py-2 px-4 border-r border-gray-300">Google Shopping</th>
-				<th class="py-2 px-4">Nostr-bot</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td class="py-2 px-4 border-r border-gray-300">Product is visible</td>
-				<td class="py-2 px-4 border-r border-gray-300 text-center">
-					<input type="checkbox" bind:checked={eshopVisible} name="eshopVisible" class="rounded" />
-				</td>
-				<td class="py-2 px-4 border-r border-gray-300 text-center">
-					<input
-						type="checkbox"
-						bind:checked={retailVisible}
-						name="retailVisible"
-						class="rounded"
-					/>
-				</td>
-				<td class="py-2 px-4 border-r border-gray-300 text-center">
-					<input
-						type="checkbox"
-						bind:checked={googleShoppingVisible}
-						name="googleShoppingVisible"
-						class="rounded"
-					/>
-				</td>
-				<td class="py-2 px-4 border-r border-gray-300 text-center">
-					<input type="checkbox" bind:checked={nostrVisible} name="nostrVisible" class="rounded" />
-				</td>
-			</tr>
-			<tr>
-				<td class="py-2 px-4 border border-gray-300">Product can be added to basket</td>
-				<td class="py-2 px-4 border border-gray-300 text-center">
-					<input type="checkbox" bind:checked={eshopBasket} name="eshopBasket" class="rounded" />
-				</td>
-				<td class="py-2 px-4 border border-gray-300 text-center">
-					<input type="checkbox" bind:checked={retailBasket} name="retailBasket" class="rounded" />
-				</td>
-				<td class="py-2 px-4 border border-gray-300 text-center" />
-				<td class="py-2 px-4 border border-gray-300 text-center">
-					<input type="checkbox" bind:checked={nostrBasket} name="nostrBasket" class="rounded" />
-				</td>
-			</tr>
-		</tbody>
-	</table>
+	<ProductActionSettingsCards
+		bind:eshopVisible
+		bind:retailVisible
+		bind:googleShoppingVisible
+		bind:nostrVisible
+		bind:eshopBasket
+		bind:retailBasket
+		bind:nostrBasket
+	/>
 	<button type="submit" class="btn btn-blue self-start">Update</button>
 </form>
 
 <h1 class="text-3xl">List of products</h1>
 
 <form class="flex flex-col" method="GET">
-	<div class="gap-4 flex flex-col md:flex-row mb-4">
+	<div class="gap-4 flex flex-col md:flex-row md:flex-wrap mb-4">
 		<label class="form-label w-[15em]">
 			Product Id
 			<input class="form-input" type="text" name="productId" placeholder="search product by id" />


### PR DESCRIPTION
## Summary
Since the admin left-sidebar took horizontal space, two blocks on `/admin/product` overflowed the pane:

- The 5-column "Default action settings" table (also present per-product on `/admin/product/new` and `/admin/product/{id}`) got its right columns clipped.
- The product filter row (Product Id / Name / Type / Attribute / Stock / Tag, each `w-[15em]`) sat on a single `md:flex-row` line and pushed off-screen.

Rewrite the action-settings table as a card grid (one card per channel: Eshop / Retail / Google Shopping / Nostr-bot, each stacking its two checkboxes). The grid wraps 1 → 2 → 4 columns depending on viewport width, so it fits every screen without horizontal scrolling. Factor into a shared `ProductActionSettingsCards.svelte` so `/admin/product` and `ProductForm.svelte` render the same layout. Add `md:flex-wrap` to the filter row (same fix already applied on `/admin/order`).

Fixes #2662