### PR TITLE
🐛 Fix mobile checkout form layout

### DIFF
--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -342,7 +342,7 @@
 					{t('checkout.paymentGenerationFailed')}
 				</div>
 			{/if}
-			<section class="gap-4 grid grid-cols-6">
+			<section class="gap-4 flex flex-col sm:grid sm:grid-cols-6">
 				<h2 class="font-light text-2xl col-span-6">{t('checkout.shipmentInfo')}</h2>
 				{#if isDigital}
 					<p class="col-span-6">
@@ -402,9 +402,7 @@
 						</select>
 					</label>
 
-					<span class="col-span-3" />
-
-					<label class="form-label col-span-2">
+					<label class="form-label col-span-3">
 						{t('address.state')}
 
 						<input
@@ -418,7 +416,7 @@
 								''}
 						/>
 					</label>
-					<label class="form-label col-span-2">
+					<label class="form-label col-span-3">
 						{t('address.city')}
 
 						<input
@@ -433,7 +431,7 @@
 							required={!data.hasPosOptions}
 						/>
 					</label>
-					<label class="form-label col-span-2">
+					<label class="form-label col-span-3">
 						{t('address.zipCode')}
 
 						<input
@@ -504,7 +502,7 @@
 			</section>
 
 			{#if showBillingInfo || (isDigital && data.isBillingAddressMandatory) || isProfessionalOrder}
-				<section class="gap-4 grid grid-cols-6">
+				<section class="gap-4 flex flex-col sm:grid sm:grid-cols-6">
 					<h2 class="font-light text-2xl col-span-6">{t('checkout.billingInfo')}</h2>
 
 					<label class="form-label col-span-3">
@@ -552,9 +550,7 @@
 						</select>
 					</label>
 
-					<span class="col-span-3" />
-
-					<label class="form-label col-span-2">
+					<label class="form-label col-span-3">
 						{t('address.state')}
 
 						<input
@@ -564,7 +560,7 @@
 							value={data.personalInfoConnected.address?.state ?? ''}
 						/>
 					</label>
-					<label class="form-label col-span-2">
+					<label class="form-label col-span-3">
 						{t('address.city')}
 
 						<input
@@ -575,7 +571,7 @@
 							required
 						/>
 					</label>
-					<label class="form-label col-span-2">
+					<label class="form-label col-span-3">
 						{t('address.zipCode')}
 
 						<input
@@ -622,7 +618,7 @@
 					<label class="form-label col-span-6">
 						{t('checkout.payment.method')}
 
-						<div class="grid grid-cols-2 gap-4 items-center">
+						<div class="flex flex-col gap-1">
 							<select
 								name="paymentMethod"
 								class="form-input"
@@ -665,7 +661,7 @@
 						{t('checkout.changePaymentExpiration')}
 					</label>
 					<label class="form-label col-span-6">
-						<div class="grid grid-cols-2 gap-4 items-center">
+						<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 items-center">
 							<input
 								type="number"
 								name="paymentTimeOut"


### PR DESCRIPTION
## Problem

The checkout address & payment form rendered poorly on mobile (reported from cloud feedback):
- Country / State / City / Zip crammed into cramped columns on phones — the "Canton / Région" label wrapped and misaligned the fields.
- Uneven ("chelou") field widths on tablet/desktop.
- Horizontal page scroll ("slide") on mobile.
- The "Mode de paiement" select was half-width and misaligned with the other selects.

## Root cause

Several grids were **hard-coded with no responsive breakpoint**. Notably, `grid-cols-1` with children spanning `col-span-3/6` does **not** stack on mobile: per the CSS Grid auto-placement algorithm, an auto-placed item whose span exceeds the explicit columns expands the *implicit* grid, and those implicit columns are `auto`-sized (content width) — producing a grid wider than the viewport → horizontal overflow and uneven widths.

## Fix

- **Address sections** (shipping + billing): `grid grid-cols-6` → `flex flex-col sm:grid sm:grid-cols-6`. On mobile the fields stack full-width (col-span ignored in flex → no implicit grid, no overflow); at `sm:` the 6-col grid returns.
- Removed the two empty `col-span-3` spacers and normalized State/City/Zip from `col-span-2` → `col-span-3`, giving consistent half-width pairs (Prénom|Nom, Pays|Canton, Ville|Code postal, Entreprise|TVA).
- **Payment method select**: `grid grid-cols-2` → `flex flex-col` so the select is full-width and aligned with the other selects; the "unavailable" message stacks below.
- **Payment timeout input**: `grid grid-cols-2` → `grid grid-cols-1 sm:grid-cols-2` so it stacks on mobile.

Net: +10 / −14 lines, one file.

## Note

The native `<select>` dropdown popup position (open list appearing above the field) is OS-controlled (macOS overlays the selected option on the control) and unaffected by this change.