### PR TITLE
Fix get() crash on missing intermediate i18n key (breaks en fallback)

### DIFF
--- a/src/lib/utils/get.ts
+++ b/src/lib/utils/get.ts
@@ -14,6 +14,8 @@ export function get<T, Path extends Paths<T> | any>(
 	}
 	const d = dict;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unsafe-member-access
-	return (key.split('.').reduce((acc, k) => (acc as any)[k as any], d) ??
+	return (key
+		.split('.')
+		.reduce((acc, k) => (acc == null ? undefined : (acc as any)[k as any]), d) ??
 		fallback) as Path extends string ? Get<T, Path> : never;
 }

--- a/src/lib/utils/get.ts
+++ b/src/lib/utils/get.ts
@@ -13,9 +13,12 @@ export function get<T, Path extends Paths<T> | any>(
 		return fallback as Path extends string ? Get<T, Path> : never;
 	}
 	const d = dict;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unsafe-member-access
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-condition
 	return (key
 		.split('.')
-		.reduce((acc, k) => (acc == null ? undefined : (acc as any)[k as any]), d) ??
-		fallback) as Path extends string ? Get<T, Path> : never;
+		.reduce<unknown>(
+			(acc, k) =>
+				acc && typeof acc === 'object' ? (acc as Record<string, unknown>)[k] : undefined,
+			d
+		) ?? fallback) as Path extends string ? Get<T, Path> : never;
 }


### PR DESCRIPTION
## Summary
- `get()` crashed instead of returning `undefined` when an intermediate path segment was missing (e.g. `de.json` has `product` but not `product.pricingSchedule`), throwing on `undefined['intro']`.
- This crash happened *before* `t()`'s `?? get(data.en, key)` fallback in `src/lib/i18n.ts:97` could run, so partially-translated locales (like `de`) crashed instead of falling back to English as intended.
- Fix: the `reduce` now short-circuits to `undefined` as soon as the accumulator is `null`/`undefined`, letting the existing `??` fallback in `t()` do its job.

## Test plan
- [x] `tsc --noEmit` passes on the touched file
- [ ] Manually verify: navigate client-side to a product page with `de` locale active where a translation key is missing under `product.pricingSchedule` — page should render with the English fallback text instead of crashing