### PR TITLE
🐛 Render the home page the same at / and at /home (#2161)

### DIFF
--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -19,8 +19,15 @@ export const load = async ({ locals, url }) => {
 				},
 				fullScreen: 1,
 				hasEmployeeContent: 1,
+				// Without this, `cmsPage.displayRawContent` below is always
+				// undefined and the home page is sanitized at `/` but not at
+				// `/home` — the <style> block of an advanced-HTML page is
+				// dropped on the site root only.
+				displayRawContent: 1,
 				hasMobileContent: 1,
+				hideFromSEO: 1,
 				maintenanceDisplay: 1,
+				metas: 1,
 				mobileContent: {
 					$ifNull: [`$translations.${locals.language}.mobileContent`, '$mobileContent']
 				},
@@ -60,7 +67,10 @@ export const load = async ({ locals, url }) => {
 			},
 			locals
 		),
-		layoutReset: cmsPage.fullScreen
+		layoutReset: cmsPage.fullScreen,
+		// `[slug]` does the same, so that the meta description of `/` is the
+		// one written on the home page rather than the shop-wide default.
+		websiteShortDescription: cmsPage.shortDescription
 	};
 };
 


### PR DESCRIPTION
Closes #2161.

The site root and `/home` serve the same CMS page, but not through the same code path. The root route decides whether to skip sanitization by reading a field it never asked the database for, so that decision is always made on an empty value.

What a shop owner can lose on `/`, while `/home` keeps it:

- the styling written in the Advanced HTML editor, when the page uses raw content;
- the SEO metas set on the home page;
- the page's own description for search engines, which falls back to the shop-wide one.

The back-office gives no hint, since the preview follows `/home`.

This aligns the root on what `[slug]` already does, so both addresses render the same page the same way.

Redirecting `/` to `/home` would have hidden the symptom too, but it moves the canonical address of every shop to `/home`. The root stays the root.
