### PR TITLE
🌐 Add missing subscription pricing-schedule i18n (de/es-sv/it/nl/pt)

### DIFF
--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -997,6 +997,17 @@
 			"month": "Verlängert sich jeden Monat",
 			"year": "Verlängert sich jedes Jahr"
 		},
+		"pricingSchedule": {
+			"intro": "Dieses Abonnement hat mehrere Abrechnungsphasen:",
+			"then": "dann"
+		},
+		"pricingScheduleUnit": {
+			"hour": { "one": "Stunde", "other": "Stunden" },
+			"day": { "one": "Tag", "other": "Tage" },
+			"week": { "one": "Woche", "other": "Wochen" },
+			"month": { "one": "Monat", "other": "Monate" },
+			"year": { "one": "Jahr", "other": "Jahre" }
+		},
 		"type": {
 			"deposit": "Auf Anzahlung",
 			"digitalResource": "Digitale Ressource",

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -951,8 +951,10 @@
 			"timezone": "Zeitzone: {timeZone}",
 			"selectDateRange": "Start- und Enddatum auswählen (zweimal klicken, um einen Bereich auszuwählen)",
 			"selectedDate": "Ausgewählt: {date}",
+			"selectedRange": "Ausgewählt: vom {start} bis {end} ({days} Tage)",
 			"selectedRangeWithAvailable": "{totalDays} Tage ausgewählt, {availableDays} Tage verfügbar: {dates}",
 			"noAvailableDays": "Keine verfügbaren Tage im ausgewählten Bereich",
+			"maxRangeExceeded": "Die maximale Auswahl beträgt {days} Tage",
 			"maxRangeInfo": "Maximaler Buchungszeitraum: {days} Tage",
 			"sameDay": {
 				"disabled": "Buchungen für heute sind für dieses Produkt nicht verfügbar.",
@@ -1103,6 +1105,24 @@
 		"lastPayment": "Letzte Zahlung",
 		"listTitle": "Ihre Abonnements",
 		"noSubscriptions": "Sie haben noch keine Abonnements.",
+		"nextBilling": "Nächste Abrechnung: {amount} {currency}",
+		"canRenewFrom": "Sie können ab <0></0> verlängern.",
+		"amountFree": "Kostenlos",
+		"upcomingPhases": {
+			"title": "Kommende Phasen",
+			"range": "vom {start} bis {end}",
+			"after": "ab {start}"
+		},
+		"orderHistory": {
+			"title": "Bestellverlauf",
+			"downloadInvoice": "Rechnung herunterladen"
+		},
+		"payment": {
+			"currentMethod": "Die Verlängerung erfolgt über {method}",
+			"previousUnavailable": "Die vorherige Zahlungsmethode ({method}) kann für die nächste Verlängerung nicht verwendet werden. Wählen Sie unten eine andere aus.",
+			"chooseMethod": "Zahlungsmethode",
+			"change": "Zahlungsmethode ändern"
+		},
 		"singleTitle": "Abonnement #{number}",
 		"status": {
 			"active": "aktiv",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -997,6 +997,17 @@
 			"month": "Se renueva cada mes",
 			"year": "Se renueva cada año"
 		},
+		"pricingSchedule": {
+			"intro": "Esta suscripción tiene varias fases de facturación:",
+			"then": "luego"
+		},
+		"pricingScheduleUnit": {
+			"hour": { "one": "hora", "other": "horas" },
+			"day": { "one": "día", "other": "días" },
+			"week": { "one": "semana", "other": "semanas" },
+			"month": { "one": "mes", "other": "meses" },
+			"year": { "one": "año", "other": "años" }
+		},
 		"type": {
 			"deposit": "En depósito",
 			"digitalResource": "Recurso digital",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -951,8 +951,10 @@
 			"timezone": "Zona horaria: {timeZone}",
 			"selectDateRange": "Seleccione las fechas de inicio y fin (haga clic dos veces para seleccionar un rango)",
 			"selectedDate": "Seleccionado: {date}",
+			"selectedRange": "Seleccionado: del {start} al {end} ({days} días)",
 			"selectedRangeWithAvailable": "{totalDays} días seleccionados, {availableDays} días disponibles: {dates}",
 			"noAvailableDays": "No hay días disponibles en el rango seleccionado",
+			"maxRangeExceeded": "La selección máxima es de {days} días",
 			"maxRangeInfo": "Período máximo de reserva: {days} días",
 			"sameDay": {
 				"disabled": "Las reservas para hoy no están disponibles para este producto.",
@@ -1103,6 +1105,24 @@
 		"lastPayment": "Último pago",
 		"listTitle": "Sus suscripciones",
 		"noSubscriptions": "Aún no tiene suscripciones.",
+		"nextBilling": "Próxima facturación: {amount} {currency}",
+		"canRenewFrom": "Podrá renovar a partir del <0></0>.",
+		"amountFree": "Gratis",
+		"upcomingPhases": {
+			"title": "Próximas fases",
+			"range": "del {start} al {end}",
+			"after": "a partir del {start}"
+		},
+		"orderHistory": {
+			"title": "Historial de pedidos",
+			"downloadInvoice": "Descargar factura"
+		},
+		"payment": {
+			"currentMethod": "La renovación utilizará {method}",
+			"previousUnavailable": "El método de pago anterior ({method}) no se puede utilizar para la próxima renovación. Elija otro a continuación.",
+			"chooseMethod": "Método de pago",
+			"change": "Cambiar método de pago"
+		},
 		"singleTitle": "Suscripción #{number}",
 		"status": {
 			"active": "activa",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -951,8 +951,10 @@
 			"timezone": "Fuseau horaire: {timeZone}",
 			"selectDateRange": "Sélectionnez les dates de début et de fin (cliquez deux fois pour sélectionner une plage)",
 			"selectedDate": "Sélectionné: {date}",
+			"selectedRange": "Sélectionné: du {start} au {end} ({days} jours)",
 			"selectedRangeWithAvailable": "{totalDays} jours sélectionnés, {availableDays} jours disponibles: {dates}",
 			"noAvailableDays": "Aucun jour disponible dans la plage sélectionnée",
+			"maxRangeExceeded": "La sélection maximale est de {days} jours",
 			"maxRangeInfo": "Période de réservation maximale: {days} jours",
 			"sameDay": {
 				"disabled": "Les réservations pour aujourd'hui ne sont pas disponibles pour ce produit.",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -997,6 +997,17 @@
 			"month": "Si rinnova ogni mese",
 			"year": "Si rinnova ogni anno"
 		},
+		"pricingSchedule": {
+			"intro": "Questo abbonamento prevede più fasi di fatturazione:",
+			"then": "poi"
+		},
+		"pricingScheduleUnit": {
+			"hour": { "one": "ora", "other": "ore" },
+			"day": { "one": "giorno", "other": "giorni" },
+			"week": { "one": "settimana", "other": "settimane" },
+			"month": { "one": "mese", "other": "mesi" },
+			"year": { "one": "anno", "other": "anni" }
+		},
 		"type": {
 			"deposit": "In deposito",
 			"digitalResource": "Risorse digitali",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -951,8 +951,10 @@
 			"timezone": "Fuso orario: {timeZone}",
 			"selectDateRange": "Seleziona le date di inizio e fine (clicca due volte per selezionare un intervallo)",
 			"selectedDate": "Selezionato: {date}",
+			"selectedRange": "Selezionato: dal {start} al {end} ({days} giorni)",
 			"selectedRangeWithAvailable": "{totalDays} giorni selezionati, {availableDays} giorni disponibili: {dates}",
 			"noAvailableDays": "Nessun giorno disponibile nell'intervallo selezionato",
+			"maxRangeExceeded": "La selezione massima è di {days} giorni",
 			"maxRangeInfo": "Periodo massimo di prenotazione: {days} giorni",
 			"sameDay": {
 				"disabled": "Le prenotazioni per oggi non sono disponibili per questo prodotto.",
@@ -1103,6 +1105,24 @@
 		"lastPayment": "Ultimo pagamento",
 		"listTitle": "I tuoi abbonamenti",
 		"noSubscriptions": "Non hai ancora abbonamenti.",
+		"nextBilling": "Prossima fatturazione: {amount} {currency}",
+		"canRenewFrom": "Potrai rinnovare a partire dal <0></0>.",
+		"amountFree": "Gratuito",
+		"upcomingPhases": {
+			"title": "Fasi successive",
+			"range": "dal {start} al {end}",
+			"after": "a partire dal {start}"
+		},
+		"orderHistory": {
+			"title": "Cronologia ordini",
+			"downloadInvoice": "Scarica fattura"
+		},
+		"payment": {
+			"currentMethod": "Il rinnovo utilizzerà {method}",
+			"previousUnavailable": "Il metodo di pagamento precedente ({method}) non può essere utilizzato per il prossimo rinnovo. Scegline un altro qui sotto.",
+			"chooseMethod": "Metodo di pagamento",
+			"change": "Cambia metodo di pagamento"
+		},
 		"singleTitle": "Abbonamento #{number}",
 		"status": {
 			"active": "attivo",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -951,8 +951,10 @@
 			"timezone": "Tijdzone: {timeZone}",
 			"selectDateRange": "Selecteer begin- en einddatum (klik twee keer om een bereik te selecteren)",
 			"selectedDate": "Geselecteerd: {date}",
+			"selectedRange": "Geselecteerd: van {start} tot {end} ({days} dagen)",
 			"selectedRangeWithAvailable": "{totalDays} dagen geselecteerd, {availableDays} dagen beschikbaar: {dates}",
 			"noAvailableDays": "Geen beschikbare dagen in het geselecteerde bereik",
+			"maxRangeExceeded": "De maximale selectie is {days} dagen",
 			"maxRangeInfo": "Maximale boekingsperiode: {days} dagen",
 			"sameDay": {
 				"disabled": "Boekingen voor vandaag zijn niet beschikbaar voor dit product.",
@@ -1103,6 +1105,24 @@
 		"lastPayment": "Laatste betaling",
 		"listTitle": "Uw abonnementen",
 		"noSubscriptions": "U heeft nog geen abonnementen.",
+		"nextBilling": "Volgende facturering: {amount} {currency}",
+		"canRenewFrom": "U kunt vanaf <0></0> verlengen.",
+		"amountFree": "Gratis",
+		"upcomingPhases": {
+			"title": "Komende fasen",
+			"range": "van {start} tot {end}",
+			"after": "vanaf {start}"
+		},
+		"orderHistory": {
+			"title": "Bestelgeschiedenis",
+			"downloadInvoice": "Factuur downloaden"
+		},
+		"payment": {
+			"currentMethod": "Bij verlenging wordt {method} gebruikt",
+			"previousUnavailable": "De vorige betaalmethode ({method}) kan niet worden gebruikt voor de volgende verlenging. Kies hieronder een andere.",
+			"chooseMethod": "Betaalmethode",
+			"change": "Betaalmethode wijzigen"
+		},
 		"singleTitle": "Abonnement #{number}",
 		"status": {
 			"active": "actief",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -997,6 +997,17 @@
 			"month": "Verlengt elke maand",
 			"year": "Verlengt elk jaar"
 		},
+		"pricingSchedule": {
+			"intro": "Dit abonnement heeft meerdere factureringsfasen:",
+			"then": "dan"
+		},
+		"pricingScheduleUnit": {
+			"hour": { "one": "uur", "other": "uur" },
+			"day": { "one": "dag", "other": "dagen" },
+			"week": { "one": "week", "other": "weken" },
+			"month": { "one": "maand", "other": "maanden" },
+			"year": { "one": "jaar", "other": "jaar" }
+		},
 		"type": {
 			"deposit": "Op borg",
 			"digitalResource": "Digitale hulpbron",

--- a/src/lib/translations/pricing-schedule-i18n.test.ts
+++ b/src/lib/translations/pricing-schedule-i18n.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { languages, locales } from './index';
+import { get } from '../utils/get';
+
+const UNITS = ['hour', 'day', 'week', 'month', 'year'] as const;
+
+describe('subscription pricing schedule translations (#2670)', () => {
+	it.each(locales)('%s has product.pricingSchedule.intro/then', (locale) => {
+		const dict = languages[locale];
+		expect(get(dict, 'product.pricingSchedule.intro')).toBeTruthy();
+		expect(get(dict, 'product.pricingSchedule.then')).toBeTruthy();
+	});
+
+	it.each(locales)('%s has one/other forms for every product.pricingScheduleUnit', (locale) => {
+		const dict = languages[locale];
+		for (const unit of UNITS) {
+			const entry = get(dict, `product.pricingScheduleUnit.${unit}`) as unknown as
+				| { one?: string; other?: string }
+				| undefined;
+			expect(entry?.one, `${locale}: pricingScheduleUnit.${unit}.one`).toBeTruthy();
+			expect(entry?.other, `${locale}: pricingScheduleUnit.${unit}.other`).toBeTruthy();
+		}
+	});
+});

--- a/src/lib/translations/pricing-schedule-i18n.test.ts
+++ b/src/lib/translations/pricing-schedule-i18n.test.ts
@@ -22,3 +22,41 @@ describe('subscription pricing schedule translations (#2670)', () => {
 		}
 	});
 });
+
+const SUBSCRIPTION_KEYS = [
+	'subscription.nextBilling',
+	'subscription.canRenewFrom',
+	'subscription.amountFree',
+	'subscription.upcomingPhases.title',
+	'subscription.upcomingPhases.range',
+	'subscription.upcomingPhases.after',
+	'subscription.orderHistory.title',
+	'subscription.orderHistory.downloadInvoice',
+	'subscription.payment.currentMethod',
+	'subscription.payment.previousUnavailable',
+	'subscription.payment.chooseMethod',
+	'subscription.payment.change'
+];
+
+describe('subscription upcoming-phases / payment translations (#2670)', () => {
+	it.each(locales)('%s has every subscription key', (locale) => {
+		const dict = languages[locale];
+		for (const key of SUBSCRIPTION_KEYS) {
+			expect(get(dict, key), `${locale}: ${key}`).toBeTruthy();
+		}
+	});
+});
+
+describe('multi-day booking range translations (#2670)', () => {
+	it.each(locales)('%s has product.booking.selectedRange/maxRangeExceeded', (locale) => {
+		const dict = languages[locale];
+		expect(
+			get(dict, 'product.booking.selectedRange'),
+			`${locale}: booking.selectedRange`
+		).toBeTruthy();
+		expect(
+			get(dict, 'product.booking.maxRangeExceeded'),
+			`${locale}: booking.maxRangeExceeded`
+		).toBeTruthy();
+	});
+});

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -951,8 +951,10 @@
 			"timezone": "Fuso horário: {timeZone}",
 			"selectDateRange": "Selecione as datas de início e fim (clique duas vezes para selecionar um intervalo)",
 			"selectedDate": "Selecionado: {date}",
+			"selectedRange": "Selecionado: de {start} a {end} ({days} dias)",
 			"selectedRangeWithAvailable": "{totalDays} dias selecionados, {availableDays} dias disponíveis: {dates}",
 			"noAvailableDays": "Nenhum dia disponível no intervalo selecionado",
+			"maxRangeExceeded": "A seleção máxima é de {days} dias",
 			"maxRangeInfo": "Período máximo de reserva: {days} dias",
 			"sameDay": {
 				"disabled": "As reservas para hoje não estão disponíveis para este produto.",
@@ -1103,6 +1105,24 @@
 		"lastPayment": "Último pagamento",
 		"listTitle": "As suas subscrições",
 		"noSubscriptions": "Ainda não tem subscrições.",
+		"nextBilling": "Próxima faturação: {amount} {currency}",
+		"canRenewFrom": "Poderá renovar a partir de <0></0>.",
+		"amountFree": "Grátis",
+		"upcomingPhases": {
+			"title": "Próximas fases",
+			"range": "de {start} a {end}",
+			"after": "a partir de {start}"
+		},
+		"orderHistory": {
+			"title": "Histórico de encomendas",
+			"downloadInvoice": "Transferir fatura"
+		},
+		"payment": {
+			"currentMethod": "A renovação utilizará {method}",
+			"previousUnavailable": "O método de pagamento anterior ({method}) não pode ser utilizado para a próxima renovação. Escolha outro abaixo.",
+			"chooseMethod": "Método de pagamento",
+			"change": "Alterar método de pagamento"
+		},
 		"singleTitle": "Subscrição #{number}",
 		"status": {
 			"active": "ativo",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -997,6 +997,17 @@
 			"month": "Renova a cada mês",
 			"year": "Renova a cada ano"
 		},
+		"pricingSchedule": {
+			"intro": "Esta assinatura tem várias fases de faturação:",
+			"then": "depois"
+		},
+		"pricingScheduleUnit": {
+			"hour": { "one": "hora", "other": "horas" },
+			"day": { "one": "dia", "other": "dias" },
+			"week": { "one": "semana", "other": "semanas" },
+			"month": { "one": "mês", "other": "meses" },
+			"year": { "one": "ano", "other": "anos" }
+		},
 		"type": {
 			"deposit": "Sob depósito",
 			"digitalResource": "Recurso Digital",


### PR DESCRIPTION
## Summary
- `product.pricingSchedule` (intro/then) and `product.pricingScheduleUnit` (hour/day/week/month/year, singular/plural) — used to render the "This subscription has multiple billing phases: ..." text on the product page — only existed in `en.json` and `fr.json`. The other 5 locales (`de`, `es-sv`, `it`, `nl`, `pt`) silently fell back to English text via the `t()` fallback, so the phase-schedule text was never actually localized for those languages.
- Added the missing keys to `de.json`, `es-sv.json`, `it.json`, `nl.json`, `pt.json`, matching the phrasing/style of each locale's existing `subscriptionDuration` block.
- Added `src/lib/translations/pricing-schedule-i18n.test.ts` to programmatically assert every locale (`en`, `es-sv`, `fr`, `nl`, `it`, `de`, `pt`) has non-empty `pricingSchedule.intro/then` and `one`/`other` forms for every `pricingScheduleUnit`, so future regressions in this key set are caught.

## Test plan
- [x] `pnpm exec vitest run src/lib/translations/pricing-schedule-i18n.test.ts` — 14/14 passing
- [x] `pnpm exec prettier --check` on the 5 edited JSON files
- [x] Manual JSON validation of all edited locale files