### PR TITLE
🐛 Drop the POS tab buttons from the non-POS order page (#2703)

### DIFF
--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -563,22 +563,6 @@
 								>
 									{t('order.note.seeText')}
 								</a>
-								{#if data.order.orderTabSlug}
-									{#if data.splitMode && showContinue}
-										<a
-											href="/pos/touch/tab/{data.order.orderTabSlug}/split?mode={data.splitMode}"
-											class="btn lg:w-auto w-full btn-black self-end"
-										>
-											{skipMode ? t('pos.split.skipForNow') : t('pos.split.continueSplit')}
-										</a>
-									{/if}
-									<a
-										href="/pos/touch/tab/{data.order.orderTabSlug}"
-										class="btn lg:w-auto w-full btn-gray self-end"
-									>
-										@@Back to order tab
-									</a>
-								{/if}
 							</div>
 						</section>
 					</form>


### PR DESCRIPTION
Closes #2703.

Opening an order that is attached to a tab — from the admin order list, a direct link, a bookmark — showed an employee two buttons leading into the point-of-sale touch flow they had not come from: **Back to order tab**, and **Continue** when the order was being split.

Clicking either dropped the employee into `/pos/touch`, away from the page they were working on. The first also displayed a raw placeholder instead of a label, in every language.

Both buttons are removed from that view. Inside the point-of-sale flow nothing changes: the return to the tab is already handled there, split included.
