### PR TITLE
🆕🔌 API v1: conditional GETs — ETag / If-None-Match / 304 on reads (#2713)

### DIFF
--- a/docs/en/api/v1-architecture.md
+++ b/docs/en/api/v1-architecture.md
@@ -114,7 +114,7 @@ src/lib/server/api/
     cors.ts
     errors.ts
     openapi.ts
-    validators.ts              # ETag / If-Match helpers (not wired to writes yet)
+    validators.ts              # ETag / If-Match helpers (wired to GET reads, never to writes)
     schemas/orders-write.ts
     orders/
       writeBatch.ts
@@ -147,15 +147,21 @@ src/lib/types/ApiKey.ts
 - **Batch over chatty APIs** — 1–100 orders/request
 - **Idempotent retries** — safe PoS replays
 - **Versioned surface** — `/api/v1` only; breaking changes → `/api/v2`
-- **Read APIs** — `GET /api/v1/catalog/products` (`catalog:read`) and `GET /api/v1/orders/paid` (`orders:read`) share Face A middleware/auth/rate-limit.
+- **Read APIs** — `GET /api/v1/catalog/products` (`catalog:read`) and `GET /api/v1/orders/paid` (`orders:read`) share Face A middleware/auth/rate-limit. Both answer conditional GETs (`ETag` / `If-None-Match` → `304`).
 - **Two faces** — Face A `/api/v1` (API keys) must not be merged with Face B storefront session Bearer ([ADR](./adr-api-faces.md))
 
 ## Conditional requests / ETag (#2713)
 
-Helpers live in `src/lib/server/api/v1/validators.ts` (`buildStrongETag`, `parseIfMatch`, `parseIfNoneMatch`, match helpers) for RFC 9110-style strong validators.
+Helpers live in `src/lib/server/api/v1/validators.ts` (`buildStrongETag`, `parseIfMatch`, `parseIfNoneMatch`, match helpers) for RFC 9110-style strong validators. `jsonWithETag(body, request)` is the single entry point used by the read routes.
 
-- **Not wired** to `POST /api/v1/orders` (batch write has its own idempotency key; no ETag precondition).
-- Intended for future **GET** catalog / orders read routes (#2713 and follow-ups): opaque strong ETags + `If-None-Match` / `If-Match` preconditions.
+- **Wired** to every Face A read: `GET /api/v1/catalog/products`, `GET /api/v1/catalog/products/{id}`, `GET /api/v1/orders/paid`.
+  - The validator is an opaque strong ETag — SHA-256 of the exact serialized JSON body, so it changes iff the representation changes. CORS headers are added afterwards and never feed it.
+  - `If-None-Match` uses weak comparison (`*` and `W/` accepted, per §13.1.2); a match short-circuits to a bodyless `304` repeating the same `ETag`.
+  - Responses carry `Cache-Control: private, no-cache`: per-API-key payloads stay out of shared caches, while clients can still store and revalidate.
+  - Cross-origin callers need the header plumbing in `cors.ts` — `If-None-Match` in `Access-Control-Allow-Headers`, `ETag` in `Access-Control-Expose-Headers`.
+  - Value for a PoS polling `/orders/paid` on a short interval: unchanged pages cost a `304` with no body.
+- **Not wired** to `POST /api/v1/orders` (batch write has its own `(apiKeyId, externalOrderId)` idempotency key; no ETag precondition, no `If-Match`).
+- `ifMatchSatisfied` / `parseIfMatch` stay available but unused: no Face A route accepts a write precondition today.
 
 ## Testing strategy
 
@@ -170,7 +176,7 @@ Helpers live in `src/lib/server/api/v1/validators.ts` (`buildStrongETag`, `parse
 
 - Redis / distributed rate-limit store
 - GraphQL / #2616 full headless cart (Face B — keep separate from Face A)
-- [Wiring ETag validators to write routes](#conditional-requests--etag-2713) (explicit non-goal; see #2713 for reads)
+- [Wiring ETag validators to write routes](#conditional-requests--etag-2713) (explicit non-goal; reads are wired, `POST /api/v1/orders` stays on idempotency keys)
 - Replacing `createOrder` internals
 - Force-stock / upsert semantics
 - Heavy OpenAPI codegen deps (hand-maintained `openapi.ts` + CDN Swagger UI instead)

--- a/docs/en/public-http-api.md
+++ b/docs/en/public-http-api.md
@@ -55,6 +55,21 @@ See [v1 orders write](./api/v1-orders-write.md). Batch, idempotent on `(apiKey, 
 
 Only orders with at least one **paid** payment. Payload includes product lines, optional `uniqueKey` (from storefront `?key=`), and the amount **actually paid**. This replaces a push webhook for partners that prefer to pull (issue #2689). The product-level paid webhook (#2646) is unrelated and not sufficient for this flow.
 
+## Conditional GETs (ETag)
+
+Every read (`/catalog/products`, `/catalog/products/{id}`, `/orders/paid`) returns a strong `ETag` over the JSON body plus `Cache-Control: private, no-cache`. Replay that value in `If-None-Match` and an unchanged representation answers `304 Not Modified` with no body — the cheap way to poll paid orders on a short interval.
+
+```
+GET /api/v1/orders/paid?since=2026-08-16T00:00:00Z
+→ 200  ETag: "9f2b…"
+
+GET /api/v1/orders/paid?since=2026-08-16T00:00:00Z
+If-None-Match: "9f2b…"
+→ 304  ETag: "9f2b…"   (empty body)
+```
+
+`304` still counts against the rate limit. Browser callers read `ETag` through `Access-Control-Expose-Headers`. Writes take no ETag precondition: `POST /api/v1/orders` is idempotent on `(apiKey, externalOrderId)` instead.
+
 ## Storefront unique key (`?key=`)
 
 `/product/{slug}?key=kfdjsfeaz12845ND9xezj91820` preselects a unique artifact secret. It is stored on the cart line and copied onto the order. Pay-what-you-want and light variations coexist with this secret. This is **not** an API key; it is a customer-facing product identifier.

--- a/docs/fr/public-http-api.md
+++ b/docs/fr/public-http-api.md
@@ -55,6 +55,21 @@ Voir [écriture commandes v1](./api/v1-orders-write.md). Lot, idempotent sur `(a
 
 Uniquement les commandes avec au moins un paiement **paid**. Le payload contient les lignes produit, l’éventuel `uniqueKey` (vitrine `?key=`), et le montant **réellement payé**. Ce n’est pas un webhook (issue #2689). Le webhook produit #2646 ne suffit pas pour ce flux.
 
+## GET conditionnels (ETag)
+
+Chaque lecture (`/catalog/products`, `/catalog/products/{id}`, `/orders/paid`) renvoie un `ETag` fort calculé sur le corps JSON, plus `Cache-Control: private, no-cache`. Renvoyez cette valeur dans `If-None-Match` : si la représentation n’a pas changé, la réponse est un `304 Not Modified` sans corps — la façon économique de poller les commandes payées à intervalle court.
+
+```
+GET /api/v1/orders/paid?since=2026-08-16T00:00:00Z
+→ 200  ETag: "9f2b…"
+
+GET /api/v1/orders/paid?since=2026-08-16T00:00:00Z
+If-None-Match: "9f2b…"
+→ 304  ETag: "9f2b…"   (corps vide)
+```
+
+Un `304` compte quand même dans la limite de débit. Les appels navigateur lisent l’`ETag` via `Access-Control-Expose-Headers`. Les écritures n’acceptent aucune précondition ETag : `POST /api/v1/orders` reste idempotent sur `(apiKey, externalOrderId)`.
+
 ## Clé unique vitrine (`?key=`)
 
 `/product/{slug}?key=kfdjsfeaz12845ND9xezj91820` présélectionne un secret d’artefact unique. Il est stocké sur la ligne panier puis copié sur la commande. Le pay-what-you-want et les variations légères cohabitent avec ce secret. Ce n’est **pas** une clé API ; c’est un identifiant produit côté client.

--- a/src/lib/server/api/v1/cors.test.ts
+++ b/src/lib/server/api/v1/cors.test.ts
@@ -48,6 +48,13 @@ describe('api v1 cors', () => {
 		expect(headers.get('Access-Control-Allow-Origin')).not.toBe('*');
 	});
 
+	it('allows If-None-Match and exposes ETag so conditional GETs work cross-origin', () => {
+		const headers = new Headers();
+		applyApiV1CorsHeaders(headers, 'https://a.example', ['https://a.example']);
+		expect(headers.get('Access-Control-Allow-Headers')).toContain('If-None-Match');
+		expect(headers.get('Access-Control-Expose-Headers')).toContain('ETag');
+	});
+
 	it('sets no ACAO header when origin is not allowlisted', () => {
 		const headers = new Headers();
 		applyApiV1CorsHeaders(headers, 'https://evil.example', ['https://a.example']);

--- a/src/lib/server/api/v1/cors.ts
+++ b/src/lib/server/api/v1/cors.ts
@@ -37,7 +37,12 @@ export function applyApiV1CorsHeaders(
 	}
 	headers.set('Access-Control-Allow-Origin', origin);
 	headers.set('Vary', 'Origin');
-	headers.set('Access-Control-Allow-Headers', 'Authorization, Content-Type, X-Api-Key');
+	headers.set(
+		'Access-Control-Allow-Headers',
+		'Authorization, Content-Type, X-Api-Key, If-None-Match'
+	);
+	// Without this a cross-origin caller cannot read the validator it needs to send back.
+	headers.set('Access-Control-Expose-Headers', 'ETag, Retry-After');
 	headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
 	headers.set('Access-Control-Max-Age', '86400');
 }

--- a/src/lib/server/api/v1/openapi.test.ts
+++ b/src/lib/server/api/v1/openapi.test.ts
@@ -56,6 +56,33 @@ describe('buildOpenApiDocument', () => {
 		]);
 	});
 
+	it('documents conditional GETs (ETag / If-None-Match / 304) on reads only', () => {
+		type LooseOperation = {
+			parameters?: Array<{ name: string }>;
+			responses: Record<string, { headers?: Record<string, unknown>; content?: unknown }>;
+		};
+		const paths = buildOpenApiDocument().paths as unknown as Record<
+			string,
+			Record<string, LooseOperation>
+		>;
+		for (const path of [
+			'/api/v1/catalog/products',
+			'/api/v1/catalog/products/{id}',
+			'/api/v1/orders/paid'
+		]) {
+			const op = paths[path].get;
+			expect(op.parameters?.some((param) => param.name === 'If-None-Match')).toBe(true);
+			expect(op.responses['200'].headers?.ETag).toBeTruthy();
+			expect(op.responses['304']).toBeTruthy();
+			expect(op.responses['304'].headers?.ETag).toBeTruthy();
+			expect(op.responses['304'].content).toBeUndefined();
+		}
+		// Writes stay on idempotency keys: no validator, no precondition.
+		const post = paths['/api/v1/orders'].post;
+		expect(post.responses['304']).toBeUndefined();
+		expect(post.responses['200'].headers).toBeUndefined();
+	});
+
 	it('strongly recommends externalPaymentId on OrderPayment and shows it in example', () => {
 		const doc = buildOpenApiDocument();
 		const payment = doc.components.schemas.OrderPayment;

--- a/src/lib/server/api/v1/openapi.ts
+++ b/src/lib/server/api/v1/openapi.ts
@@ -206,6 +206,32 @@ export function buildOpenApiDocument(opts?: { serverUrl?: string }) {
 
 	const errorRef = { $ref: '#/components/schemas/ErrorEnvelope' };
 
+	// Conditional GETs (#2713, RFC 9110). Reads only — POST /api/v1/orders relies on
+	// (apiKeyId, externalOrderId) idempotency and takes no ETag precondition.
+	const ifNoneMatchParam = {
+		name: 'If-None-Match',
+		in: 'header',
+		required: false,
+		schema: { type: 'string' },
+		description:
+			'Strong entity-tag returned by a previous read. When it still matches, the server answers 304 with no body.'
+	};
+	const etagResponseHeaders = {
+		ETag: {
+			description:
+				'Strong validator (opaque SHA-256 of the JSON body). Replay it in If-None-Match.',
+			schema: { type: 'string' }
+		},
+		'Cache-Control': {
+			description: 'Always `private, no-cache` — per-API-key payloads must be revalidated.',
+			schema: { type: 'string' }
+		}
+	};
+	const notModifiedResponse = {
+		description: 'Not modified — the If-None-Match validator still matches. Body is empty.',
+		headers: etagResponseHeaders
+	};
+
 	return {
 		openapi: '3.0.3',
 		info: {
@@ -303,6 +329,7 @@ export function buildOpenApiDocument(opts?: { serverUrl?: string }) {
 							schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 }
 						},
 						{ name: 'cursor', in: 'query', schema: { type: 'string' } },
+						ifNoneMatchParam,
 						{
 							name: 'lang',
 							in: 'query',
@@ -313,12 +340,14 @@ export function buildOpenApiDocument(opts?: { serverUrl?: string }) {
 					responses: {
 						'200': {
 							description: 'Catalog page',
+							headers: etagResponseHeaders,
 							content: {
 								'application/json': {
 									schema: { $ref: '#/components/schemas/CatalogListResponse' }
 								}
 							}
 						},
+						'304': notModifiedResponse,
 						'401': {
 							description: 'Missing or invalid API key',
 							content: { 'application/json': { schema: errorRef } }
@@ -357,17 +386,20 @@ export function buildOpenApiDocument(opts?: { serverUrl?: string }) {
 					security: [{ BearerAuth: ['catalog:read'] }, { ApiKeyAuth: ['catalog:read'] }],
 					parameters: [
 						{ name: 'id', in: 'path', required: true, schema: { type: 'string' } },
-						{ name: 'lang', in: 'query', schema: { type: 'string' } }
+						{ name: 'lang', in: 'query', schema: { type: 'string' } },
+						ifNoneMatchParam
 					],
 					responses: {
 						'200': {
 							description: 'Product',
+							headers: etagResponseHeaders,
 							content: {
 								'application/json': {
 									schema: { $ref: '#/components/schemas/CatalogProductResponse' }
 								}
 							}
 						},
+						'304': notModifiedResponse,
 						'404': {
 							description: 'Product not found or not visible',
 							content: { 'application/json': { schema: errorRef } }
@@ -416,17 +448,20 @@ export function buildOpenApiDocument(opts?: { serverUrl?: string }) {
 							in: 'query',
 							schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 }
 						},
-						{ name: 'cursor', in: 'query', schema: { type: 'string' } }
+						{ name: 'cursor', in: 'query', schema: { type: 'string' } },
+						ifNoneMatchParam
 					],
 					responses: {
 						'200': {
 							description: 'Paid orders only. Unpaid rows are never returned.',
+							headers: etagResponseHeaders,
 							content: {
 								'application/json': {
 									schema: { $ref: '#/components/schemas/PaidOrdersResponse' }
 								}
 							}
 						},
+						'304': notModifiedResponse,
 						'401': {
 							description: 'Missing or invalid API key',
 							content: { 'application/json': { schema: errorRef } }

--- a/src/lib/server/api/v1/validators.test.ts
+++ b/src/lib/server/api/v1/validators.test.ts
@@ -3,6 +3,7 @@ import {
 	buildStrongETag,
 	ifMatchSatisfied,
 	ifNoneMatchMatchesCurrent,
+	jsonWithETag,
 	parseEntityTag,
 	parseIfMatch,
 	parseIfNoneMatch,
@@ -86,5 +87,52 @@ describe('ifMatchSatisfied / ifNoneMatchMatchesCurrent', () => {
 		expect(ifNoneMatchMatchesCurrent(current, weakEquivalent)).toBe(true);
 		expect(ifNoneMatchMatchesCurrent(current, '*')).toBe(true);
 		expect(ifNoneMatchMatchesCurrent(current, '"nope"')).toBe(false);
+	});
+});
+
+describe('jsonWithETag', () => {
+	const body = { ok: true, products: [{ id: 'espresso' }] };
+	const get = (headers?: HeadersInit) =>
+		new Request('http://localhost/api/v1/catalog/products', { method: 'GET', headers });
+
+	it('returns 200 with a strong ETag of the serialized body', async () => {
+		const res = jsonWithETag(body, get());
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toBe('application/json');
+		expect(res.headers.get('cache-control')).toBe('private, no-cache');
+		expect(res.headers.get('etag')).toBe(buildStrongETag(JSON.stringify(body)));
+		await expect(res.json()).resolves.toEqual(body);
+	});
+
+	it('returns a bodyless 304 carrying the same validator when If-None-Match matches', async () => {
+		const etag = jsonWithETag(body, get()).headers.get('etag');
+		expect(etag).toBeTruthy();
+		const res = jsonWithETag(body, get({ 'if-none-match': etag as string }));
+		expect(res.status).toBe(304);
+		expect(res.headers.get('etag')).toBe(etag);
+		expect(res.headers.get('cache-control')).toBe('private, no-cache');
+		await expect(res.text()).resolves.toBe('');
+	});
+
+	it('honours weak comparison and * for If-None-Match', () => {
+		const etag = buildStrongETag(JSON.stringify(body));
+		expect(jsonWithETag(body, get({ 'if-none-match': `W/${etag}` })).status).toBe(304);
+		expect(jsonWithETag(body, get({ 'if-none-match': '*' })).status).toBe(304);
+		expect(jsonWithETag(body, get({ 'if-none-match': `"stale", ${etag}` })).status).toBe(304);
+	});
+
+	it('returns 200 when the representation changed or the header is unusable', () => {
+		const stale = buildStrongETag(JSON.stringify({ ok: true, products: [] }));
+		expect(jsonWithETag(body, get({ 'if-none-match': stale })).status).toBe(200);
+		expect(jsonWithETag(body, get({ 'if-none-match': 'garbage' })).status).toBe(200);
+		expect(jsonWithETag(body, get({ 'if-none-match': '' })).status).toBe(200);
+	});
+
+	it('keeps extra headers on both 200 and 304', () => {
+		const etag = buildStrongETag(JSON.stringify(body));
+		const ok = jsonWithETag(body, get(), { 'X-Test': 'a' });
+		const notModified = jsonWithETag(body, get({ 'if-none-match': etag }), { 'X-Test': 'a' });
+		expect(ok.headers.get('x-test')).toBe('a');
+		expect(notModified.headers.get('x-test')).toBe('a');
 	});
 });

--- a/src/lib/server/api/v1/validators.ts
+++ b/src/lib/server/api/v1/validators.ts
@@ -1,6 +1,7 @@
 /**
- * HTTP conditional-request helpers (RFC 9110 spirit) for future Face A GET routes.
+ * HTTP conditional-request helpers (RFC 9110 spirit) for Face A GET routes.
  *
+ * Wired to the read routes (catalog list/detail, paid-orders poll) via `jsonWithETag`.
  * NOT wired to POST /api/v1/orders — batch writes use (apiKeyId, externalOrderId)
  * idempotency instead. See docs/en/api/v1-architecture.md (#2713).
  */
@@ -141,4 +142,28 @@ export function ifNoneMatchMatchesCurrent(
 		}
 	}
 	return false;
+}
+
+/**
+ * JSON 200 carrying a strong ETag of the exact serialized bytes, short-circuited to a
+ * bodyless 304 when If-None-Match already matches (RFC 9110 §13.1.2 / §15.4.5).
+ *
+ * `Cache-Control: private, no-cache` keeps per-API-key payloads out of shared caches while
+ * still letting a client store the representation and revalidate it with the validator.
+ * CORS headers are added afterwards by `apiV1Handler`, so they never feed the ETag.
+ */
+export function jsonWithETag(body: unknown, request: Request, headersInit?: HeadersInit): Response {
+	const payload = JSON.stringify(body);
+	const etag = buildStrongETag(payload);
+	const headers = new Headers(headersInit);
+	headers.set('ETag', etag);
+	headers.set('Cache-Control', 'private, no-cache');
+
+	if (ifNoneMatchMatchesCurrent(etag, request.headers.get('if-none-match'))) {
+		// 304 must not carry a body, and repeats the validator it would have sent on 200.
+		return new Response(null, { status: 304, headers });
+	}
+
+	headers.set('Content-Type', 'application/json');
+	return new Response(payload, { status: 200, headers });
 }

--- a/src/routes/api/v1/catalog/products/+server.ts
+++ b/src/routes/api/v1/catalog/products/+server.ts
@@ -1,7 +1,8 @@
-import { json, type RequestHandler } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
 import { apiV1Handler, apiV1OptionsHandler } from '$lib/server/api/v1/handler';
 import { requireApiKey } from '$lib/server/api/v1/auth';
 import { apiError } from '$lib/server/api/v1/errors';
+import { jsonWithETag } from '$lib/server/api/v1/validators';
 import { listCatalogProducts } from '$lib/server/api/v1/catalog/listProducts';
 import { checkRateLimit } from '$lib/server/rateLimit';
 import { runtimeConfig } from '$lib/server/runtime-config';
@@ -35,10 +36,13 @@ export const GET: RequestHandler = apiV1Handler(async (event) => {
 		runtimeConfig.defaultLanguage as LanguageKey
 	);
 
-	return json({
-		ok: true,
-		language: result.language,
-		products: result.products,
-		page: result.page
-	});
+	return jsonWithETag(
+		{
+			ok: true,
+			language: result.language,
+			products: result.products,
+			page: result.page
+		},
+		event.request
+	);
 });

--- a/src/routes/api/v1/catalog/products/[id]/+server.ts
+++ b/src/routes/api/v1/catalog/products/[id]/+server.ts
@@ -1,7 +1,8 @@
-import { json, type RequestHandler } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
 import { apiV1Handler, apiV1OptionsHandler } from '$lib/server/api/v1/handler';
 import { requireApiKey } from '$lib/server/api/v1/auth';
 import { apiError } from '$lib/server/api/v1/errors';
+import { jsonWithETag } from '$lib/server/api/v1/validators';
 import { getCatalogProduct, parseCatalogLanguage } from '$lib/server/api/v1/catalog/listProducts';
 import { checkRateLimit } from '$lib/server/rateLimit';
 import { runtimeConfig } from '$lib/server/runtime-config';
@@ -34,5 +35,5 @@ export const GET: RequestHandler = apiV1Handler(async (event) => {
 	if (!product) {
 		return apiError(404, 'NOT_FOUND', 'Product not found');
 	}
-	return json({ ok: true, language, product });
+	return jsonWithETag({ ok: true, language, product }, event.request);
 });

--- a/src/routes/api/v1/catalog/products/[id]/server.test.ts
+++ b/src/routes/api/v1/catalog/products/[id]/server.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
+const requireApiKey = vi.fn();
+const checkRateLimit = vi.fn();
+const getCatalogProduct = vi.fn();
+
+vi.mock('$lib/server/api/v1/auth', () => ({
+	requireApiKey: (...args: unknown[]) => requireApiKey(...args)
+}));
+vi.mock('$lib/server/rateLimit', () => ({
+	checkRateLimit: (...args: unknown[]) => checkRateLimit(...args)
+}));
+vi.mock('$lib/server/api/v1/catalog/listProducts', () => ({
+	getCatalogProduct: (...args: unknown[]) => getCatalogProduct(...args),
+	parseCatalogLanguage: (lang: string | undefined, fallback: string) => lang ?? fallback
+}));
+vi.mock('$lib/server/runtime-config', () => ({
+	runtimeConfig: { defaultLanguage: 'en', apiV1: { corsOrigins: [] } }
+}));
+
+import { GET } from './+server';
+
+function call(opts?: { ifNoneMatch?: string }) {
+	const headers = new Headers();
+	if (opts?.ifNoneMatch) {
+		headers.set('if-none-match', opts.ifNoneMatch);
+	}
+	const locals = {
+		apiKey: {
+			_id: new ObjectId(),
+			name: 't',
+			scopes: ['catalog:read'] as const,
+			keyPrefix: 'bebop_ak_test_abcd1234'
+		},
+		clientIp: '203.0.113.50'
+	};
+	const url = 'http://localhost/api/v1/catalog/products/espresso';
+	return GET({
+		request: new Request(url, { method: 'GET', headers }),
+		url: new URL(url),
+		params: { id: 'espresso' },
+		locals
+	} as unknown as Parameters<typeof GET>[0]);
+}
+
+describe('GET /api/v1/catalog/products/[id]', () => {
+	beforeEach(() => {
+		requireApiKey.mockReset();
+		checkRateLimit.mockReset();
+		checkRateLimit.mockReturnValue({ limited: false });
+		getCatalogProduct.mockReset();
+		requireApiKey.mockImplementation(
+			async (event: { locals: { apiKey?: unknown } }) => event.locals.apiKey
+		);
+		getCatalogProduct.mockResolvedValue({ id: 'espresso', name: 'Espresso', type: 'resource' });
+	});
+
+	it('requires catalog:read and returns the product', async () => {
+		const res = await call();
+		expect(requireApiKey.mock.calls[0][1]).toBe('catalog:read');
+		expect(res.status).toBe(200);
+		await expect(res.json()).resolves.toMatchObject({ ok: true, product: { id: 'espresso' } });
+	});
+
+	it('exposes a strong ETag and answers 304 on a matching If-None-Match', async () => {
+		const etag = (await call()).headers.get('etag');
+		expect(etag).toMatch(/^"[a-f0-9]{64}"$/);
+
+		const res = await call({ ifNoneMatch: etag as string });
+		expect(res.status).toBe(304);
+		expect(res.headers.get('etag')).toBe(etag);
+		await expect(res.text()).resolves.toBe('');
+	});
+
+	it('returns 404 without a validator when the product is not visible', async () => {
+		getCatalogProduct.mockResolvedValueOnce(null);
+		const res = await call();
+		expect(res.status).toBe(404);
+		expect(res.headers.get('etag')).toBeNull();
+	});
+});

--- a/src/routes/api/v1/catalog/products/server.test.ts
+++ b/src/routes/api/v1/catalog/products/server.test.ts
@@ -19,10 +19,13 @@ vi.mock('$lib/server/runtime-config', () => ({
 
 import { GET } from './+server';
 
-function call(opts?: { origin?: string; query?: string }) {
+function call(opts?: { origin?: string; query?: string; ifNoneMatch?: string }) {
 	const headers = new Headers();
 	if (opts?.origin) {
 		headers.set('origin', opts.origin);
+	}
+	if (opts?.ifNoneMatch) {
+		headers.set('if-none-match', opts.ifNoneMatch);
 	}
 	const locals = {
 		apiKey: {
@@ -75,6 +78,31 @@ describe('GET /api/v1/catalog/products', () => {
 		expect(body.ok).toBe(true);
 		expect(body.products[0].id).toBe('espresso');
 		expect(res.headers.get('access-control-allow-origin')).toBe('https://allowed.example');
+	});
+
+	it('exposes a strong ETag and answers 304 on a matching If-None-Match', async () => {
+		const first = await call();
+		const etag = first.headers.get('etag');
+		expect(etag).toMatch(/^"[a-f0-9]{64}"$/);
+		expect(first.headers.get('cache-control')).toBe('private, no-cache');
+
+		const second = await call({ ifNoneMatch: etag as string });
+		expect(second.status).toBe(304);
+		expect(second.headers.get('etag')).toBe(etag);
+		await expect(second.text()).resolves.toBe('');
+	});
+
+	it('returns a fresh 200 + new ETag when the catalog changed', async () => {
+		const etag = (await call()).headers.get('etag');
+		listCatalogProducts.mockResolvedValueOnce({
+			products: [{ id: 'latte', name: 'Latte', alias: [], type: 'resource' }],
+			page: { limit: 20, nextCursor: null },
+			language: 'en'
+		});
+		const res = await call({ ifNoneMatch: etag as string });
+		expect(res.status).toBe(200);
+		expect(res.headers.get('etag')).not.toBe(etag);
+		await expect(res.json()).resolves.toMatchObject({ products: [{ id: 'latte' }] });
 	});
 
 	it('returns 401 without API key', async () => {

--- a/src/routes/api/v1/orders/paid/+server.ts
+++ b/src/routes/api/v1/orders/paid/+server.ts
@@ -1,7 +1,8 @@
-import { json, type RequestHandler } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
 import { apiV1Handler, apiV1OptionsHandler } from '$lib/server/api/v1/handler';
 import { requireApiKey } from '$lib/server/api/v1/auth';
 import { apiError } from '$lib/server/api/v1/errors';
+import { jsonWithETag } from '$lib/server/api/v1/validators';
 import { listPaidOrders } from '$lib/server/api/v1/orders/listPaid';
 import { checkRateLimit } from '$lib/server/rateLimit';
 
@@ -29,9 +30,12 @@ export const GET: RequestHandler = apiV1Handler(async (event) => {
 		cursor: url.searchParams.get('cursor') ?? undefined
 	});
 
-	return json({
-		ok: true,
-		orders: result.orders,
-		page: result.page
-	});
+	return jsonWithETag(
+		{
+			ok: true,
+			orders: result.orders,
+			page: result.page
+		},
+		event.request
+	);
 });

--- a/src/routes/api/v1/orders/paid/server.test.ts
+++ b/src/routes/api/v1/orders/paid/server.test.ts
@@ -19,7 +19,11 @@ vi.mock('$lib/server/runtime-config', () => ({
 
 import { GET } from './+server';
 
-function call() {
+function call(opts?: { ifNoneMatch?: string }) {
+	const headers = new Headers();
+	if (opts?.ifNoneMatch) {
+		headers.set('if-none-match', opts.ifNoneMatch);
+	}
 	const locals = {
 		apiKey: {
 			_id: new ObjectId(),
@@ -31,7 +35,7 @@ function call() {
 	};
 	const url = 'http://localhost/api/v1/orders/paid';
 	return GET({
-		request: new Request(url, { method: 'GET' }),
+		request: new Request(url, { method: 'GET', headers }),
 		url: new URL(url),
 		locals
 	} as unknown as Parameters<typeof GET>[0]);
@@ -62,5 +66,29 @@ describe('GET /api/v1/orders/paid', () => {
 		const res = await call();
 		expect(res.status).toBe(200);
 		await expect(res.json()).resolves.toMatchObject({ ok: true, orders: [] });
+	});
+
+	it('exposes a strong ETag and answers 304 on a matching If-None-Match', async () => {
+		const first = await call();
+		const etag = first.headers.get('etag');
+		expect(etag).toMatch(/^"[a-f0-9]{64}"$/);
+		expect(first.headers.get('cache-control')).toBe('private, no-cache');
+
+		const second = await call({ ifNoneMatch: etag as string });
+		expect(second.status).toBe(304);
+		expect(second.headers.get('etag')).toBe(etag);
+		await expect(second.text()).resolves.toBe('');
+	});
+
+	it('returns a fresh 200 + new ETag once a new paid order lands', async () => {
+		const etag = (await call()).headers.get('etag');
+		listPaidOrders.mockResolvedValueOnce({
+			orders: [{ id: 'order-1', status: 'paid' }],
+			page: { limit: 20, nextCursor: null }
+		});
+		const res = await call({ ifNoneMatch: etag as string });
+		expect(res.status).toBe(200);
+		expect(res.headers.get('etag')).not.toBe(etag);
+		await expect(res.json()).resolves.toMatchObject({ orders: [{ id: 'order-1' }] });
 	});
 });


### PR DESCRIPTION
Conditional GETs on the Face A reads: strong ETags, `If-None-Match`, `304`.

Closes #2713

**Depends on #2722.**

## What lands here

The RFC 9110 validators already lived in `validators.ts` but were called from nowhere. `jsonWithETag(body, request)` is the missing bridge: it serializes once, derives a strong ETag from the exact bytes, and short-circuits to a bodyless `304` repeating the same validator when `If-None-Match` matches (weak comparison, `*` and `W/` accepted, §13.1.2).

Wired to all three reads: catalog list, catalog detail, paid-orders poll. A PoS polling `/orders/paid` on a short interval now pays a `304` with no body when nothing changed.

## Deliberately not on the write path

`POST /api/v1/orders` takes no ETag precondition — the batch write has its own `(apiKeyId, externalOrderId)` idempotency key. An OpenAPI test locks that absence in so it is not added by reflex later.

## Also here

- `Cache-Control: private, no-cache` on the reads: per-key payloads stay out of shared caches, clients can still store and revalidate.
- CORS accepts `If-None-Match` and exposes `ETag` — without that plumbing a browser caller cannot read back the validator it is asked to replay.
