### PR TITLE
🐛 Remove the View button from the discount edit page (#2692)

### DIFF
--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.svelte
@@ -392,7 +392,6 @@
 	<div class="flex flex-row justify-between gap-2">
 		<div class="flex gap-2 w-min">
 			<input type="submit" class="btn btn-blue text-white" formaction="?/update" value="Update" />
-			<a href="/discounts/{data.discount._id}" class="btn body-mainCTA">View</a>
 			<button
 				type="submit"
 				class="btn btn-green text-white ml-auto whitespace-nowrap"


### PR DESCRIPTION
Closes #2692.

Editing a discount in the back-office offered a **View** button next to **Update**. Discounts have no public page, so the button led nowhere: every click landed on the 404 page. On a shop that has not customised that page, the visitor — here, the shop owner — gets the default placeholder text.

The button is removed. Nothing else on the page changes.
