### PR TITLE
Fix vatRate wrongly stored as array in VAT-to-array migration

### DIFF
--- a/src/lib/server/migrations.test.ts
+++ b/src/lib/server/migrations.test.ts
@@ -74,3 +74,63 @@ describe('migration #2492 — drop single-currency (SAT) amount from order.vat',
 		expect(after?.vat).toEqual([{ rate: 8.1, country: 'CH' }]);
 	});
 });
+
+function migrationVatArray() {
+	const migration = migrations.find((m) => m._id.equals(new ObjectId('65bd8fc40914f6a599ede07d')));
+	if (!migration) {
+		throw new Error('migration "Convert VAT rate to array in orders" not found');
+	}
+	return migration;
+}
+
+describe('migration — Convert VAT rate to array in orders', () => {
+	it('stores a scalar vatRate on each item, not an array', async () => {
+		await cleanDb();
+
+		const _id = 'legacy-order-vat-array';
+		await collections.orders.insertOne({
+			_id,
+			vat: { price: { amount: 100, currency: 'EUR' }, rate: 8.1, country: 'CH' },
+			items: [{ quantity: 1 }, { quantity: 2 }]
+		} as never);
+
+		await withTransaction((session) => migrationVatArray().run(session));
+
+		const migrated = await collections.orders.findOne({ _id });
+		expect(migrated?.vat).toEqual([
+			{ price: { amount: 100, currency: 'EUR' }, rate: 8.1, country: 'CH' }
+		]);
+		for (const item of migrated?.items ?? []) {
+			expect(item.vatRate).toBe(8.1);
+		}
+	});
+});
+
+function migrationVatRateArrayFix() {
+	const migration = migrations.find((m) => m._id.equals(new ObjectId('0295fdf30e394bdf3fc015b1')));
+	if (!migration) {
+		throw new Error('migration "Fix items.vatRate wrongly stored as an array" not found');
+	}
+	return migration;
+}
+
+describe('migration — Fix items.vatRate wrongly stored as an array', () => {
+	it('flattens an array vatRate back to its scalar value', async () => {
+		await cleanDb();
+
+		const _id = 'order-with-array-vat-rate';
+		await collections.orders.insertOne({
+			_id,
+			items: [
+				{ quantity: 1, vatRate: [8.1] },
+				{ quantity: 2, vatRate: 5.5 }
+			]
+		} as never);
+
+		await withTransaction((session) => migrationVatRateArrayFix().run(session));
+
+		const migrated = await collections.orders.findOne({ _id });
+		expect(migrated?.items[0].vatRate).toBe(8.1);
+		expect(migrated?.items[1].vatRate).toBe(5.5);
+	});
+});

--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -409,7 +409,10 @@ export const migrations = [
 				[
 					{
 						$set: {
-							vat: ['$vat'],
+							// items must be computed before vat is reassigned below: $set fields
+							// evaluate sequentially, so referencing '$vat.rate' after 'vat' has
+							// already been turned into an array would read the array, not the
+							// original scalar rate.
 							items: {
 								$map: {
 									input: '$items',
@@ -423,7 +426,8 @@ export const migrations = [
 										]
 									}
 								}
-							}
+							},
+							vat: ['$vat']
 						}
 					}
 				],
@@ -973,6 +977,30 @@ export const migrations = [
 						after: publicDiscountPriceSnapshot(discount),
 						createdAt: discount.createdAt ?? new Date()
 					},
+					{ session }
+				);
+			}
+		}
+	},
+	{
+		_id: new ObjectId('0295fdf30e394bdf3fc015b1'),
+		name: 'Fix items.vatRate wrongly stored as an array by the VAT-to-array migration',
+		run: async (session: ClientSession) => {
+			// The 'Convert VAT rate to array in orders' migration referenced '$vat.rate' after
+			// already reassigning 'vat' to an array in the same $set stage, so it picked up the
+			// array-wrapped rate ([rate]) instead of the scalar rate.
+			for await (const order of collections.orders.find(
+				{ 'items.vatRate': { $type: 'array' } },
+				{ session }
+			)) {
+				for (const item of order.items) {
+					if (Array.isArray(item.vatRate)) {
+						item.vatRate = item.vatRate[0];
+					}
+				}
+				await collections.orders.updateOne(
+					{ _id: order._id },
+					{ $set: { items: order.items } },
 					{ session }
 				);
 			}


### PR DESCRIPTION
## Summary
- The "Convert VAT rate to array in orders" migration referenced `$vat.rate` inside the same `$set` stage where `vat` was already being reassigned to `['$vat']`. Since `$set` fields evaluate sequentially, `items.vatRate` ended up as `[rate]` (an array) instead of the scalar `number` the `Order` type expects.
- Fixed by computing `items` before reassigning `vat` in that stage.
- Added a corrective migration (`0295fdf30e394bdf3fc015b1`) that flattens any `items.vatRate` already stored as an array back to its scalar value, for databases that already ran the buggy version.
- Added tests covering both the corrected migration's output and the corrective migration.

## Test plan
- [x] `vitest run src/lib/server/migrations.test.ts` — 4 tests pass
- [x] `eslint` on changed files — clean
- [x] `svelte-check` — 0 errors