### PR TITLE
🐛🤖 Subscription lock: skip Nostr cursors for subs with empty/null npub (#2670)

### DIFF
--- a/src/lib/server/locks/subscription-lock.ts
+++ b/src/lib/server/locks/subscription-lock.ts
@@ -46,7 +46,7 @@ export function getSubscriptionsToRemindViaNostr(
 			$lt: reminderWindow
 		},
 		cancelledAt: { $exists: false },
-		'user.npub': { $exists: true },
+		'user.npub': { $exists: true, $nin: ['', null] },
 		notifications: { $not: { $elemMatch: { type: 'reminder', medium: 'nostr' } } }
 	});
 }
@@ -72,7 +72,7 @@ export function getSubscriptionsToNotifyEndViaNostr(now: Date): FindCursor<PaidS
 			$lt: now
 		},
 		cancelledAt: { $exists: false },
-		'user.npub': { $exists: true },
+		'user.npub': { $exists: true, $nin: ['', null] },
 		notifications: { $not: { $elemMatch: { type: 'expiration', medium: 'nostr' } } }
 	});
 }


### PR DESCRIPTION
## Summary

Fixes #2670. Two Mongo cursors in `subscription-lock.ts` treated `'user.npub': { $exists: true }` as "user has a Nostr identity", but empty-string / null values passed the filter and reached `notifySubscription{Reminder,Ended}ViaNostr`, which then log-spammed `user has no npub` at every tick of `maintainLock`. Tightened both filters with `$nin: ['', null]`.

Out of scope of this PR (kept for a follow-up if wanted): gating the whole Nostr branch of `maintainLock` behind `isNostrConfigured()` — the filter tightening alone kills the reported log spam.