### PR TITLE
✨ Add Blink Lightning payment processor

### DIFF
--- a/src/lib/server/blink.test.ts
+++ b/src/lib/server/blink.test.ts
@@ -1,0 +1,78 @@
+import { createHash, randomBytes } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import {
+	graphqlEndpointForDomain,
+	mapGraphqlInvoiceStatus,
+	parseLnAddress,
+	validatePreimage
+} from './blink';
+
+describe('blink', () => {
+	describe('parseLnAddress', () => {
+		it('splits user@domain', () => {
+			expect(parseLnAddress('alice@blink.sv')).toEqual({ username: 'alice', domain: 'blink.sv' });
+		});
+		it('defaults a bare username to blink.sv', () => {
+			expect(parseLnAddress('alice')).toEqual({ username: 'alice', domain: 'blink.sv' });
+		});
+		it('lowercases username and domain', () => {
+			expect(parseLnAddress('Alice@Blink.SV')).toEqual({ username: 'alice', domain: 'blink.sv' });
+		});
+		it('rejects empty input', () => {
+			expect(() => parseLnAddress('@blink.sv')).toThrow();
+			expect(() => parseLnAddress('alice@')).toThrow();
+		});
+	});
+
+	describe('graphqlEndpointForDomain', () => {
+		it('maps blink.sv to api.blink.sv', () => {
+			expect(graphqlEndpointForDomain('blink.sv')).toBe('https://api.blink.sv/graphql');
+		});
+		it('prefixes api. for other domains', () => {
+			expect(graphqlEndpointForDomain('example.com')).toBe('https://api.example.com/graphql');
+		});
+		it('does not double-prefix api.', () => {
+			expect(graphqlEndpointForDomain('api.blink.sv')).toBe('https://api.blink.sv/graphql');
+		});
+		it('uses http for localhost', () => {
+			expect(graphqlEndpointForDomain('localhost:4455')).toBe('http://api.localhost:4455/graphql');
+		});
+	});
+
+	describe('mapGraphqlInvoiceStatus', () => {
+		it('maps PAID to paid', () => {
+			expect(mapGraphqlInvoiceStatus('PAID')).toBe('paid');
+		});
+		it('maps EXPIRED to expired', () => {
+			expect(mapGraphqlInvoiceStatus('EXPIRED')).toBe('expired');
+		});
+		it('maps PENDING and unknown/null to pending', () => {
+			expect(mapGraphqlInvoiceStatus('PENDING')).toBe('pending');
+			expect(mapGraphqlInvoiceStatus(null)).toBe('pending');
+			expect(mapGraphqlInvoiceStatus(undefined)).toBe('pending');
+			expect(mapGraphqlInvoiceStatus('SOMETHING_ELSE')).toBe('pending');
+		});
+	});
+
+	describe('validatePreimage', () => {
+		it('accepts a preimage whose sha256 equals the payment hash', () => {
+			const preimage = randomBytes(32).toString('hex');
+			const paymentHash = createHash('sha256').update(Buffer.from(preimage, 'hex')).digest('hex');
+			expect(validatePreimage(preimage, paymentHash)).toBe(true);
+		});
+		it('is case-insensitive on the payment hash', () => {
+			const preimage = randomBytes(32).toString('hex');
+			const paymentHash = createHash('sha256').update(Buffer.from(preimage, 'hex')).digest('hex');
+			expect(validatePreimage(preimage, paymentHash.toUpperCase())).toBe(true);
+		});
+		it('rejects a mismatched preimage', () => {
+			const preimage = randomBytes(32).toString('hex');
+			const wrongHash = createHash('sha256').update(Buffer.from('deadbeef', 'hex')).digest('hex');
+			expect(validatePreimage(preimage, wrongHash)).toBe(false);
+		});
+		it('rejects a malformed preimage', () => {
+			expect(validatePreimage('not-hex', 'a'.repeat(64))).toBe(false);
+			expect(validatePreimage('abcd', 'a'.repeat(64))).toBe(false);
+		});
+	});
+});

