### PR TITLE
🆕🤖 Admin session expiry warning banner (#2510)

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -31,6 +31,7 @@ declare global {
 			};
 			email?: string;
 			npub?: string;
+			expireUserAt?: Date;
 			sso?: Array<{
 				provider: string;
 				email?: string;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -228,6 +228,9 @@ const handleGlobal: Handle = async ({ event, resolve }) => {
 						hasPosOptions: user.hasPosOptions,
 						recoveryEmail: user.recovery?.email
 					};
+					if (session.expireUserAt) {
+						event.locals.expireUserAt = session.expireUserAt;
+					}
 				}
 			}
 		}
@@ -281,7 +284,9 @@ const handleGlobal: Handle = async ({ event, resolve }) => {
 
 		// User-self endpoints (per-user prefs) only need an admin login, no role permission.
 		const normalizedAdminPath = event.url.pathname.replace(/^\/admin-[a-zA-Z0-9]+/, '/admin');
-		const isUserSelfAdminEndpoint = normalizedAdminPath === '/admin/back-office-bookmark';
+		const isUserSelfAdminEndpoint =
+			normalizedAdminPath === '/admin/back-office-bookmark' ||
+			normalizedAdminPath === '/admin/session/extend';
 
 		if (
 			!isUserSelfAdminEndpoint &&

--- a/src/lib/components/SessionExpiryBanner.svelte
+++ b/src/lib/components/SessionExpiryBanner.svelte
@@ -84,12 +84,7 @@
 {:else if isWarning && !dismissed}
 	<div class="bg-yellow-300 text-black p-3 flex flex-wrap items-center gap-3" role="alert">
 		<span>{t('admin.session.expiry.warning.message', { countdown })}</span>
-		<button
-			type="button"
-			on:click={extend}
-			disabled={extending}
-			class="btn body-mainCTA"
-		>
+		<button type="button" on:click={extend} disabled={extending} class="btn body-mainCTA">
 			{t('admin.session.expiry.warning.extend')}
 		</button>
 		<button type="button" on:click={dismiss} class="underline">

--- a/src/lib/components/SessionExpiryBanner.svelte
+++ b/src/lib/components/SessionExpiryBanner.svelte
@@ -25,7 +25,9 @@
 	});
 
 	onDestroy(() => {
-		if (interval) clearInterval(interval);
+		if (interval) {
+			clearInterval(interval);
+		}
 	});
 
 	$: if ($page.url.pathname !== lastPath) {
@@ -48,7 +50,9 @@
 	}
 
 	async function extend() {
-		if (extending) return;
+		if (extending) {
+			return;
+		}
 		extending = true;
 		try {
 			const res = await fetch(`${adminPrefix}/session/extend`, {
@@ -69,38 +73,26 @@
 </script>
 
 {#if isExpired}
-	<div
-		class="fixed top-0 inset-x-0 z-[1000] bg-red-600 text-white px-4 py-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm shadow-lg"
-		role="alert"
-	>
-		<span>
-			<Trans key="admin.session.expiry.expired.message">
-				<a slot="0" href="{adminPrefix}/login" class="underline font-semibold" let:translation>
-					{translation}
-				</a>
-			</Trans>
-		</span>
-		<span class="opacity-90">{t('admin.session.expiry.expired.configHint')}</span>
+	<div class="bg-red-600 text-white p-3" role="alert">
+		<Trans key="admin.session.expiry.expired.message">
+			<a slot="0" href="{adminPrefix}/login" class="underline" let:translation>
+				{translation}
+			</a>
+		</Trans>
+		{t('admin.session.expiry.expired.configHint')}
 	</div>
 {:else if isWarning && !dismissed}
-	<div
-		class="fixed top-0 inset-x-0 z-[1000] bg-orange-500 text-white px-4 py-3 flex flex-wrap items-center justify-center gap-3 text-sm shadow-lg"
-		role="alert"
-	>
+	<div class="bg-yellow-300 text-black p-3 flex flex-wrap items-center gap-3" role="alert">
 		<span>{t('admin.session.expiry.warning.message', { countdown })}</span>
 		<button
 			type="button"
 			on:click={extend}
 			disabled={extending}
-			class="bg-white text-orange-700 px-3 py-1 rounded font-semibold disabled:opacity-60"
+			class="btn body-mainCTA"
 		>
 			{t('admin.session.expiry.warning.extend')}
 		</button>
-		<button
-			type="button"
-			on:click={dismiss}
-			class="border border-white px-3 py-1 rounded hover:bg-white hover:bg-opacity-10"
-		>
+		<button type="button" on:click={dismiss} class="underline">
 			{t('admin.session.expiry.warning.ignore')}
 		</button>
 	</div>

--- a/src/lib/components/SessionExpiryBanner.svelte
+++ b/src/lib/components/SessionExpiryBanner.svelte
@@ -73,7 +73,7 @@
 </script>
 
 {#if isExpired}
-	<div class="bg-red-600 text-white p-3" role="alert">
+	<div class="sticky top-0 z-40 bg-red-600 text-white p-3" role="alert">
 		<Trans key="admin.session.expiry.expired.message">
 			<a slot="0" href="{adminPrefix}/login" class="underline" let:translation>
 				{translation}
@@ -82,7 +82,10 @@
 		{t('admin.session.expiry.expired.configHint')}
 	</div>
 {:else if isWarning && !dismissed}
-	<div class="bg-yellow-300 text-black p-3 flex flex-wrap items-center gap-3" role="alert">
+	<div
+		class="sticky top-0 z-40 bg-yellow-300 text-black p-3 flex flex-wrap items-center gap-3"
+		role="alert"
+	>
 		<span>{t('admin.session.expiry.warning.message', { countdown })}</span>
 		<button type="button" on:click={extend} disabled={extending} class="btn body-mainCTA">
 			{t('admin.session.expiry.warning.extend')}

--- a/src/lib/components/SessionExpiryBanner.svelte
+++ b/src/lib/components/SessionExpiryBanner.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { page } from '$app/stores';
+	import { invalidateAll } from '$app/navigation';
+	import { useI18n } from '$lib/i18n';
+	import Trans from '$lib/components/Trans.svelte';
+
+	export let expireUserAt: string;
+	export let adminPrefix: string;
+
+	const { t } = useI18n();
+
+	const WARNING_THRESHOLD_MS = 5 * 60 * 1000;
+
+	let now = Date.now();
+	let dismissed = false;
+	let extending = false;
+	let interval: ReturnType<typeof setInterval> | undefined;
+	let lastPath = '';
+
+	onMount(() => {
+		interval = setInterval(() => {
+			now = Date.now();
+		}, 1000);
+	});
+
+	onDestroy(() => {
+		if (interval) clearInterval(interval);
+	});
+
+	$: if ($page.url.pathname !== lastPath) {
+		lastPath = $page.url.pathname;
+		dismissed = false;
+	}
+
+	$: expiryMs = new Date(expireUserAt).getTime();
+	$: msRemaining = expiryMs - now;
+	$: isExpired = msRemaining <= 0;
+	$: isWarning = !isExpired && msRemaining <= WARNING_THRESHOLD_MS;
+
+	$: countdown = formatCountdown(msRemaining);
+
+	function formatCountdown(ms: number): string {
+		const s = Math.max(0, Math.ceil(ms / 1000));
+		const mm = String(Math.floor(s / 60)).padStart(2, '0');
+		const ss = String(s % 60).padStart(2, '0');
+		return `${mm}:${ss}`;
+	}
+
+	async function extend() {
+		if (extending) return;
+		extending = true;
+		try {
+			const res = await fetch(`${adminPrefix}/session/extend`, {
+				method: 'POST',
+				redirect: 'manual'
+			});
+			if (res.ok) {
+				await invalidateAll();
+			}
+		} finally {
+			extending = false;
+		}
+	}
+
+	function dismiss() {
+		dismissed = true;
+	}
+</script>
+
+{#if isExpired}
+	<div
+		class="fixed top-0 inset-x-0 z-[1000] bg-red-600 text-white px-4 py-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm shadow-lg"
+		role="alert"
+	>
+		<span>
+			<Trans key="admin.session.expiry.expired.message">
+				<a slot="0" href="{adminPrefix}/login" class="underline font-semibold" let:translation>
+					{translation}
+				</a>
+			</Trans>
+		</span>
+		<span class="opacity-90">{t('admin.session.expiry.expired.configHint')}</span>
+	</div>
+{:else if isWarning && !dismissed}
+	<div
+		class="fixed top-0 inset-x-0 z-[1000] bg-orange-500 text-white px-4 py-3 flex flex-wrap items-center justify-center gap-3 text-sm shadow-lg"
+		role="alert"
+	>
+		<span>{t('admin.session.expiry.warning.message', { countdown })}</span>
+		<button
+			type="button"
+			on:click={extend}
+			disabled={extending}
+			class="bg-white text-orange-700 px-3 py-1 rounded font-semibold disabled:opacity-60"
+		>
+			{t('admin.session.expiry.warning.extend')}
+		</button>
+		<button
+			type="button"
+			on:click={dismiss}
+			class="border border-white px-3 py-1 rounded hover:bg-white hover:bg-opacity-10"
+		>
+			{t('admin.session.expiry.warning.ignore')}
+		</button>
+	</div>
+{/if}

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -40,6 +40,19 @@
 				"noReference": "-- Keine Referenz (eigenen Lagerbestand verwenden) --",
 				"warning": "⚠️ Dieses Produkt verweist auf den Lagerbestand eines anderen Produkts. Lagerbestandsänderungen wirken sich auf das referenzierte Produkt aus."
 			}
+		},
+		"session": {
+			"expiry": {
+				"warning": {
+					"message": "Ihre Sitzung endet in {countdown}",
+					"extend": "Verlängern",
+					"ignore": "Ausblenden"
+				},
+				"expired": {
+					"message": "Ihre Sitzung wurde beendet. Ihre nicht gespeicherten Änderungen werden nicht übernommen, bitte <0>melden Sie sich erneut an</0>.",
+					"configHint": "Eine längere Sitzungsdauer kann beim Anmelden konfiguriert werden."
+				}
+			}
 		}
 	},
 	"ageWarning": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -40,6 +40,19 @@
 				"noReference": "-- No reference (use own stock) --",
 				"warning": "⚠️ This product references another product's stock. Stock changes will affect the referenced product."
 			}
+		},
+		"session": {
+			"expiry": {
+				"warning": {
+					"message": "Your session will end in {countdown}",
+					"extend": "Extend",
+					"ignore": "Dismiss"
+				},
+				"expired": {
+					"message": "Your session has been disconnected. Any unsaved changes will not be recorded, please <0>log in again</0>.",
+					"configHint": "A longer session duration can be configured at login."
+				}
+			}
 		}
 	},
 	"ageWarning": {

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -40,6 +40,19 @@
 				"noReference": "-- Sin referencia (usar stock propio) --",
 				"warning": "⚠️ Este producto referencia el stock de otro producto. Los cambios de stock afectarán al producto referenciado."
 			}
+		},
+		"session": {
+			"expiry": {
+				"warning": {
+					"message": "Su sesión finalizará en {countdown}",
+					"extend": "Prolongar",
+					"ignore": "Ignorar"
+				},
+				"expired": {
+					"message": "Su sesión ha sido desconectada. Sus cambios no guardados no serán registrados, por favor <0>vuelva a iniciar sesión</0>.",
+					"configHint": "Puede configurar una duración de sesión más larga al iniciar sesión."
+				}
+			}
 		}
 	},
 	"ageWarning": {

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -40,6 +40,19 @@
 				"noReference": "-- Pas de référence (utiliser le stock propre) --",
 				"warning": "⚠️ Ce produit référence le stock d'un autre produit. Les modifications de stock affecteront le produit référencé."
 			}
