### PR TITLE
🔧 Release notes from the merged PR, and manual-only deploys

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -56,11 +56,31 @@ jobs:
         with:
           path: release_artifacts
           merge-multiple: true
-      - name: Get merge commit message
+      # The release name and notes come from the merged pull request, not from
+      # the last commit on main. With a merge or rebase strategy, that commit is
+      # whatever the branch ended on — a formatting pass, a lint fix, a fixup —
+      # and the release then announces that instead of the feature. Trailers are
+      # stripped: they address the commit log, not the people reading releases.
+      - name: Get release title and notes from the merged pull request
         id: commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TITLE=$(git log -1 --pretty=%s)
-          BODY=$(git log -1 --pretty=%b)
+          SHA=$(git rev-parse HEAD)
+          PR_JSON=$(gh api "repos/${{ github.repository }}/commits/$SHA/pulls" \
+            --jq '.[0] // empty' 2>/dev/null || true)
+          if [ -n "$PR_JSON" ]; then
+            NUMBER=$(printf '%s' "$PR_JSON" | jq -r '.number')
+            TITLE=$(printf '%s' "$PR_JSON" | jq -r '.title')
+            BODY=$(printf '%s' "$PR_JSON" | jq -r '.body // ""')
+            BODY=$(printf '%s\n\nPR #%s' "$BODY" "$NUMBER")
+          else
+            # Direct push to main: nothing better to fall back on.
+            TITLE=$(git log -1 --pretty=%s)
+            BODY=$(git log -1 --pretty=%b)
+          fi
+          TITLE=$(printf '%s' "$TITLE" | sed -e 's/:new:/🆕/g' -e 's/🤖//g' -e 's/  */ /g' -e 's/^ *//' -e 's/ *$//')
+          BODY=$(printf '%s' "$BODY" | grep -viE '^[[:space:]]*(co-authored-by:|.*claude\.ai/code|.*generated with )' | cat -s || true)
           COMMIT_DATE="$(git log -1 --date=format:%F --pretty=format:%cd)"
           HASH=$(git rev-parse --short HEAD)
           echo "title<<EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: deploy
 
+# Deploys are manual. Every merge to main used to ship straight to the
+# environment named by the DEFAULT_ENV variable, which left no room between
+# review and production.
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Two CI changes.

## Release notes

`artifacts.yml` took the release title and body from `git log -1` on `main`. With a squash merge that commit carries the PR title, so the release is right. With a merge or a rebase it is whatever the branch happened to end on.

Eight releases since June announced a formatting pass, a lint fix or a `.gitignore` tweak, while the feature they actually shipped appeared nowhere — the price calendar (#2614), the admin sidebar (#2618), the GDPR consent banner (#2637), the fix for premature expiration of on-chain payments (#2629), among others.

The step now resolves the pull request associated with the pushed SHA and uses its title and body. A direct push to `main` still falls back to the commit. Commit trailers are dropped from the notes: they address the commit log, not the people reading releases. `:new:` is expanded to its emoji so titles read the same on the releases page as in the PR list.

The 38 releases published since 11 June have been corrected by hand to match their pull request.

## Deploys

`deploy.yml` ran on every push to `main`, deploying to the environment named by `DEFAULT_ENV`. Merging and shipping were the same action, which left no room between review and production. The `push` trigger is removed; `workflow_dispatch` stays, so a deploy is one click from the Actions tab.