--- a/src/lib/server/blink.ts
+++ b/src/lib/server/blink.ts
@@ -1,0 +1,475 @@
+import { createHash } from 'crypto';
+import { z } from 'zod';
+import { runtimeConfig } from './runtime-config';
+
+/**
+ * Blink Lightning client — receive-only, BTC-only.
+ *
+ * Supports the three receive modes of the Blink BTCPay plugin, selected from config:
+ *   (a) api-key custodial  — `blink.apiKey` set: authenticated GraphQL at api.blink.sv
+ *   (b) ln-address custodial — `blink.lnAddress` resolves a Blink-hosted wallet via the
+ *       public (no-key) GraphQL `accountDefaultWallet` probe; invoices minted + polled via GraphQL
+ *   (c) ln-address non-custodial (Spark) — `blink.lnAddress` that does NOT resolve to a
+ *       custodial wallet: LNURL-pay to fetch a bolt11 + LUD-21 verify URL for settlement
+ *
+ * be-BOP shows Blink's bolt11 directly (no re-served LNURL), so the plugin's LNURL request
+ * filter / description-hash mirroring is not needed here. Settlement is driven by be-BOP's
+ * existing 2s order poller calling checkPayment(), so no separate poll loop is needed.
+ */
+
+// Blink's HTTP API can hang on bad credentials / network blips. Fail fast (mirrors
+// swiss-bitcoin-pay.ts) so checkout and the admin "test connection" button don't stall.
+const BLINK_HTTP_TIMEOUT_MS = 15_000;
+
+export function isBlinkConfigured(): boolean {
+	return !!(runtimeConfig.blink?.apiKey || runtimeConfig.blink?.lnAddress);
+}
+
+// --- Mode resolution ---
+
+export type BlinkMode =
+	| { mode: 'api-key' }
+	| { mode: 'custodial'; walletId: string }
+	| { mode: 'spark' };
+
+/**
+ * Parse `user@domain` (or bare `user` → `user@blink.sv`) into its parts.
+ */
+export function parseLnAddress(lnAddress: string): { username: string; domain: string } {
+	const trimmed = lnAddress.trim();
+	const [username, domain] = trimmed.includes('@') ? trimmed.split('@') : [trimmed, 'blink.sv'];
+	if (!username || !domain) {
+		throw new Error(`Invalid Blink Lightning address: ${lnAddress}`);
+	}
+	return { username: username.toLowerCase(), domain: domain.toLowerCase() };
+}
+
+/**
+ * Derive the GraphQL endpoint for a Blink domain.
+ * blink.sv → https://api.blink.sv/graphql ; otherwise https://api.{domain}/graphql
+ */
+export function graphqlEndpointForDomain(domain: string): string {
+	const host = domain.startsWith('api.') ? domain : `api.${domain}`;
+	const scheme = domain.startsWith('localhost') ? 'http' : 'https';
+	return `${scheme}://${host}/graphql`;
+}
+
+// Cache confident custodial/spark verdicts per address so we don't probe every payment.
+const accountKindCache = new Map<string, BlinkMode>();
+
+/**
+ * Resolve which mode applies given current config. Called at createPayment time.
+ * At checkPayment time we instead discriminate from persisted payment fields (see PPBlink).
+ */
+export async function blinkResolveMode(): Promise<BlinkMode> {
+	if (runtimeConfig.blink.apiKey) {
+		return { mode: 'api-key' };
+	}
+	if (!runtimeConfig.blink.lnAddress) {
+		throw new Error('Blink is not configured');
+	}
+
+	const { username, domain } = parseLnAddress(runtimeConfig.blink.lnAddress);
+	const cacheKey = `${domain}|${username}`;
+	const cached = accountKindCache.get(cacheKey);
+	if (cached) {
+		return cached;
+	}
+
+	// Public no-API-key probe: does this username resolve to a custodial Blink wallet?
+	const query = `query AccountDefaultWallet($username: Username!, $walletCurrency: WalletCurrency) {
+		accountDefaultWallet(username: $username, walletCurrency: $walletCurrency) { id walletCurrency }
+	}`;
+	try {
+		const data = await blinkGraphql<{
+			accountDefaultWallet?: { id?: string; walletCurrency?: string } | null;
+		}>(graphqlEndpointForDomain(domain), query, { username, walletCurrency: 'BTC' });
+		const walletId = data?.accountDefaultWallet?.id;
+		if (walletId) {
+			const verdict: BlinkMode = { mode: 'custodial', walletId };
+			accountKindCache.set(cacheKey, verdict);
+			return verdict;
+		}
+		// Resolved with no wallet id → treat as spark, but don't cache (ambiguous).
+		return { mode: 'spark' };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (/does not exist/i.test(message)) {
+			// Confident: not a Blink custodial account → non-custodial Spark.
+			const verdict: BlinkMode = { mode: 'spark' };
+			accountKindCache.set(cacheKey, verdict);
+			return verdict;
+		}
+		// Ambiguous (rate-limit, transient) → assume spark for this call, don't cache.
+		return { mode: 'spark' };
+	}
+}
+
+// --- GraphQL transport ---
+
+async function blinkGraphql<T>(
+	endpoint: string,
+	query: string,
+	variables: Record<string, unknown>,
+	apiKey?: string
+): Promise<T> {
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json',
+		'user-agent': 'be-BOP'
+	};
+	if (apiKey) {
+		headers['X-API-KEY'] = apiKey;
+	}
+
+	const response = await fetch(endpoint, {
+		method: 'POST',
+		headers,
+		body: JSON.stringify({ query, variables }),
+		signal: AbortSignal.timeout(BLINK_HTTP_TIMEOUT_MS)
+	});
+
+	if (!response.ok) {
+		throw new Error(`Blink GraphQL request failed: ${response.status} ${response.statusText}`);
+	}
+
+	const json = z
+		.object({
+			data: z.unknown().nullable().optional(),
+			errors: z.array(z.object({ message: z.string() })).optional()
+		})
+		.parse(await response.json());
+
+	if (json.errors?.length) {
+		throw new Error(json.errors[0].message);
+	}
+	if (json.data === null || json.data === undefined) {
+		throw new Error('Blink GraphQL response contained no data');
+	}
+	return json.data as T;
+}
+
+const invoiceCreateResult = z.object({
+	invoice: z.object({ paymentHash: z.string(), paymentRequest: z.string() }).nullable().optional(),
+	errors: z.array(z.object({ message: z.string() })).optional()
+});
+
+/**
+ * Mint a BTC lightning invoice for a given wallet via `lnInvoiceCreateOnBehalfOfRecipient`.
+ * Used by both api-key (authenticated) and custodial-ln-address (public) modes.
+ * Returns { paymentRequest (bolt11), paymentHash }.
+ */
+async function blinkCreateInvoiceOnBehalf(params: {
+	endpoint: string;
+	walletId: string;
+	amountSat: number;
+	memo: string;
+	expiresInMinutes: number;
+	apiKey?: string;
+}): Promise<{ paymentRequest: string; paymentHash: string }> {
+	const mutation = `mutation CreateInvoice($input: LnInvoiceCreateOnBehalfOfRecipientInput!) {
+		lnInvoiceCreateOnBehalfOfRecipient(input: $input) {
+			invoice { paymentHash paymentRequest }
+			errors { message }
+		}
+	}`;
+	const data = await blinkGraphql<{
+		lnInvoiceCreateOnBehalfOfRecipient: z.infer<typeof invoiceCreateResult>;
+	}>(
+		params.endpoint,
+		mutation,
+		{
+			input: {
+				recipientWalletId: params.walletId,
+				amount: params.amountSat,
+				memo: params.memo,
+				expiresIn: params.expiresInMinutes
+			}
+		},
+		params.apiKey
+	);
+	const payload = invoiceCreateResult.parse(data.lnInvoiceCreateOnBehalfOfRecipient);
+	if (!payload.invoice) {
+		throw new Error(payload.errors?.[0]?.message ?? 'Blink returned no invoice');
+	}
+	return payload.invoice;
+}
+
+/**
+ * Resolve the account default wallet for API-key mode (unless walletId is configured).
+ * Rejects non-BTC wallets (be-BOP Blink support is BTC-only).
+ */
+async function blinkResolveApiKeyWallet(): Promise<string> {
+	if (runtimeConfig.blink.walletId) {
+		return runtimeConfig.blink.walletId;
+	}
+	const query = `query GetDefaultWallet {
+		me { defaultAccount { defaultWallet { id walletCurrency } } }
+	}`;
+	const data = await blinkGraphql<{
+		me?: { defaultAccount?: { defaultWallet?: { id?: string; walletCurrency?: string } } };
+	}>('https://api.blink.sv/graphql', query, {}, runtimeConfig.blink.apiKey);
+	const wallet = data?.me?.defaultAccount?.defaultWallet;
+	if (!wallet?.id) {
+		throw new Error('Could not resolve a default Blink wallet');
+	}
+	if (wallet.walletCurrency && wallet.walletCurrency !== 'BTC') {
+		throw new Error(
+			`Blink default wallet is ${wallet.walletCurrency}; be-BOP supports BTC wallets only. ` +
+				`Set a BTC wallet id in the Blink admin settings.`
+		);
+	}
+	return wallet.id;
+}
+
+// --- Public create/check API used by the SDK adapter ---
+
+export interface BlinkCreatedInvoice {
+	/** bolt11 payment request — goes into OrderPayment.address */
+	paymentRequest: string;
+	/** payment hash — goes into OrderPayment.invoiceId */
+	paymentHash: string;
+	/** Spark LUD-21 verify URL — goes into OrderPayment.checkoutId (mode 'spark' only) */
+	verifyUrl?: string;
+}
+
+/**
+ * Create a Blink invoice for `amountSat`, dispatching on the resolved mode.
+ */
+export async function blinkCreateInvoice(params: {
+	amountSat: number;
+	memo: string;
+	expiresInMinutes: number;
+}): Promise<BlinkCreatedInvoice> {
+	const resolved = await blinkResolveMode();
+
+	if (resolved.mode === 'api-key') {
+		const walletId = await blinkResolveApiKeyWallet();
+		return await blinkCreateInvoiceOnBehalf({
+			endpoint: 'https://api.blink.sv/graphql',
+			walletId,
+			amountSat: params.amountSat,
+			memo: params.memo,
+			expiresInMinutes: params.expiresInMinutes,
+			apiKey: runtimeConfig.blink.apiKey
+		});
+	}
+
+	const { username, domain } = parseLnAddress(runtimeConfig.blink.lnAddress);
+
+	if (resolved.mode === 'custodial') {
+		return await blinkCreateInvoiceOnBehalf({
+			endpoint: graphqlEndpointForDomain(domain),
+			walletId: resolved.walletId,
+			amountSat: params.amountSat,
+			memo: params.memo,
+			expiresInMinutes: params.expiresInMinutes
+		});
+	}
+
+	// mode 'spark' — LNURL-pay + LUD-21 verify
+	return await sparkCreateInvoice({ username, domain, amountSat: params.amountSat });
+}
+
+/**
+ * Non-custodial Spark receive: resolve the LNURL-pay endpoint, request an invoice for the
+ * exact amount, and capture the LUD-21 verify URL for settlement polling.
+ */
+async function sparkCreateInvoice(params: {
+	username: string;
+	domain: string;
+	amountSat: number;
+}): Promise<BlinkCreatedInvoice> {
+	const scheme = params.domain.startsWith('localhost') ? 'http' : 'https';
+	const metadataUrl = `${scheme}://${params.domain}/.well-known/lnurlp/${encodeURIComponent(
+		params.username
+	)}`;
+
+	const metaResp = await fetch(metadataUrl, {
+		headers: { 'user-agent': 'be-BOP' },
+		signal: AbortSignal.timeout(BLINK_HTTP_TIMEOUT_MS)
+	});
+	if (!metaResp.ok) {
+		throw new Error(`LNURL-pay endpoint unavailable: ${metaResp.status} ${metaResp.statusText}`);
+	}
+	const meta = z
+		.object({
+			tag: z.string().optional(),
+			callback: z.string().optional(),
+			minSendable: z.number().optional(),
+			maxSendable: z.number().optional(),
+			status: z.string().optional(),
+			reason: z.string().optional()
+		})
+		.parse(await metaResp.json());
+
+	if (meta.status === 'ERROR') {
+		throw new Error(meta.reason ?? 'LNURL-pay endpoint returned an error');
+	}
+	if (meta.tag !== 'payRequest' || !meta.callback) {
+		throw new Error('Not a valid LNURL-pay endpoint');
+	}
+
+	const amountMsat = params.amountSat * 1000;
+	if (meta.minSendable !== undefined && amountMsat < meta.minSendable) {
+		throw new Error(`Amount below Lightning address minimum (${meta.minSendable} msat)`);
+	}
+	if (meta.maxSendable !== undefined && amountMsat > meta.maxSendable) {
+		throw new Error(`Amount above Lightning address maximum (${meta.maxSendable} msat)`);
+	}
+
+	const callbackUrl = new URL(meta.callback);
+	callbackUrl.searchParams.set('amount', String(amountMsat));
+
+	const cbResp = await fetch(callbackUrl, {
+		headers: { 'user-agent': 'be-BOP' },
+		signal: AbortSignal.timeout(BLINK_HTTP_TIMEOUT_MS)
+	});
+	if (!cbResp.ok) {
+		throw new Error(`LNURL-pay callback failed: ${cbResp.status} ${cbResp.statusText}`);
+	}
+	const cb = z
+		.object({
+			pr: z.string().optional(),
+			verify: z.string().optional(),
+			status: z.string().optional(),
+			reason: z.string().optional()
+		})
+		.parse(await cbResp.json());
+
+	if (cb.status === 'ERROR') {
+		throw new Error(cb.reason ?? 'LNURL-pay callback returned an error');
+	}
+	if (!cb.pr) {
+		throw new Error('LNURL-pay callback did not return an invoice');
+	}
+
+	// The verify URL host serves LUD-21; derive the payment hash from it when present so we
+	// don't need a bolt11 decoder (matches the plugin's "verify key is authoritative" stance).
+	const verifyUrl = cb.verify;
+	const paymentHash = verifyUrl ? verifyUrl.split('/').pop() ?? '' : '';
+	if (!verifyUrl || !paymentHash) {
+		throw new Error('LNURL-pay callback did not return a LUD-21 verify URL');
+	}
+
+	return { paymentRequest: cb.pr, paymentHash, verifyUrl };
+}
+
+// --- Status checking ---
+
+export type BlinkInvoiceStatus = 'paid' | 'pending' | 'expired';
+
+export function mapGraphqlInvoiceStatus(status: string | null | undefined): BlinkInvoiceStatus {
+	switch (status) {
+		case 'PAID':
+			return 'paid';
+		case 'EXPIRED':
+			return 'expired';
+		default:
+			return 'pending';
+	}
+}
+
+/**
+ * Check an API-key-mode invoice via `invoiceByPaymentHash` under the wallet.
+ */
+async function blinkCheckApiKeyInvoice(paymentHash: string): Promise<BlinkInvoiceStatus> {
+	const walletId = await blinkResolveApiKeyWallet();
+	const query = `query InvoiceByPaymentHash($paymentHash: PaymentHash!, $walletId: WalletId!) {
+		me { defaultAccount { walletById(walletId: $walletId) {
+			invoiceByPaymentHash(paymentHash: $paymentHash) { paymentStatus }
+		} } }
+	}`;
+	const data = await blinkGraphql<{
+		me?: {
+			defaultAccount?: {
+				walletById?: { invoiceByPaymentHash?: { paymentStatus?: string } };
+			};
+		};
+	}>('https://api.blink.sv/graphql', query, { paymentHash, walletId }, runtimeConfig.blink.apiKey);
+	return mapGraphqlInvoiceStatus(
+		data?.me?.defaultAccount?.walletById?.invoiceByPaymentHash?.paymentStatus
+	);
+}
+
+/**
+ * Check a custodial-ln-address invoice via the public `lnInvoicePaymentStatusByHash` query.
+ * Ledger-aware: reports PAID even for intraledger (Blink-app) payments that LUD-21 would miss.
+ */
+async function blinkCheckCustodialInvoice(paymentHash: string): Promise<BlinkInvoiceStatus> {
+	const { domain } = parseLnAddress(runtimeConfig.blink.lnAddress);
+	const query = `query PaymentStatus($input: LnInvoicePaymentStatusByHashInput!) {
+		lnInvoicePaymentStatusByHash(input: $input) { status }
+	}`;
+	const data = await blinkGraphql<{
+		lnInvoicePaymentStatusByHash?: { status?: string };
+	}>(graphqlEndpointForDomain(domain), query, { input: { paymentHash } });
+	return mapGraphqlInvoiceStatus(data?.lnInvoicePaymentStatusByHash?.status);
+}
+
+/**
+ * Check a Spark invoice via its LUD-21 verify URL. Paid when `settled === true`.
+ * Validates SHA256(preimage) === paymentHash when a preimage is returned (warn-only on mismatch).
+ */
+async function blinkCheckSparkInvoice(
+	verifyUrl: string,
+	paymentHash: string
+): Promise<BlinkInvoiceStatus | 'failed'> {
+	const resp = await fetch(verifyUrl, {
+		headers: { 'user-agent': 'be-BOP' },
+		signal: AbortSignal.timeout(BLINK_HTTP_TIMEOUT_MS)
+	});
+	if (!resp.ok) {
+		// Transient — let the poller retry.
+		return 'pending';
+	}
+	const json = z
+		.object({
+			status: z.string().optional(),
+			settled: z.boolean().optional(),
+			preimage: z.string().nullable().optional()
+		})
+		.parse(await resp.json());
+
+	if (json.status === 'ERROR') {
+		return 'failed';
+	}
+	if (json.settled) {
+		if (json.preimage && !validatePreimage(json.preimage, paymentHash)) {
+			console.warn(
+				`Blink Spark invoice ${paymentHash} settled but preimage did not match payment hash`
+			);
+		}
+		return 'paid';
+	}
+	return 'pending';
+}
+
+export function validatePreimage(preimage: string, paymentHash: string): boolean {
+	if (!/^[0-9a-fA-F]{64}$/.test(preimage)) {
+		return false;
+	}
+	const computed = createHash('sha256').update(Buffer.from(preimage, 'hex')).digest('hex');
+	return computed.toLowerCase() === paymentHash.trim().toLowerCase();
+}
+
+/**
+ * Look up an invoice's status, dispatching on the persisted payment fields.
+ *
+ * @param paymentHash  OrderPayment.invoiceId
+ * @param verifyUrl    OrderPayment.checkoutId (present ⇒ Spark mode)
+ */
+export async function blinkLookupInvoice(
+	paymentHash: string,
+	verifyUrl?: string
+): Promise<BlinkInvoiceStatus | 'failed'> {
+	if (verifyUrl) {
+		return await blinkCheckSparkInvoice(verifyUrl, paymentHash);
+	}
+	if (runtimeConfig.blink.apiKey) {
+		return await blinkCheckApiKeyInvoice(paymentHash);
+	}
+	if (runtimeConfig.blink.lnAddress) {
+		return await blinkCheckCustodialInvoice(paymentHash);
+	}
+	throw new Error('Blink is not configured');
+}