+		},
+		"session": {
+			"expiry": {
+				"warning": {
+					"message": "Votre session va se terminer dans {countdown}",
+					"extend": "Prolonger",
+					"ignore": "Ignorer"
+				},
+				"expired": {
+					"message": "Votre session a été déconnectée. L'enregistrement de vos modifications ne sera pas pris en compte, merci de vous <0>reconnecter</0>.",
+					"configHint": "Une durée de session plus longue peut être configurée à la connexion."
+				}
+			}
 		}
 	},
 	"ageWarning": {

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -40,6 +40,19 @@
 				"noReference": "-- Nessun riferimento (usa stock proprio) --",
 				"warning": "⚠️ Questo prodotto fa riferimento allo stock di un altro prodotto. Le modifiche allo stock influenzeranno il prodotto di riferimento."
 			}
+		},
+		"session": {
+			"expiry": {
+				"warning": {
+					"message": "La sua sessione terminerà tra {countdown}",
+					"extend": "Prolunga",
+					"ignore": "Ignora"
+				},
+				"expired": {
+					"message": "La sua sessione è stata disconnessa. Le modifiche non salvate non verranno registrate, la preghiamo di <0>accedere di nuovo</0>.",
+					"configHint": "Una durata di sessione più lunga può essere configurata al momento dell'accesso."
+				}
+			}
 		}
 	},
 	"ageWarning": {

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -40,6 +40,19 @@
 				"noReference": "-- Geen verwijzing (gebruik eigen voorraad) --",
 				"warning": "⚠️ Dit product verwijst naar de voorraad van een ander product. Voorraadwijzigingen zullen het gerefereerde product beïnvloeden."
 			}
