### PR TITLE
🐛 Fix CurrencyCalculator SSR crash on CMS pages (#2680)

### DIFF
--- a/src/lib/components/CurrencyCalculator.svelte
+++ b/src/lib/components/CurrencyCalculator.svelte
@@ -6,8 +6,8 @@
 	import { getCurrencyFromCountry } from '$lib/types/Country';
 	import Select from 'svelte-select';
 
-	$: sortedCurrencies = sortCurrencies($currencies.main, $currencies.secondary);
-	$: currencyOptions = currenciesToSelectOptions(sortedCurrencies);
+	const sortedCurrencies = sortCurrencies($currencies.main, $currencies.secondary);
+	const currencyOptions = currenciesToSelectOptions(sortedCurrencies);
 
 	function getDefaultSecondCurrency(): Currency {
 		if ($currencies.secondary) {


### PR DESCRIPTION
Fixes #2680.

`sortedCurrencies` and `currencyOptions` were declared with reactive `$:` blocks but were consumed by non-reactive `let` initializers a few lines below, which read `undefined` in SSR ordering.