### PR TITLE
🐛 API v1: review follow-ups on the read and write paths

### DIFF
--- a/src/lib/server/api/create-action.prg.test.ts
+++ b/src/lib/server/api/create-action.prg.test.ts
@@ -50,6 +50,15 @@ function mockCookies(initial?: Record<string, string>) {
 	return { cookies, jar };
 }
 
+/** Always-valid expiry, so the suite does not rot the day a hard-coded date goes past. */
+function futureIso(): string {
+	return new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function pastIso(): string {
+	return new Date(Date.now() - 60_000).toISOString();
+}
+
 describe('api key create PRG + reveal one-shot', () => {
 	beforeEach(() => {
 		createApiKey.mockReset();
@@ -79,7 +88,7 @@ describe('api key create PRG + reveal one-shot', () => {
 		const body = new FormData();
 		body.set('name', 'desk');
 		body.append('scopes', 'orders:write');
-		body.set('expiresAt', '2026-12-01T10:00:00.000Z');
+		body.set('expiresAt', futureIso());
 
 		let thrown: unknown;
 		try {
@@ -99,6 +108,26 @@ describe('api key create PRG + reveal one-shot', () => {
 		const red = thrown as { status: number; location: string };
 		expect(red.status).toBe(303);
 		expect(red.location).toBe('/admin/api-keys/new/reveal');
+	});
+
+	it('rejects an expiry in the past instead of minting a dead-on-arrival key', async () => {
+		const { cookies, jar } = mockCookies();
+		const body = new FormData();
+		body.set('name', 'desk');
+		body.append('scopes', 'orders:write');
+		body.set('expiresAt', pastIso());
+
+		const res = (await actions.createApiKey({
+			request: new Request('http://localhost/admin/api-keys/new', { method: 'POST', body }),
+			locals: { user: { roleId: SUPER_ADMIN_ROLE_ID, _id: new ObjectId() } },
+			cookies
+		} as never)) as { status: number; data: { error: { formErrors: string[] } } };
+
+		expect(res.status).toBe(400);
+		expect(res.data.error.formErrors[0]).toMatch(/future/i);
+		// No secret was generated, so nothing to reveal.
+		expect(createApiKey).not.toHaveBeenCalled();
+		expect(jar.has(API_KEY_REVEAL_COOKIE)).toBe(false);
 	});
 
 	it('reveal load consumes cookie once; second load reports already shown (no second create)', async () => {

--- a/src/lib/server/api/v1/middleware.test.ts
+++ b/src/lib/server/api/v1/middleware.test.ts
@@ -151,7 +151,7 @@ describe('handleApiV1', () => {
 		expect(res.status).toBe(200);
 	});
 
-	it('rate-limits missing clientIp under fixed unknown-ip bucket', async () => {
+	it('skips the IP bucket when clientIp is unknown instead of pooling every caller', async () => {
 		checkRateLimit.mockReturnValue({ limited: false });
 		const resolve = vi.fn(async () => new Response('ok'));
 		const event = makeEvent({
@@ -163,7 +163,9 @@ describe('handleApiV1', () => {
 			throw new Error('no address');
 		};
 		await handleApiV1({ event: event as never, resolve: resolve as never });
-		expect(checkRateLimit).toHaveBeenCalledWith('unknown-ip', 'api.v1.ip', 120, { minutes: 1 });
+		// A shared 'unknown-ip' bucket would 429 the whole API shop-wide on a misconfigured proxy.
+		// The route below still requires an API key and applies its own per-key limit.
+		expect(checkRateLimit).not.toHaveBeenCalled();
 		expect(resolve).toHaveBeenCalled();
 	});
 	it('keeps GET /api/v1/openapi.json up during maintenance and skips IP RL', async () => {

--- a/src/lib/server/api/v1/middleware.ts
+++ b/src/lib/server/api/v1/middleware.ts
@@ -53,8 +53,13 @@ export const handleApiV1: Handle = async ({ event, resolve }) => {
 
 	// IP safety net: skip public GETs and CORS preflights so monitors / docs / PoS preflights
 	// are not starved by the write-path bucket.
-	if (!isPublicReadGet && !isOptions) {
-		const limit = checkRateLimit(event.locals.clientIp ?? 'unknown-ip', 'api.v1.ip', 120, {
+	//
+	// Skipped as well when getClientAddress() gave us nothing (untrusted proxy setup): bucketing
+	// every caller under one 'unknown-ip' key would 429 the whole API after 120 req/min shop-wide.
+	// Nothing is left unprotected — every route below requires an API key and carries its own
+	// per-key limit; this bucket only exists to blunt pre-auth floods from a single address.
+	if (!isPublicReadGet && !isOptions && event.locals.clientIp) {
+		const limit = checkRateLimit(event.locals.clientIp, 'api.v1.ip', 120, {
 			minutes: 1
 		});
 		if (limit.limited) {

--- a/src/lib/server/api/v1/openapi.ts
+++ b/src/lib/server/api/v1/openapi.ts
@@ -653,8 +653,14 @@ export function buildOpenApiDocument(opts?: { serverUrl?: string }) {
 						quantity: { type: 'integer' },
 						uniqueKey: { type: 'string' },
 						chosenVariations: { type: 'object', additionalProperties: { type: 'string' } },
+						freeQuantity: {
+							type: 'integer',
+							description: 'Units given away on this line (POS offer). Absent when zero.'
+						},
 						unitPrice: {
 							type: 'object',
+							description:
+								'Per-unit price after any line discount. Charged units = quantity - freeQuantity.',
 							required: ['amountMinor', 'currency'],
 							properties: {
 								amountMinor: { $ref: '#/components/schemas/AmountMinor' },

--- a/src/lib/server/api/v1/orders/listPaid.test.ts
+++ b/src/lib/server/api/v1/orders/listPaid.test.ts
@@ -146,3 +146,24 @@ describe('listPaidOrders pagination', () => {
 		expect(res.page.nextCursor).toBeNull();
 	});
 });
+
+describe('toItemDto discounts', () => {
+	it('reports the discounted unit price, not the raw snapshot price', () => {
+		const order = makeOrder({ paid: true });
+		order.items[0].discountPercentage = 25;
+		const dto = toPaidOrderDto(order);
+		// 100 EUR snapshot, 25% off -> 75 EUR per unit.
+		expect(dto?.items[0].unitPrice).toEqual({ amountMinor: 7500, currency: 'EUR' });
+	});
+
+	it('exposes freeQuantity so charged units can be derived, and omits it when zero', () => {
+		const order = makeOrder({ paid: true });
+		order.items[0].quantity = 3;
+		order.items[0].freeQuantity = 1;
+		const dto = toPaidOrderDto(order);
+		expect(dto?.items[0].quantity).toBe(3);
+		expect(dto?.items[0].freeQuantity).toBe(1);
+
+		expect(toPaidOrderDto(makeOrder({ paid: true }))?.items[0].freeQuantity).toBeUndefined();
+	});
+});

--- a/src/lib/server/api/v1/orders/listPaid.test.ts
+++ b/src/lib/server/api/v1/orders/listPaid.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ObjectId } from 'mongodb';
 import type { Order } from '$lib/types/Order';
-import { toPaidOrderDto } from './listPaid';
+import { exchangeRate } from '$lib/stores/exchangeRate';
+
+const find = vi.fn();
+vi.mock('$lib/server/database', () => ({
+	collections: { orders: { find: (...args: unknown[]) => find(...args) } }
+}));
+
+import { listPaidOrders, toPaidOrderDto } from './listPaid';
 import { TEST_DIGITAL_PRODUCT } from '$lib/server/seed/product';
+
+/** Mongo cursor stub: find().sort().limit().toArray() */
+function cursorOf(docs: unknown[]) {
+	return { sort: () => ({ limit: () => ({ toArray: async () => docs }) }) };
+}
 
 function makeOrder(opts: { paid: boolean; uniqueKey?: string }): Order {
 	const amount = 100;
@@ -84,5 +96,53 @@ describe('toOrderReadDto', () => {
 		expect(dto.status).toBe('pending');
 		expect(dto.amountPaid).toEqual({ amountMinor: 0, currency: 'EUR' });
 		expect(dto.paidAt).toBeNull();
+	});
+});
+
+describe('paidAmount currency conversion', () => {
+	beforeEach(() => {
+		exchangeRate.set({ BTC: 1, EUR: 30_000, USD: 60_000, CHF: 30_000, SAT: 100_000_000, ZAR: 0 });
+	});
+
+	it('converts a payment made in another currency into the order currency', () => {
+		const order = makeOrder({ paid: true });
+		// 100 USD at 60k USD/BTC is 50 EUR at 30k EUR/BTC.
+		order.payments[0].currencySnapshot.main.price = { amount: 100, currency: 'USD' };
+		const dto = toPaidOrderDto(order);
+		expect(dto?.amountPaid).toEqual({ amountMinor: 5000, currency: 'EUR' });
+	});
+
+	it('leaves same-currency payments untouched', () => {
+		const dto = toPaidOrderDto(makeOrder({ paid: true }));
+		expect(dto?.amountPaid).toEqual({ amountMinor: 10000, currency: 'EUR' });
+	});
+});
+
+describe('listPaidOrders pagination', () => {
+	beforeEach(() => {
+		find.mockReset();
+	});
+
+	it('derives hasMore from the query result, not from the mapped rows', async () => {
+		// limit 2 over-fetches 3; the middle row is unmappable and gets dropped.
+		const page = [
+			{ ...makeOrder({ paid: true }), _id: 'ord_c' },
+			{ ...makeOrder({ paid: false }), _id: 'ord_b' },
+			{ ...makeOrder({ paid: true }), _id: 'ord_a' }
+		];
+		find.mockReturnValue(cursorOf(page));
+
+		const res = await listPaidOrders({ limit: '2' });
+		// One row dropped, so a single order comes back — but a third row exists behind it and
+		// the cursor must still advance, otherwise the poller stops with orders unread.
+		expect(res.orders).toHaveLength(1);
+		expect(res.page.nextCursor).toBe('ord_b');
+	});
+
+	it('closes the page when the query returns no extra row', async () => {
+		find.mockReturnValue(cursorOf([{ ...makeOrder({ paid: true }), _id: 'ord_c' }]));
+		const res = await listPaidOrders({ limit: '2' });
+		expect(res.orders).toHaveLength(1);
+		expect(res.page.nextCursor).toBeNull();
 	});
 });

--- a/src/lib/server/api/v1/orders/listPaid.ts
+++ b/src/lib/server/api/v1/orders/listPaid.ts
@@ -1,5 +1,7 @@
 import { collections } from '$lib/server/database';
 import type { Order } from '$lib/types/Order';
+import type { Currency } from '$lib/types/Currency';
+import { toCurrency } from '$lib/utils/toCurrency';
 import { amountToMinor } from './money';
 
 const MAX_LIMIT = 100;
@@ -57,7 +59,9 @@ function paidAmount(order: Order): { amountMinor: number; currency: string } | n
 		if (snap.currency === currency) {
 			return sum + snap.amount;
 		}
-		return sum + snap.amount;
+		// A payment snapshot may be in another currency than the order total; converting is the
+		// whole point of labelling amountPaid with the order currency.
+		return sum + toCurrency(currency as Currency, snap.amount, snap.currency as Currency);
 	}, 0);
 	return { amountMinor: amountToMinor(amount, currency), currency };
 }
@@ -128,17 +132,20 @@ export async function listPaidOrders(query: PaidOrdersQuery): Promise<{
 		.limit(limit + 1)
 		.toArray();
 
-	const mapped: PaidOrderDto[] = [];
-	for (const doc of docs) {
+	// Page on `docs` (the +1 over-fetch), never on the mapped array: toPaidOrderDto drops rows,
+	// and a single drop on a full page would zero out nextCursor and strand the poller.
+	const hasMore = docs.length > limit;
+	const pageDocs = hasMore ? docs.slice(0, limit) : docs;
+	const orders: PaidOrderDto[] = [];
+	for (const doc of pageDocs) {
 		const dto = toPaidOrderDto(doc as Order);
 		if (dto) {
-			mapped.push(dto);
+			orders.push(dto);
 		}
 	}
-	const hasMore = mapped.length > limit;
-	const pageDocs = hasMore ? mapped.slice(0, limit) : mapped;
-	const nextCursor = hasMore ? pageDocs[pageDocs.length - 1].orderId : null;
-	return { orders: pageDocs, page: { limit, nextCursor } };
+	// Cursor follows the last row actually read, so a dropped row is skipped, not replayed.
+	const nextCursor = hasMore ? String(pageDocs[pageDocs.length - 1]._id) : null;
+	return { orders, page: { limit, nextCursor } };
 }
 
 export type OrderReadDto = PaidOrderDto & { status: string };
@@ -189,9 +196,9 @@ export async function listOrders(query: PaidOrdersQuery): Promise<{
 		.limit(limit + 1)
 		.toArray();
 
-	const mapped = docs.map((doc) => toOrderReadDto(doc as Order));
-	const hasMore = mapped.length > limit;
-	const pageDocs = hasMore ? mapped.slice(0, limit) : mapped;
-	const nextCursor = hasMore ? pageDocs[pageDocs.length - 1].orderId : null;
-	return { orders: pageDocs, page: { limit, nextCursor } };
+	const hasMore = docs.length > limit;
+	const pageDocs = hasMore ? docs.slice(0, limit) : docs;
+	const orders = pageDocs.map((doc) => toOrderReadDto(doc as Order));
+	const nextCursor = hasMore ? String(pageDocs[pageDocs.length - 1]._id) : null;
+	return { orders, page: { limit, nextCursor } };
 }

--- a/src/lib/server/api/v1/orders/listPaid.ts
+++ b/src/lib/server/api/v1/orders/listPaid.ts
@@ -1,5 +1,5 @@
 import { collections } from '$lib/server/database';
-import type { Order } from '$lib/types/Order';
+import { orderIndividualItemPrice, type Order } from '$lib/types/Order';
 import type { Currency } from '$lib/types/Currency';
 import { toCurrency } from '$lib/utils/toCurrency';
 import { amountToMinor } from './money';
@@ -20,7 +20,10 @@ export type PaidOrderItemDto = {
 	quantity: number;
 	uniqueKey?: string;
 	chosenVariations?: Record<string, string>;
+	/** Per-unit price after any line discount. Units actually charged = quantity - freeQuantity. */
 	unitPrice: { amountMinor: number; currency: string };
+	/** Units given away on the line (POS offer). Omitted when zero. */
+	freeQuantity?: number;
 };
 
 export type PaidOrderDto = {
@@ -68,16 +71,20 @@ function paidAmount(order: Order): { amountMinor: number; currency: string } | n
 
 function toItemDto(item: Order['items'][number]): PaidOrderItemDto {
 	const currency = item.currencySnapshot.main.price.currency;
-	const unit = item.currencySnapshot.main.customPrice ?? item.currencySnapshot.main.price;
+	// Raw snapshot prices ignore discountPercentage / freeQuantity, so sum(items) drifted above
+	// amountPaid on any discounted line. Report what was actually charged instead.
+	const unitAmount = orderIndividualItemPrice(item, 'main');
+	const freeQuantity = item.freeQuantity ?? 0;
 	return {
 		productId: item.product._id,
 		name: item.product.name,
 		quantity: item.quantity,
 		...(item.uniqueKey && { uniqueKey: item.uniqueKey }),
 		...(item.chosenVariations && { chosenVariations: item.chosenVariations }),
+		...(freeQuantity > 0 && { freeQuantity }),
 		unitPrice: {
-			amountMinor: amountToMinor(unit.amount, unit.currency ?? currency),
-			currency: unit.currency ?? currency
+			amountMinor: amountToMinor(unitAmount, currency),
+			currency
 		}
 	};
 }

--- a/src/lib/server/api/v1/orders/resolveProducts.ts
+++ b/src/lib/server/api/v1/orders/resolveProducts.ts
@@ -1,6 +1,10 @@
 import { collections } from '$lib/server/database';
 import type { Currency } from '$lib/types/Currency';
-import type { Product } from '$lib/types/Product';
+import {
+	checkProductVariationsIntegrity,
+	productPriceWithVariations,
+	type Product
+} from '$lib/types/Product';
 import type { Price } from '$lib/types/Order';
 import type { ApiV1Warning } from '$lib/types/ApiV1';
 import type { OrderWriteCommand } from '$lib/server/api/v1/schemas/orders-write';
@@ -65,10 +69,24 @@ export async function resolveProducts(
 	const lines: ResolvedLine[] = [];
 
 	for (const item of items) {
-		const customPrice = item.customPrice
+		const clientPrice = item.customPrice
 			? minorToPrice(item.customPrice.amountMinor, item.customPrice.currency)
 			: undefined;
 		const existing = byId.get(item.productId);
+		// The web cart prices variations when the line is added (cart.ts). Face A has no cart, so
+		// do it here: createOrder computes the order total from these lines and only patches
+		// customPrice afterwards, too late to reach the total or the payment amount.
+		const variationPrice =
+			existing &&
+			existing.variations?.length &&
+			!existing.payWhatYouWant &&
+			checkProductVariationsIntegrity(existing, item.chosenVariations)
+				? {
+						amount: productPriceWithVariations(existing, item.chosenVariations),
+						currency: existing.price.currency
+				  }
+				: undefined;
+		const customPrice = variationPrice ?? clientPrice;
 		const missing = !existing;
 		if (missing) {
 			warnings.push({
@@ -78,7 +96,7 @@ export async function resolveProducts(
 			});
 		}
 		lines.push({
-			product: existing ?? stubMissingProduct(item.productId, customPrice, orderCurrency),
+			product: existing ?? stubMissingProduct(item.productId, clientPrice, orderCurrency),
 			quantity: item.quantity,
 			...(customPrice && { customPrice }),
 			...(item.chosenVariations && { chosenVariations: item.chosenVariations }),

--- a/src/lib/server/api/v1/orders/writeBatch.test.ts
+++ b/src/lib/server/api/v1/orders/writeBatch.test.ts
@@ -83,6 +83,48 @@ describe.skipIf(!mongoAvailable)('writeBatch / writeOne (Mongo integration)', ()
 		runtimeConfig.vatExempted = true;
 	}, 60_000);
 
+	it('does not settle a zero-base-price variation product as free', async () => {
+		// Base price 0, the paid part lives entirely in the chosen variation. Summing the base
+		// price alone would read this as a zero total, pick paymentMethod 'free', and mark the
+		// order paid without any money moving.
+		const variationProduct = {
+			...TEST_DIGITAL_PRODUCT,
+			_id: 'variation-zero-base',
+			alias: ['variation-zero-base'],
+			price: { amount: 0, currency: 'EUR' as const },
+			payWhatYouWant: false,
+			variations: [{ name: 'size', value: 'XL', price: 10 }]
+		};
+		await collections.products.insertOne(variationProduct);
+
+		const res = await writeBatch({
+			apiKey,
+			orders: [
+				{
+					externalOrderId: 'variation-not-free-1',
+					currency: 'EUR' as const,
+					items: [
+						{ productId: variationProduct._id, quantity: 1, chosenVariations: { size: 'XL' } }
+					],
+					payment: {
+						method: 'point-of-sale' as const,
+						status: 'paid' as const,
+						amountMinor: amountToMinor(10, 'EUR'),
+						currency: 'EUR' as const
+					}
+				}
+			]
+		});
+
+		const order = await collections.orders.findOne({ _id: requireOrderId(res.results[0]) });
+		expect(order).toBeTruthy();
+		expect(order?.payments[0].method).not.toBe('free');
+		expect(order?.payments[0].method).toBe('point-of-sale');
+		// The variation surcharge must reach the order total, not just the item line.
+		expect(order?.currencySnapshot.main.totalPrice.amount).toBe(10);
+		expect(order?.items[0].currencySnapshot.main.customPrice?.amount).toBe(10);
+	});
+
 	it('creates a paid order from lines and marks payment paid', async () => {
 		const res = await writeBatch({
 			apiKey,

--- a/src/lib/server/api/v1/orders/writeOne.ts
+++ b/src/lib/server/api/v1/orders/writeOne.ts
@@ -17,6 +17,7 @@ import {
 	type OrderPaymentWrite,
 	type OrderWriteCommand
 } from '$lib/server/api/v1/schemas/orders-write';
+import { checkProductVariationsIntegrity, productPriceWithVariations } from '$lib/types/Product';
 import { amountToMinor, minorToPrice } from './money';
 import { mapCustomFields } from './mapCustomFields';
 import { mapDomainError } from './mapErrors';
@@ -347,10 +348,21 @@ export async function writeOne(params: WriteOneParams): Promise<ApiV1OrderResult
 		// createOrder → addOrderPayment rejects point-of-sale when the line total is 0.
 		// Missing-product stubs may be priced at customPrice||0 (M5). Prefer 'free' for
 		// zero-total paid so the domain paid pipeline runs (stock/webhooks/accounting).
-		const provisionalMajor = lines.reduce(
-			(sum, line) => sum + (line.customPrice?.amount ?? line.product.price.amount) * line.quantity,
-			0
-		);
+		// Mirror what createOrder will actually charge: it overwrites customPrice with
+		// productPriceWithVariations for variation products. Summing the base price here would
+		// read a 0-base-price product with a paid variation as a zero total, flip paymentMethod
+		// to 'free', and auto-settle an order nobody paid.
+		const provisionalMajor = lines.reduce((sum, line) => {
+			const product = line.product;
+			const hasPricedVariations =
+				!!product.variations?.length &&
+				!product.payWhatYouWant &&
+				checkProductVariationsIntegrity(product, line.chosenVariations);
+			const unit = hasPricedVariations
+				? productPriceWithVariations(product, line.chosenVariations)
+				: line.customPrice?.amount ?? product.price.amount;
+			return sum + unit * line.quantity;
+		}, 0);
 		const isZeroTotal = provisionalMajor <= 0;
 		const multi = payments.length > 1 && !isZeroTotal;
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/api-keys/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/api-keys/new/+page.server.ts
@@ -31,6 +31,13 @@ export const actions: Actions = {
 		if (!expiresParsed.ok) {
 			return fail(400, { error: { formErrors: [expiresParsed.message], fieldErrors: {} } });
 		}
+		// A past date parses fine, then isApiKeyUsable rejects the key on first use: the admin walks
+		// away from the reveal page holding a secret that never worked.
+		if (expiresParsed.value && expiresParsed.value.getTime() <= Date.now()) {
+			return fail(400, {
+				error: { formErrors: ['Expiration date must be in the future'], fieldErrors: {} }
+			});
+		}
 
 		const parsed = z
 			.object({

--- a/src/routes/(app)/admin[[hash=admin_hash]]/api-keys/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/api-keys/new/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { useI18n } from '$lib/i18n.js';
 	import { groupScopesByCategory } from '$lib/types/ApiV1';
 
@@ -8,6 +9,16 @@
 	const { t } = useI18n();
 
 	let expiresLocal = '';
+	/**
+	 * Browser UTC offset for the no-JS fallback. Filled on mount, never server-rendered: evaluating
+	 * getTimezoneOffset() during SSR sends the *server* offset and expires the key at the wrong
+	 * instant for any admin in another zone.
+	 */
+	let expiresOffsetMinutes = '';
+
+	onMount(() => {
+		expiresOffsetMinutes = String(new Date().getTimezoneOffset());
+	});
 
 	let selectedScopes: Record<string, boolean> = Object.fromEntries(
 		data.scopes.map((scope: string) => [scope, false])
@@ -151,12 +162,15 @@
 				bind:value={expiresLocal}
 			/>
 			<input type="hidden" name="expiresAt" value="" />
-			<input type="hidden" name="expiresAtOffsetMinutes" value={new Date().getTimezoneOffset()} />
+			<input type="hidden" name="expiresAtOffsetMinutes" bind:value={expiresOffsetMinutes} />
 			<span class="text-sm opacity-70">{t('admin.apiKeys.expiresAtHint')}</span>
 		</label>
 
 		{#if form?.error}
 			<p class="text-red-600">{t('admin.apiKeys.createError')}</p>
+			{#each form.error.formErrors ?? [] as formError}
+				<p class="text-red-600 text-sm">{formError}</p>
+			{/each}
 		{/if}
 
 		<input


### PR DESCRIPTION
Review follow-ups on the API v1 series: three defects, one dead configuration path, two CLI scripts retired.

No source issue — findings from a review of the whole stack.

**Depends on #2723.** Last of the 5 — three commits.

## Bug fixes

- **Variations were never priced on Face A.** The web cart applies `productPriceWithVariations` when a line is added; `resolveProducts` did not. `createOrder` therefore computed the order total from base prices and only patched `item.customPrice` afterwards, too late for the total, the VAT, or the payment amount. A product priced 0 with a paid variation looked like a zero total, `writeOne` picked `paymentMethod: 'free'`, and the order was marked paid with no money moving.
- **Cross-currency `amountPaid` was summed raw** — the `if (snap.currency === currency)` branch and its fallback were byte-identical, so the conversion had never been written.
- **Pagination derived `hasMore` from the mapped array**, after rows had been dropped. One dropped row on a full page zeroed `nextCursor` and left a poller convinced it had reached the end.
- **The IP rate-limit net pooled every caller** under a fixed `unknown-ip` key when `getClientAddress()` threw, so a misconfigured proxy capped the whole API at 120 req/min shop-wide.
- **`PaidOrderItem.unitPrice` ignored discounts** — `quantity * unitPrice` came out above `amountPaid` on any discounted line.
- **Admin key expiry**: the timezone offset was evaluated during SSR (server zone applied to the admin's wall clock on the no-JS path), and a past expiry was accepted, minting a key that `isApiKeyUsable` rejected on first use.

Each fix ships with a regression test; the pagination and variation tests both fail on the previous commit.

## Left open on purpose

- `GET /api/v1/orders` returns every order including unpaid ones, is absent from the OpenAPI document, and is the only read without an ETag. Needs a product call: document it, scope it, or drop it.
- The `ts-node` devDependency predates this work (added in #207) and may now be unused repo-wide.