+		},
+		"session": {
+			"expiry": {
+				"warning": {
+					"message": "Uw sessie eindigt over {countdown}",
+					"extend": "Verlengen",
+					"ignore": "Negeren"
+				},
+				"expired": {
+					"message": "Uw sessie is verbroken. Niet-opgeslagen wijzigingen zullen niet worden vastgelegd, gelieve <0>opnieuw in te loggen</0>.",
+					"configHint": "Een langere sessieduur kan worden geconfigureerd bij het inloggen."
+				}
+			}
 		}
 	},
 	"ageWarning": {

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -40,6 +40,19 @@
 				"noReference": "-- Sem referência (usar stock próprio) --",
 				"warning": "⚠️ Este produto referencia o stock de outro produto. As alterações de stock afetarão o produto referenciado."
 			}
+		},
+		"session": {
+			"expiry": {
+				"warning": {
+					"message": "A sua sessão irá terminar em {countdown}",
+					"extend": "Prolongar",
+					"ignore": "Ignorar"
+				},
+				"expired": {
+					"message": "A sua sessão foi desconectada. As alterações não guardadas não serão registadas, por favor <0>volte a iniciar sessão</0>.",
+					"configHint": "Uma duração de sessão mais longa pode ser configurada no início de sessão."
+				}
+			}
 		}
 	},
 	"ageWarning": {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/+layout.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+layout.server.ts
@@ -86,6 +86,7 @@ export async function load({ locals }) {
 		allowPaidOrderWebhook: isPaidOrderWebhookEnabled(),
 		s3IsConfigured: !!s3IsConfigured(),
 		disabledAdminEntries: runtimeConfig.disabledAdminEntries,
+		expireUserAt: locals.expireUserAt?.toISOString() ?? null,
 		backOfficeBookmarks: locals.user
 			? collections.users
 					.findOne(

--- a/src/routes/(app)/admin[[hash=admin_hash]]/+layout.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+layout.svelte
@@ -137,10 +137,6 @@
 	}
 </script>
 
-{#if !isLoginPage && data.expireUserAt}
-	<SessionExpiryBanner expireUserAt={data.expireUserAt} adminPrefix={data.adminPrefix} />
-{/if}
-
 {#if isLoginPage}
 	<main class="p-4 flex flex-col gap-4 body-mainPlan {$page.data.bodyClass || ''}">
 		<slot />
@@ -264,6 +260,9 @@
 		</aside>
 
 		<main class="flex-1 p-4 flex flex-col gap-4 body-mainPlan {$page.data.bodyClass || ''}">
+			{#if data.expireUserAt}
+				<SessionExpiryBanner expireUserAt={data.expireUserAt} adminPrefix={data.adminPrefix} />
+			{/if}
 			<button
 				type="button"
 				class="md:hidden self-start bg-gray-400 text-gray-800 rounded p-2 text-2xl"

--- a/src/routes/(app)/admin[[hash=admin_hash]]/+layout.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+layout.svelte
@@ -10,6 +10,7 @@
 	import { isAllowedOnPage } from '$lib/types/Role';
 	import { adminLinks as adminLinksImported } from './adminLinks.js';
 	import { POS_ROLE_ID, SUPER_ADMIN_ROLE_ID } from '$lib/types/User.js';
+	import SessionExpiryBanner from '$lib/components/SessionExpiryBanner.svelte';
 
 	export let data;
 
@@ -135,6 +136,10 @@
 		}
 	}
 </script>
+
+{#if !isLoginPage && data.expireUserAt}
+	<SessionExpiryBanner expireUserAt={data.expireUserAt} adminPrefix={data.adminPrefix} />
+{/if}
 
 {#if isLoginPage}
 	<main class="p-4 flex flex-col gap-4 body-mainPlan {$page.data.bodyClass || ''}">

--- a/src/routes/(app)/admin[[hash=admin_hash]]/session/extend/+server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/session/extend/+server.ts
@@ -1,0 +1,27 @@
+import { collections } from '$lib/server/database';
+import { error, json } from '@sveltejs/kit';
+import { addSeconds } from 'date-fns';
+
+const EXTENSION_SECONDS = 30 * 60;
+
+export const POST = async ({ locals }) => {
+	if (!locals.user) {
+		throw error(401, 'Not logged in');
+	}
+
+	const session = await collections.sessions.findOne({ sessionId: locals.sessionId });
+	if (!session?.expireUserAt) {
+		throw error(400, 'No admin session expiry to extend');
+	}
+	if (session.expireUserAt < new Date()) {
+		throw error(401, 'Session already expired');
+	}
+
+	const nextExpireUserAt = addSeconds(session.expireUserAt, EXTENSION_SECONDS);
+	await collections.sessions.updateOne(
+		{ sessionId: locals.sessionId },
+		{ $set: { expireUserAt: nextExpireUserAt, updatedAt: new Date() } }
+	);
+
+	return json({ expireUserAt: nextExpireUserAt.toISOString() });
+};


### PR DESCRIPTION
Closes #2510.

Two-phase banner injected into the ARM back-office layout : orange warning surfaces at T-5min with **Prolonger** (+30min additive on `session.expireUserAt`) and **Ignorer** (page-scoped) buttons, red expired banner at T=0 with a direct login link and a hint about the session-duration control on the login page.

Copy delivered in the 7 repo languages under `admin.session.expiry.*`. Client uses a local JS timer against `data.expireUserAt` — no server polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)