--- a/src/lib/server/locks/order-lock.ts
+++ b/src/lib/server/locks/order-lock.ts
@@ -75,6 +75,7 @@ async function handleTapToPayCheck(
 					});
 				}
 				break;
+			case 'blink':
 			case 'btcpay-server':
 			case 'paypal':
 			case 'phoenixd':

--- a/src/lib/server/payment-methods.ts
+++ b/src/lib/server/payment-methods.ts
@@ -19,6 +19,7 @@ export type PaymentMethod = (typeof ALL_PAYMENT_METHODS)[number];
 export const ALL_PAYMENT_PROCESSORS = [
 	'bitcoin-nodeless',
 	'bitcoind',
+	'blink',
 	'btcpay-server',
 	'lnd',
 	'paypal',

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -261,6 +261,14 @@ const baseConfig = {
 	swissBitcoinPay: {
 		apiKey: ''
 	},
+	blink: {
+		/** blink_... — when set, uses the API-key custodial GraphQL mode */
+		apiKey: '',
+		/** user@blink.sv — when set (and no apiKey), auto-detects custodial vs non-custodial (Spark) */
+		lnAddress: '',
+		/** Optional wallet id override for API-key mode; empty = account default wallet */
+		walletId: ''
+	},
 	taler: {
 		backendUrl: '',
 		backendApiKey: '',

--- a/src/lib/server/sdk/contrib/PPBlink.ts
+++ b/src/lib/server/sdk/contrib/PPBlink.ts
@@ -1,0 +1,66 @@
+import { isBlinkConfigured, blinkCreateInvoice, blinkLookupInvoice } from '$lib/server/blink';
+import { toSatoshis } from '$lib/utils/toSatoshis';
+import { differenceInMinutes } from 'date-fns';
+import { lightningPaymentPrice, lightningLabel } from '../pp';
+import type {
+	PaymentProcessorDefinition,
+	CreatePaymentParams,
+	CreatePaymentResult,
+	CheckPaymentResult
+} from '../pp';
+import type { Order } from '$lib/types/Order';
+
+/**
+ * Blink Lightning processor (receive-only, BTC-only).
+ *
+ * A single processor covering all three Blink receive modes (api-key custodial,
+ * ln-address custodial, ln-address non-custodial/Spark). The mode is resolved from config
+ * at createPayment time; at checkPayment time it is re-derived from the persisted payment:
+ *   - checkoutId set  ⇒ Spark (LUD-21 verify URL)
+ *   - otherwise       ⇒ GraphQL lookup (api-key or custodial, per current config)
+ */
+export default {
+	meta: { processor: 'blink', method: 'lightning', emoji: '⚡' },
+
+	isEnabled: () => isBlinkConfigured(),
+
+	paymentPrice: lightningPaymentPrice,
+
+	async createPayment(params: CreatePaymentParams): Promise<CreatePaymentResult> {
+		const satoshis = toSatoshis(params.toPay.amount, params.toPay.currency);
+		const memo = lightningLabel(params.orderId, params.orderNumber);
+		// Blink GraphQL expiry is in minutes; default to 60 when no expiry was provided.
+		const expiresInMinutes = params.expiresAt
+			? Math.max(1, differenceInMinutes(params.expiresAt, new Date()))
+			: 60;
+		const invoice = await blinkCreateInvoice({ amountSat: satoshis, memo, expiresInMinutes });
+		return {
+			address: invoice.paymentRequest,
+			invoiceId: invoice.paymentHash,
+			// Spark verify URL persisted here; its presence discriminates the mode at check time.
+			...(invoice.verifyUrl && { checkoutId: invoice.verifyUrl }),
+			processor: 'blink'
+		};
+	},
+
+	async checkPayment(
+		payment: Order['payments'][number],
+		order: Order // eslint-disable-line @typescript-eslint/no-unused-vars
+	): Promise<CheckPaymentResult> {
+		if (!payment.invoiceId) {
+			throw new Error('Missing invoice ID on blink payment');
+		}
+		const status = await blinkLookupInvoice(payment.invoiceId, payment.checkoutId);
+		if (status === 'paid') {
+			// The invoice was for a fixed sat amount; report the payment's sat price as received.
+			return { status: 'paid', received: { amount: payment.price.amount, currency: 'SAT' } };
+		}
+		if (status === 'failed') {
+			return { status: 'failed' };
+		}
+		if (status === 'expired' || (payment.expiresAt && payment.expiresAt < new Date())) {
+			return { status: 'expired' };
+		}
+		return { status: 'pending' };
+	}
+} satisfies PaymentProcessorDefinition;

--- a/src/lib/server/sdk/pp-registry.ts
+++ b/src/lib/server/sdk/pp-registry.ts
@@ -5,6 +5,7 @@ import PPSwissBitcoinPay from './contrib/PPSwissBitcoinPay';
 import PPBtcpayServer from './contrib/PPBtcpayServer';
 import PPPhoenixd from './contrib/PPPhoenixd';
 import PPLnd from './contrib/PPLnd';
+import PPBlink from './contrib/PPBlink';
 import PPBitcoinNodeless from './contrib/PPBitcoinNodeless';
 import PPBitcoind from './contrib/PPBitcoind';
 import PPPaypal from './contrib/PPPaypal';
@@ -17,11 +18,12 @@ import PPOsb from './contrib/PPOsb';
 registerProcessor(PPSumUp);
 registerProcessor(PPStripe);
 
-// lightning: swiss-bitcoin-pay → btcpay-server → phoenixd → lnd
+// lightning: swiss-bitcoin-pay → btcpay-server → phoenixd → lnd → blink
 registerProcessor(PPSwissBitcoinPay);
 registerProcessor(PPBtcpayServer);
 registerProcessor(PPPhoenixd);
 registerProcessor(PPLnd);
+registerProcessor(PPBlink);
 
 // bitcoin: bitcoin-nodeless → bitcoind
 registerProcessor(PPBitcoinNodeless);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
@@ -158,6 +158,10 @@ export const adminLinks: AdminLinks = [
 				label: 'Swiss Bitcoin Pay'
 			},
 			{
+				href: '/admin/blink',
+				label: 'Blink'
+			},
+			{
 				href: '/admin/bitcoind',
 				label: 'Bitcoin core node'
 			},

--- a/src/routes/(app)/admin[[hash=admin_hash]]/blink/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/blink/+page.server.ts
@@ -1,0 +1,60 @@
+import { collections } from '$lib/server/database.js';
+import { runtimeConfig } from '$lib/server/runtime-config';
+import { updateLightningInvoiceDescription } from '$lib/server/actions.js';
+import { rateLimit } from '$lib/server/rateLimit';
+import { testProcessorConnection } from '$lib/server/sdk/test-connection';
+import { z } from 'zod';
+
+export async function load() {
+	return {
+		apiKey: runtimeConfig.blink.apiKey,
+		lnAddress: runtimeConfig.blink.lnAddress,
+		walletId: runtimeConfig.blink.walletId,
+		lightningInvoiceDescription: runtimeConfig.lightningQrCodeDescription
+	};
+}
+
+export const actions = {
+	save: async function ({ request }) {
+		const blink = z
+			.object({
+				apiKey: z.string().trim().default(''),
+				lnAddress: z.string().trim().default(''),
+				walletId: z.string().trim().default('')
+			})
+			.refine((v) => v.apiKey || v.lnAddress, {
+				message: 'Provide either a Lightning address or an API key'
+			})
+			.parse(Object.fromEntries(await request.formData()));
+		await collections.runtimeConfig.updateOne(
+			{
+				_id: 'blink'
+			},
+			{
+				$set: {
+					data: blink,
+					updatedAt: new Date()
+				}
+			},
+			{
+				upsert: true
+			}
+		);
+		runtimeConfig.blink = blink;
+	},
+	delete: async function () {
+		await collections.runtimeConfig.deleteOne({
+			_id: 'blink'
+		});
+		runtimeConfig.blink = {
+			apiKey: '',
+			lnAddress: '',
+			walletId: ''
+		};
+	},
+	updateLightningInvoiceDescription,
+	testConnection: async function ({ locals }) {
+		rateLimit(locals.clientIp, 'pp.test.blink', 5, { minutes: 1 });
+		return await testProcessorConnection('blink');
+	}
+};

--- a/src/routes/(app)/admin[[hash=admin_hash]]/blink/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/blink/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import SetLightningQrCodeDescription from '$lib/components/SetLightningQrCodeDescription.svelte';
+	import { enhance } from '$app/forms';
+	export let data;
+	export let form;
+
+	let testInFlight = false;
+	let testCooldownUntil = 0;
+	$: testDisabled = testInFlight || Date.now() < testCooldownUntil;
+</script>
+
+<h1 class="text-3xl">Blink</h1>
+
+<p class="text-sm">
+	Receive Lightning payments into your Blink account. Configure <strong>one</strong> of the two options
+	below. A Lightning address needs no API key and works for both custodial Blink accounts and self-custodial
+	(Spark) addresses. Only BTC wallets are supported.
+</p>
+
+<form class="contents" method="post" action="?/save">
+	<h2 class="text-2xl">Option 1 — Lightning address (no API key)</h2>
+	<label class="form-label">
+		Lightning address
+		<input
+			class="form-input"
+			type="text"
+			name="lnAddress"
+			placeholder="you@blink.sv"
+			value={data.lnAddress}
+		/>
+	</label>
+
+	<h2 class="text-2xl">Option 2 — API key (custodial account)</h2>
+	<label class="form-label">
+		API Key
+		<input
+			class="form-input"
+			type="password"
+			name="apiKey"
+			placeholder="blink_..."
+			value={data.apiKey}
+		/>
+	</label>
+	<label class="form-label">
+		Wallet ID (optional — defaults to your account's default BTC wallet)
+		<input class="form-input" type="text" name="walletId" value={data.walletId} />
+	</label>
+
+	<div class="flex justify-between">
+		<button class="btn btn-black" type="submit">Save</button>
+		<button class="btn btn-red" type="submit" form="delete-form">Reset</button>
+	</div>
+</form>
+<form class="contents" method="post" action="?/delete" id="delete-form"></form>
+
+<form
+	method="post"
+	action="?/testConnection"
+	use:enhance={() => {
+		testInFlight = true;
+		return async ({ update }) => {
+			await update({ reset: false });
+			testInFlight = false;
+			testCooldownUntil = Date.now() + 10_000;
+		};
+	}}
+	class="flex flex-col gap-2"
+>
+	<button class="btn btn-blue self-start" type="submit" disabled={testDisabled}>
+		{testInFlight ? 'Testing…' : 'Test connection'}
+	</button>
+	{#if form?.ok}
+		<div class="alert-success">Connection successful. Blink credentials are working.</div>
+	{:else if form?.reason}
+		<div class="alert-error">Connection failed: {form.reason}</div>
+	{/if}
+</form>
+
+<h2 class="text-2xl">Invoices</h2>
+
+<SetLightningQrCodeDescription
+	bind:invoiceDescription={data.lightningInvoiceDescription}
+	bind:brandName={data.brandName}
+	showThirdPartyWarning={true}
+/>

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
@@ -24,6 +24,7 @@ import { isLndConfigured } from '$lib/server/lnd';
 import { isPhoenixdConfigured } from '$lib/server/phoenixd';
 import { isSwissBitcoinPayConfigured } from '$lib/server/swiss-bitcoin-pay';
 import { isBtcpayServerConfigured } from '$lib/server/btcpay-server';
+import { isBlinkConfigured } from '$lib/server/blink';
 import { logAccountingEvent, employeeFromLocals } from '$lib/server/accounting-log';
 import { SUBSCRIPTION_DURATIONS } from '$lib/types/SubscriptionDuration';
 
@@ -87,6 +88,7 @@ export async function load(event) {
 		phoenixdConfigured: isPhoenixdConfigured(),
 		swissBitcoinPayConfigured: isSwissBitcoinPayConfigured(),
 		btcpayServerConfigured: isBtcpayServerConfigured(),
+		blinkConfigured: isBlinkConfigured(),
 		dataCleanup: runtimeConfig.dataCleanup
 	};
 }
@@ -158,7 +160,7 @@ export const actions = {
 				preferredProcessorCard: z.enum(['sumup', 'stripe', '']).optional(),
 				preferredProcessorBitcoin: z.enum(['bitcoind', 'bitcoin-nodeless', '']).optional(),
 				preferredProcessorLightning: z
-					.enum(['lnd', 'phoenixd', 'swiss-bitcoin-pay', 'btcpay-server', ''])
+					.enum(['lnd', 'phoenixd', 'swiss-bitcoin-pay', 'btcpay-server', 'blink', ''])
 					.optional()
 			})
 			.parse({

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
@@ -156,7 +156,8 @@
 		{ name: 'swiss-bitcoin-pay' as const, configured: data.swissBitcoinPayConfigured },
 		{ name: 'btcpay-server' as const, configured: data.btcpayServerConfigured },
 		{ name: 'phoenixd' as const, configured: data.phoenixdConfigured },
-		{ name: 'lnd' as const, configured: data.lndConfigured }
+		{ name: 'lnd' as const, configured: data.lndConfigured },
+		{ name: 'blink' as const, configured: data.blinkConfigured }
 	]
 		.filter((p) => p.configured)
 		.map((p) => p.name);
@@ -627,6 +628,7 @@
 			{ href: `${data.adminPrefix}/phoenixd`, name: 'PhoenixD' },
 			{ href: `${data.adminPrefix}/swiss-bitcoin-pay`, name: 'Swiss Bitcoin Pay' },
 			{ href: `${data.adminPrefix}/btcpay-server`, name: 'BTCPay Server' },
+			{ href: `${data.adminPrefix}/blink`, name: 'Blink' },
 			{ href: '#', name: 'LND via environment variables' }
 		]}
 	/>


### PR DESCRIPTION
New 'blink' processor for the existing lightning method. Supports three receive modes: API-key custodial GraphQL (api.blink.sv), ln-address custodial, and ln-address non-custodial (Spark/LNURL + LUD-21 verify). Payment detection via the existing order poller (no subscriptions).

- blink.ts: low-level GraphQL/LNURL client + pure helpers
- PPBlink.ts: PaymentProcessorDefinition adapter (lightning)
- admin/blink: DB-backed config UI (lnAddress or apiKey, BTC-only)
- register in pp-registry, payment-methods, config, adminLinks, order-lock

(courtesy of pretyflaco on #2693, cloning the PR for artifact release & test process)