### PR TITLE
📝 Refactor README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,276 @@
-# be-BOP
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="src/lib/assets/bebop-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="src/lib/assets/bebop-light.svg">
+    <img alt="be-BOP" src="src/lib/assets/bebop-light.svg" width="140">
+  </picture>
+</p>
 
-be-BOP is a free and open-source, peer-to-peer monetization platform built for
-communities and creators. It combines e-commerce, point-of-sale (PoS),
-subscriptions, crowdfunding/peerfunding, ticketing, donations, and
-pay-what-you-want models — all under one roof.
+<h1 align="center">be-BOP</h1>
+
+<p align="center"><strong>The ethical sales toolbox.</strong></p>
+
+<p align="center">
+  Libre and open-source monetization, from e-commerce to Point of Sale —
+  subscriptions, peerfunding, ticketing, booking, restaurant UI, and many payment
+  methods, Bitcoin and Lightning included.<br>
+  No vendor lock-in, no paywall, no subscription, no sales commission. Ever.
+</p>
+
+---
+
+## Getting started
+
+Four ways to run be-BOP.
+
+### 1. Install wizard
+
+One command on a fresh server:
+
+```bash
+curl -sfSL "https://be-bop.io/wizard/install.sh" -o be-bop-wizard.sh \
+  && bash ./be-bop-wizard.sh -- --domain "your-domain.com" --email "you@example.com"
+```
+
+It installs and configures everything — MongoDB, Garage for object storage, web
+server and TLS certificate — and hands you a working shop. You do not need to
+clone this repository or install Node.
+
+**You need** a VPS with 2 GB of RAM and 20 GB of storage, a domain name pointing
+at it, and an email address for the TLS certificate.
+**Technical level** — low: point a domain, connect over SSH, run one command.
+
+📖 **[Step-by-step guide with screenshots →](https://be-bop.io/get-started-diy)**
+
+### 2. Cloud
+
+Hosted by be-BOP.io, nothing to install or maintain:
+
+- **Switzerland** — [ch.be-bop.io](https://ch.be-bop.io)
+- **French Polynesia** — [pf.be-bop.io](https://pf.be-bop.io)
+
+Stay tuned for new markets opening!
+
+**You need** to comply with the service's terms of use, an email address, and a
+payment mean for the monthly subscription.
+**Technical level** — none.
+
+To try it first, spin up a [free 4-hour
+sandbox](https://sandbox.be-bop.dev/product/be-bop-sandbox-2h) — no account, no
+card.
+
+### 3. Docker
+
+`docker compose up` brings up be-BOP with a MongoDB and an S3 storage. Good for
+local development, and for a single-host deployment you manage yourself.
+
+**You need** Docker, and the environment variables from
+[Configuration](#configuration). See [Docker Compose](#docker-compose).
+**Technical level** — high: you own the containers, the backups and the reverse
+proxy.
+
+### 4. Self install
+
+Bring your own MongoDB replica set and S3 storage, and run be-BOP with Node.
+
+**You need** everything listed in [Requirements](#requirements).
+**Technical level** — expert.
+
+## What you can sell
+
+|                                   |                                                                       |
+| --------------------------------- | --------------------------------------------------------------------- |
+| **E-commerce**                    | Physical and digital products, stock, variations, delivery zones      |
+| **Point of Sale**                 | In-person checkout, touchscreen interface, restaurant tabs, Z-tickets |
+| **Subscriptions**                 | Recurring memberships and plans, with reminders                       |
+| **Peerfunding**                   | Fund goals and projects, with progress widgets and leaderboards       |
+| **Ticketing & booking**           | Sell, schedule and validate tickets; calendar-based bookings          |
+| **Donations & pay-what-you-want** | Customer-set pricing, deposits, partial payments                      |
+
+**Payments.**
+
+- **Bitcoin and Lightning** — your own node, or nodeless with `phoenixd`. Also through BTCPay Server, Swiss Bitcoin Pay or Blink.
+- **Cards** — Stripe, SumUp, OSB.
+- **PayPal**.
+- **GNU Taler** — digital cash.
+- **At the counter** — cash and custom methods.
+
+**Also built in.** A CMS with embeddable widgets, a Nostr bot, multi-currency
+pricing, VAT profiles per country, invoicing, and an admin back-office
+available in 7 languages.
+
+## Documentation
+
+The back-office documentation lives in [`docs/`](docs/), one folder per
+language.
+
+|                      |                                                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Start here**       | [Initialize be-BOP](docs/en/00%20-%20initialize%20beBOP.md) — first steps after installation                                         |
+| **Full walkthrough** | [Step-by-step guide](docs/en/be-BOP-step-by-step-doc-EN-🇬🇧.md)                                                                       |
+| **Point of Sale**    | [PoS options](docs/en/point-of-sale-options.md)                                                                                      |
+| **CMS**              | [Required CMS pages](docs/en/required-CMS-pages.md) · [Customise cart & checkout](docs/en/customise-cart-checkout-order-with-CMS.md) |
+| **Team & access**    | [Back-office access](docs/en/back-office-access.md)                                                                                  |
+| **Delivery**         | [Delivery management](docs/en/delivery-management.md)                                                                                |
+| **Questions**        | [FAQ](docs/en/FAQ.md)                                                                                                                |
+
+Other languages: [🇫🇷 Français](docs/fr/) (the most complete set, 62 documents,
+including VAT configuration, reporting, stock, subscriptions and the be-BOP
+manifesto) · [🇩🇪 Deutsch](docs/de/) · [🇪🇸 Español](docs/es-sv/) ·
+[🇮🇹 Italiano](docs/it/) · [🇳🇱 Nederlands](docs/nl/) · [🇵🇹 Português](docs/pt/)
+
+---
+
+# Running from source
+
+Everything below is for contributors and for operators who prefer to deploy by
+hand rather than with the wizard.
+
+## Table of contents
+
+- [Requirements](#requirements)
+- [Quick start](#quick-start)
+  - [Option A: Cloud services (minimal setup)](#option-a-cloud-services-minimal-setup)
+  - [Option B: Docker Compose (fully local)](#option-b-docker-compose-fully-local)
+- [Configuration](#configuration)
+  - [Core](#core)
+  - [S3 object storage](#s3-object-storage)
+  - [Email and notifications](#email-and-notifications)
+  - [Bitcoin & Lightning](#bitcoin--lightning)
+  - [SSO sign-in](#sso-sign-in)
+- [Production](#production)
+  - [Running](#running)
+  - [Docker](#docker)
+  - [Docker Compose](#docker-compose)
+- [Operations](#operations)
+  - [Reverse proxy](#reverse-proxy)
+  - [Maintenance mode](#maintenance-mode)
+  - [Copying DB & S3 to another instance](#copying-db--s3-to-another-instance)
+- [Analytics](#analytics)
+- [Contributing](#contributing)
+- [Licence](#licence)
 
 ## Requirements
 
-- A S3-compatible object storage. There are hundreds of solutions, including https://min.io/, an open source solution that can be run inside docker, or paid services like AWS, Scaleway, ...
-- SMTP credentials, for sending emails
-- A MongoDB replica set. You can run it inside docker or use MongoDB Atlas.
-- A bitcoin node, and lnd
-- Node version 18+, corepack enabled with `corepack enable`
-- Git LFS installed with `git lfs install`
+- **Node.js 18+**, with corepack enabled: `corepack enable`
+- **pnpm** (enabled via corepack — you may need `sudo corepack enable`)
+- **Git LFS**, installed with `git lfs install`
+- A **MongoDB replica set** — run it in Docker or use [MongoDB Atlas](https://www.mongodb.com/atlas/database)
+- An **S3-compatible object storage** — [Garage](https://garagehq.deuxfleurs.fr/) (open source, lightweight, what the wizard installs), or a paid service like AWS or Scaleway. be-BOP configures the bucket to accept CORS `PUT` calls automatically.
 
-### S3 configuration
+Optional, depending on what you sell and how you notify customers:
 
-The app will automatically configure the S3 bucket to accept CORS PUT calls.
+- **SMTP credentials** for email — or a **Nostr `nsec`** (`NOSTR_PRIVATE_KEY`) to notify over Nostr instead
+- A **Bitcoin node and lnd** — not required: `phoenixd` gives you Lightning and Bitcoin nodeless, straight from the admin UI
 
-## Environment variables
+## Quick start
 
-Add `.env.local` or `.env.{development,test,production}.local` files for secrets not committed to git and to override the `.env`
+```bash
+pnpm install
+pnpm dev
+```
 
-- `LINK_PRELOAD_HEADERS` - Set to `true` to enable the `Link rel=preload` header, see [explanation](https://nitropack.io/blog/post/link-rel-preload-explained). If you do so, you may need to configure nginx to allow bigger header with `proxy_buffer_size   16k`, see [explanation](https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx).
-- `MONGODB_URL` - The connection URL to the MongoDB replicaset
-- `MONGODB_DB` - The DB name, defaulting to "bebop"
-- `NOSTR_PRIVATE_KEY` - To send notifications
-- `ORIGIN` - The url where be-BOP will be deployed. For example, https://dev-bootik.pvh-labs.ch
-- `S3_BUCKET` - The name of the bucket for the S3-compatible object storage
-- `S3_ENDPOINT_URL` - The endpoint for the S3-compatible object storage - eg http://s3-website.us-east-1.amazonaws.com or http://s3.fr-par.scw.cloud
-- `S3_KEY_ID` - Credentials for the S3-compatible object storage
-- `S3_KEY_SECRET` - Credentials for the S3-compatible object storage
-- `S3_REGION` - Region from the S3-compatible object storage
-- `SMTP_HOST` - Specify all the SMTP variables to enable email notifications
-- `SMTP_PASSWORD` - Specify all the SMTP variables to enable email notifications
-- `SMTP_PORT` - Specify all the SMTP variables to enable email notifications
-- `SMTP_USER` - Specify all the SMTP variables to enable email notifications
-- `SMTP_FROM` - Optional, defaults to `SMTP_USER`. Sender email address for email notifications
+be-BOP still needs a MongoDB replica set and an S3-compatible object storage.
+Pick one of the two setups below, add the variables to a `.env.local` file, then
+run `pnpm dev`.
 
-### Bitcoin and LND nodes
+### Option A: Cloud services (minimal setup)
 
-🚨 You can use `phoenixd` for lightning and bitcoin nodeless directly from the UI, without setting up these env vars.
+Use [MongoDB Atlas](https://www.mongodb.com/atlas/database) for the database and
+a hosted S3 (AWS, Scaleway…) for the object storage, then put their credentials
+in `.env.local`. See [Configuration](#configuration) for the variable names.
 
-- `BITCOIN_RPC_URL` - The RPC url for the bitcoin node. Set to http://127.0.0.1:8332 if you run a bitcoin node locally with default configuration
-- `BITCOIN_RPC_USER` - The RPC user
-- `BITCOIN_RPC_PASSWORD` - The RPC password
-- `BIP84_XPUB` - with derivation path m/84'/0'/0'. If you have a ZPub, use https://jlopp.github.io/xpub-converter/ to convert to xpub. This enables a completely trustless setup, where the be-BOP server does not need to know the private key. You can generate the xpub from the sparrow wallet, for example.
-- `LND_REST_URL` - The LND Rest interface URL. Set to http://127.0.0.1:8080 if you run a lnd node locally with default configuration
-- `LND_MACAROON_PATH` - Where the credentials for lnd are located. For example, `~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon`. Leave empty if lnd runs with `--no-macaroons`, or if you're using `LND_MACAROON_VALUE`. You can use `invoices.macaroon` instead of `admin.macaroon`, but then the admin LND page in the be-BOP will not work. Orders should work fine.
-- `LND_MACAROON_VALUE` - Upper-case hex-encoded represenetation of the LND macaroon. Leave empty if lnd runs with `--no-macaroons`, or if you're using `LND_MACAROON_PATH`. Example command: `cat .lnd/data/chain/bitcoin/mainnet/admin.macaroon | hexdump -e '16/1 "%02X"'`. You can use `invoices.macaroon` instead of `admin.macaroon`, but then the admin LND page in the be-BOP will not work. Orders should work fine.
-- `TOR_PROXY_URL` - Url of the SOCKS5 proxy used to access TOR. If set, and the hostname for `BITCOIN_RPC_URL` is a `.onion` address, the app will use the proxy to access the bitcoin node. In the same manner, if `LND_REST_URL` is a `.onion` address, TOR will be used to access the lightning node.
+### Option B: Docker Compose (fully local)
 
-### SSO sign-in for users
+Runs MongoDB and an S3 storage locally. Add an S3 access key and secret to `.env.local`
+if they are not there yet:
 
-You can also set the following environment variables to allow SSO. Set your redirect url to `https://<...>/api/callback/<provider>`, where `<provider>` is one of `github`, `google`, `facebook`, `twitter`, when you create your app on the provider's website:
+```console
+echo "S3_KEY_ID=$(openssl rand -base64 63 | tr -d '\n')" >> .env.local
+echo "S3_KEY_SECRET=$(openssl rand -base64 63 | tr -d '\n')" >> .env.local
+```
 
-- `GITHUB_ID`
-- `GITHUB_SECRET`
-- `GOOGLE_ID`
-- `GOOGLE_SECRET`
-- `FACEBOOK_ID`
-- `FACEBOOK_SECRET`
-- `TWITTER_ID`
-- `TWITTER_SECRET`
+Then start the containers:
+
+```bash
+docker compose -f docker-compose.dev.yml -f docker-compose.override.yml up -d
+```
+
+## Configuration
+
+Add a `.env.local` (or `.env.{development,test,production}.local`) file for
+secrets that should not be committed to git; these override the values in
+`.env`.
+
+### Core
+
+| Variable                    | Description                                                                                                                                                                                                                                                                                           |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MONGODB_URL`               | The connection URL to the MongoDB replica set                                                                                                                                                                                                                                                         |
+| `MONGODB_DB`                | The DB name, defaulting to `bebop`                                                                                                                                                                                                                                                                    |
+| `MONGODB_DIRECT_CONNECTION` | Set to `true` to connect directly to a single node rather than discovering the replica set                                                                                                                                                                                                            |
+| `ORIGIN`                    | The URL where be-BOP will be deployed, e.g. `https://bebop.example.com`                                                                                                                                                                                                                               |
+| `NOSTR_PRIVATE_KEY`         | Private key (`nsec…`) used to send Nostr notifications                                                                                                                                                                                                                                                |
+| `LINK_PRELOAD_HEADERS`      | Set to `true` to enable the `Link rel=preload` header ([explanation](https://nitropack.io/blog/post/link-rel-preload-explained)). If you do, you may need to raise nginx's `proxy_buffer_size 16k` ([explanation](https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx)) |
+| `BODY_SIZE_LIMIT`           | Maximum upload size in bytes, e.g. `20000000` for 20 MB. Not needed for normal usage                                                                                                                                                                                                                  |
+| `PORT`                      | Port to listen on, defaults to `3000`                                                                                                                                                                                                                                                                 |
+
+### S3 object storage
+
+be-BOP automatically configures the S3 bucket to accept CORS `PUT` calls.
+
+| Variable                 | Description                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------- |
+| `S3_BUCKET`              | The bucket name for the S3-compatible object storage                                           |
+| `S3_ENDPOINT_URL`        | The endpoint, e.g. `http://s3.fr-par.scw.cloud` or `http://s3-website.us-east-1.amazonaws.com` |
+| `PUBLIC_S3_ENDPOINT_URL` | Public-facing endpoint used to build browser-visible asset URLs                                |
+| `S3_REGION`              | The region of the bucket                                                                       |
+| `S3_KEY_ID`              | The access key ID                                                                              |
+| `S3_KEY_SECRET`          | The access key secret                                                                          |
+
+### Email and notifications
+
+Order notifications can go out over email, over Nostr, or both. For email, set
+all four `SMTP_*` variables; for Nostr, set `NOSTR_PRIVATE_KEY` in
+[Core](#core).
+
+| Variable        | Description                                                                      |
+| --------------- | -------------------------------------------------------------------------------- |
+| `SMTP_HOST`     | SMTP server host — set all four `SMTP_*` variables to enable email notifications |
+| `SMTP_PORT`     | SMTP server port                                                                 |
+| `SMTP_USER`     | SMTP username                                                                    |
+| `SMTP_PASSWORD` | SMTP password                                                                    |
+| `SMTP_FROM`     | Optional sender address, defaults to `SMTP_USER`                                 |
+| `SMTP_FAKE`     | Set to `true` to mock emails in development                                      |
+
+### Bitcoin & Lightning
+
+> 🚨 You can use `phoenixd` for Lightning and Bitcoin **nodeless directly from
+> the UI**, without setting up any of these variables.
+
+| Variable               | Description                                                                                                                                                                                                                                                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BITCOIN_RPC_URL`      | The RPC url for the bitcoin node. Set to `http://127.0.0.1:8332` if you run a bitcoin node locally with default configuration                                                                                                                                                                                     |
+| `BITCOIN_RPC_USER`     | The RPC user                                                                                                                                                                                                                                                                                                      |
+| `BITCOIN_RPC_PASSWORD` | The RPC password                                                                                                                                                                                                                                                                                                  |
+| `BIP84_XPUB`           | With derivation path `m/84'/0'/0'`. If you have a ZPub, use the [xpub converter](https://jlopp.github.io/xpub-converter/). This enables a completely trustless setup, where the be-BOP server never knows the private key. You can generate the xpub from Sparrow Wallet, for example                             |
+| `LND_REST_URL`         | The LND REST interface URL. Set to `http://127.0.0.1:8080` if you run an lnd node locally with default configuration                                                                                                                                                                                              |
+| `LND_MACAROON_PATH`    | Where the credentials for lnd are located, e.g. `~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon`. Leave empty if lnd runs with `--no-macaroons`, or if you use `LND_MACAROON_VALUE`. You can use `invoices.macaroon` instead of `admin.macaroon`, but then the admin LND page will not work — orders still will |
+| `LND_MACAROON_VALUE`   | Upper-case hex-encoded macaroon. Leave empty if lnd runs with `--no-macaroons`, or if you use `LND_MACAROON_PATH`. Example: `cat .lnd/data/chain/bitcoin/mainnet/admin.macaroon \| hexdump -e '16/1 "%02X"'`                                                                                                      |
+| `TOR_PROXY_URL`        | URL of the SOCKS5 proxy used to reach TOR. If set, and `BITCOIN_RPC_URL` or `LND_REST_URL` is a `.onion` address, that node is reached through the proxy                                                                                                                                                          |
+
+### SSO sign-in
+
+Set the following variables to allow SSO. On each provider's website, set the
+redirect URL to `https://<your-domain>/api/callback/<provider>`, where
+`<provider>` is one of `github`, `google`, `facebook`, or `twitter`:
+
+| Provider | Variables                        |
+| -------- | -------------------------------- |
+| GitHub   | `GITHUB_ID`, `GITHUB_SECRET`     |
+| Google   | `GOOGLE_ID`, `GOOGLE_SECRET`     |
+| Facebook | `FACEBOOK_ID`, `FACEBOOK_SECRET` |
+| Twitter  | `TWITTER_ID`, `TWITTER_SECRET`   |
 
 ## Production
 
@@ -71,33 +279,34 @@ You can also set the following environment variables to allow SSO. Set your redi
 ```shell
 pnpm run build
 node --enable-source-maps build/index.js
-
-# If behind a reverse proxy, you can use the following config:
-# ADDRESS_HEADER=X-Forwarded-For XFF_DEPTH=1 node build/index.js
 ```
 
-You can set the `PORT` environment variable to change from the default 3000 port to another port.
+Behind a reverse proxy, add the headers described in
+[Reverse proxy](#reverse-proxy):
 
-You can also use [pm2](https://pm2.keymetrics.io/docs/usage/quick-start/) to manage your node application, and run it on multiple cores.
+```shell
+ADDRESS_HEADER=X-Forwarded-For XFF_DEPTH=1 node build/index.js
+```
+
+You can also use [pm2](https://pm2.keymetrics.io/docs/usage/quick-start/) to
+manage the process and run it on multiple cores:
 
 ```shell
 NODE_OPTIONS=--enable-source-maps pm2 start --name bebop --update-env build/index.js
 
-# If behind a reverse proxy, you can use the following config:
-# NODE_OPTIONS=--enable-source-maps ADDRESS_HEADER=X-Forwarded-For XFF_DEPTH=1 pm2 start --name bebop --update-env build/index.js
+# behind a reverse proxy
+NODE_OPTIONS=--enable-source-maps ADDRESS_HEADER=X-Forwarded-For XFF_DEPTH=1 pm2 start --name bebop --update-env build/index.js
 ```
-
-Note: for uploading large payloads you may want to set the `BODY_SIZE_LIMIT=20000000` environment variable to allow 20MB payloads for example. It should not be needed for normal usage.
 
 ### Docker
 
-- Build the docker image
+Build the image:
 
 ```shell
 docker build -t bebop .
 ```
 
-- Run the docker image with environment variables
+Run it with environment variables:
 
 ```shell
 export DOTENV_LOCAL=$(cat .env.local)
@@ -107,92 +316,74 @@ docker run -p 3000:3000 --env DOTENV_LOCAL=$DOTENV_LOCAL bebop --add-host=host.d
 or
 
 ```shell
-# Be careful, double-quotes surrounding values in .env.local will not be ignored
+# Careful: double quotes around values in .env.local are not ignored
 docker run -p 3000:3000 --env-file .env.local bebop --add-host=host.docker.internal:host-gateway
 ```
 
-If you want to access a local BTC node or LND node, use `host.docker.internal` as the hostname instead of `localhost`:
+> **Reaching a local node from Docker:** use `host.docker.internal` as the
+> hostname instead of `localhost`, e.g.
+> `BITCOIN_RPC_URL=http://host.docker.internal:8332`.
 
-```env
-BITCOIN_RPC_URL=http://host.docker.internal:8332
-```
+### Docker Compose
 
-### Docker compose
+Docker Compose is used for local development, but it also works in production.
+It launches a MongoDB and an S3 storage container.
 
-Docker compose is used for local development, but you can also use it for production. It will launch a mongodb and minio container.
-
-#### Required configuration
-
-Edit `.env.local` to add a S3 access key and secret if not already present, for example:
+Add an S3 access key and secret to `.env.local` if not already present:
 
 ```console
 echo "S3_KEY_ID=$(openssl rand -base64 63 | tr -d '\n')" >> .env.local
 echo "S3_KEY_SECRET=$(openssl rand -base64 63 | tr -d '\n')" >> .env.local
 ```
 
-Make sure to have a fairly recent version of docker & docker compose.
+Make sure you have a fairly recent version of docker and docker compose, then:
 
-#### Start the containers
-
-```
-# Optional: update dependencies
+```shell
+# optional: update dependencies
 docker compose pull
-# --build will rebuild the docker image when you change the code. Use --force-recreate to force a rebuild (eg after updating dependencies).
+# --build rebuilds the image when the code changes; --force-recreate forces it
 docker compose --env-file .env.local up --build -d
 ```
 
-It will still use the `.env.local` file for the environment variables if present, overriding the values for MongoDB and S3.
+The object storage will be available on http://localhost:9000 and be-BOP on
+http://localhost:3000.
 
-Minio will be available on http://localhost:9000 and be-BOP on http://localhost:3000.
-
-Some helper commands:
+Helper commands:
 
 ```bash
-# See the containers
-docker compose ps
-# Get the logs
-docker compose logs bebop -f
-# Enter the container
-docker compose exec bebop sh
-# Stop the containers
-docker compose down
+docker compose ps              # see the containers
+docker compose logs bebop -f   # follow the logs
+docker compose exec bebop sh   # enter the container
+docker compose down            # stop the containers
 ```
 
-#### Other configuration
-
-See the beginning of the README for other environment variables you can set in `.env.local`, including the SMTP credentials.
-
-If you run in production, you will need to set the `ORIGIN` environment variable to the URL of your be-BOP instance:
+For production, set `ORIGIN` and the public URL of your object storage in
+`.env.local`:
 
 ```env
-# .env.local - replace with your be-BOP url
 ORIGIN=https://bebop.example.com
+S3_ENDPOINT_URL=https://s3.bebop.example.com
 ```
 
-As well as the object storage (minio) url:
+See [Configuration](#configuration) for the other variables. To reach a local
+BTC or LND node, use `host.docker.internal` (see [Docker](#docker)).
 
-```env
-# .env.local - replace with your minio url
-S3_ENDPOINT_URL=https://minio.bebop.example.com
-```
+## Operations
 
-If you want to access a local BTC node or LND node, use `host.docker.internal` as the hostname instead of `localhost`:
+### Reverse proxy
 
-```env
-BITCOIN_RPC_URL=http://host.docker.internal:8332
-```
-
-When placing the beBOP behind a reverse proxy, to get your user's IPs, you will need to set the `ADDRESS_HEADER` to `X-Forwarded-For` and the `XFF_DEPTH` header to `1` (or appropriate value depending on your config) in the environment.
+Behind a reverse proxy such as nginx, set `ADDRESS_HEADER` to `X-Forwarded-For`
+and `XFF_DEPTH` to `1` (or whatever matches your setup) so be-BOP resolves your
+users' IP addresses correctly. This also matters for
+[maintenance mode](#maintenance-mode).
 
 ### Maintenance mode
 
-It's possible to enable maintenance mode in the admin.
-
-To correctly recognize your IP, if you are behind a reverse proxy like nginx, you will need to set the `ADDRESS_HEADER` to `X-Forwarded-For` and the `XFF_DEPTH` header to `1` in the environment.
+Maintenance mode is enabled from the admin. It relies on correct client IP
+resolution — behind a reverse proxy, configure it as described in
+[Reverse proxy](#reverse-proxy) first, or you will lock yourself out.
 
 ### Copying DB & S3 to another instance
-
-You can run the following command to copy the DB and S3 to another instance:
 
 ```shell
 export OLD_DB_URL="..."
@@ -216,122 +407,37 @@ export NEW_S3_ENDPOINT="..."
 pnpm run copy-db-s3
 ```
 
-## Local development
+## Analytics
 
-### Prerequisites
+Analytics are entirely optional — be-BOP runs without them, and ships no tracker
+of its own.
 
-- Node.js 18+
-- pnpm (install with `sudo corepack enable`)
-- Git LFS (`git lfs install`)
+Go to `/admin/config` and paste the script URL of your favourite analytics tool
+with a snippet. For example, with a self-hosted
+[Plausible](https://plausible.io/docs/self-hosting):
 
-```bash
-pnpm install
-pnpm dev
+```
+https://plausible.your-domain.com/js/script.js
 ```
 
-be-BOP requires a MongoDB replica set and an S3-compatible object storage. There are two ways to set them up:
+## Contributing
 
-### Option A: Cloud services (minimal setup)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for localisation and testing notes.
 
-The fastest way to get started — use cloud-hosted MongoDB, and either a cloud S3 or a single local MinIO container:
-
-1. **MongoDB:** Get a free tier on [MongoDB Atlas](https://www.mongodb.com/atlas/database). A free M0 cluster is more than enough for development.
-2. **S3-compatible storage** — pick one:
-   - **Quickest local option:** Run a single MinIO container (see below) — this is the only Docker container you'll need
-   - [AWS S3](https://aws.amazon.com/s3/) free tier
-   - [Scaleway Object Storage](https://www.scaleway.com/en/object-storage/) free tier
-   - Or any other S3-compatible service
-
-To run MinIO locally:
-
-```bash
-mkdir -p ${HOME}/minio/data
-
-docker run -d \
-   -p 9000:9000 \
-   -p 9090:9090 \
-   --name minio \
-   -e "MINIO_ROOT_USER=ROOTUSER" \
-   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
-   -v ${HOME}/minio/data:/data \
-   quay.io/minio/minio server /data --console-address ":9090"
+```console
+pnpm test:unit -t "<part of test name>"   # run one unit test
+pnpm run check                            # type-check
+pnpm run lint                             # lint
 ```
 
-MinIO console will be available at http://127.0.0.1:9090. The S3 bucket will be created automatically by be-BOP on first run.
+Translations live in `src/lib/translations`, one JSON file per language. Add a
+language by creating its file and registering it in
+`src/lib/translations/index.ts`. In Svelte pages and components, call
+`useI18n()` once at top level so SSR picks the right locale — parallel requests
+can be in different languages.
 
-Add to your `.env.local`:
+## Licence
 
-```bash
-# MongoDB Atlas
-MONGODB_URL="mongodb+srv://<user>:<password>@<cluster>.mongodb.net/..."
-MONGODB_DB="bebop"
+be-BOP is [GNU AGPL v3](LICENCE) — libre, open source, copyleft.
 
-# Your app URL
-ORIGIN="http://localhost:5173"
-
-# MinIO (local) — or replace with your cloud S3 credentials
-S3_BUCKET="bebop"
-S3_ENDPOINT_URL="http://127.0.0.1:9000"
-PUBLIC_S3_ENDPOINT_URL="http://127.0.0.1:9000"
-S3_REGION="localhost"
-S3_KEY_ID="ROOTUSER"
-S3_KEY_SECRET="CHANGEME123"
-
-# Mock emails in development
-SMTP_FAKE="true"
-```
-
-Run `pnpm dev` and you're ready to go.
-
-### Option B: Docker Compose (fully local)
-
-Run both MongoDB and MinIO locally using Docker Compose — no cloud accounts needed:
-
-```bash
-docker compose -f docker-compose.dev.yml up -d
-```
-
-This starts a MongoDB replica set (port 27017) and MinIO (ports 9000, 9090). No be-BOP container — you run the app with `pnpm dev`.
-
-Add to your `.env.local`:
-
-```bash
-MONGODB_URL=mongodb://localhost:27017
-MONGODB_DIRECT_CONNECTION=true
-MONGODB_DB="bebop"
-ORIGIN="http://localhost:5173"
-S3_BUCKET="bebop"
-S3_ENDPOINT_URL="http://localhost:9000"
-PUBLIC_S3_ENDPOINT_URL="http://localhost:9000"
-S3_REGION="localhost"
-S3_KEY_ID="minio"
-S3_KEY_SECRET="minio123"
-SMTP_FAKE="true"
-```
-
-> **Note:** `MONGODB_DIRECT_CONNECTION=true` is required when connecting to a MongoDB replica set running inside Docker from the host machine.
-
-Helper commands:
-
-```bash
-docker compose -f docker-compose.dev.yml ps       # See running containers
-docker compose -f docker-compose.dev.yml logs -f   # View logs
-docker compose -f docker-compose.dev.yml down      # Stop containers
-```
-
-To add personal services like [mongo-express](https://github.com/mongo-express/mongo-express) or [mailhog](https://github.com/mailhog/MailHog), you can either add them directly to your local `docker-compose.dev.yml` (changes will show in `git diff`), or create a separate `docker-compose.override.yml` (gitignored) and run both with:
-
-```bash
-docker compose -f docker-compose.dev.yml -f docker-compose.override.yml up -d
-```
-
-### Configuring plausible
-
-Self install plausible : [Plausible](https://plausible.io/docs/self-hosting)
-
-Then, go in the config page : /admin/config
-
-And : Copy/paste your Plausible URL in the plausible input
-#for example: https://plausible.your-domain.com/js/script.js
-
-To have **emails**, for example to have multiple users, you need [to configure SMTP with environment variables](https://plausible.io/docs/self-hosting-configuration#mailersmtp-setup) and set `DISABLE_REGISTRATION=invite_only`.
+Available for custom development: **contact@be-bop.io**


### PR DESCRIPTION
## Summary

Reorganizes and modernizes the README for readability. Content is preserved — this is a restructure, not a rewrite.

### Highlights
- **Theme-aware logo header** (`<picture>` swaps `bebop-dark.svg` / `bebop-light.svg` by color scheme) + centered title.
- **DIY quick start link** to https://be-bop.io/get-started-diy — a callout under the intro and again atop the local-dev section.
- **Features list + Table of contents** added.
- **Quick start moved up** — local development now follows Requirements instead of sitting at the bottom.
- **Env vars as reference tables**, grouped by concern (Core, S3, SMTP, Bitcoin & Lightning, SSO).
- **Deduplicated repeated notes** — `host.docker.internal` (was 3×) and the `ADDRESS_HEADER`/`XFF_DEPTH` reverse-proxy note (was 3×) each stated once, with a new **Operations → Reverse proxy** section and cross-links.
- Documented vars that appeared in examples but were missing from the list: `PUBLIC_S3_ENDPOINT_URL`, `SMTP_FAKE`, `MONGODB_DIRECT_CONNECTION`.

### Note
The logo uses repo-relative paths (`src/lib/assets/bebop-*.svg`), which render on GitHub but not on external mirrors (e.g. npm). Can switch to absolute raw URLs if preferred.

---

## Issue #2298

Refs #2298 — this PR covers the README half of it, not the whole issue.

| point of #2298 | state |
| --- | --- |
| Bitcoin node + lnd listed as required | done — marked optional, points at nodeless `phoenixd` |
| SMTP → "or Nsec for Nostr" | done — the `nsec` (`NOSTR_PRIVATE_KEY`) is named as the alternative |
| Docker → focus on the Wizard | partial — the guided DIY install is now the first thing a shop owner reads, and the local-dev sections are marked as being for contributors. The Docker sections stay: dropping them depends on the two conditions Tirodem set in the issue thread (a docker-compose → wizard migration tool, and branch switching from the wizard). |
| Plausible pricing changed | done — analytics stated as optional, hosted Plausible flagged as paid, self-hosting framed as the free route |

**Not covered here: the GitHub About description.** It is a repository setting rather than a file, so it cannot ship in a PR. The text proposed in #2298 also runs past what the About field displays on one line, so it needs condensing before being applied.
