### PR TITLE
🐛🤖 Cancel pending payments left on fully paid orders (#2738)

### DIFF
--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -977,6 +977,26 @@ export const migrations = [
 				);
 			}
 		}
+	},
+	{
+		_id: new ObjectId('000000000000000000002738'),
+		name: 'Cancel pending payments left on fully paid orders (issue #2738)',
+		run: async (session: ClientSession) => {
+			// Imported here and not at the top: runtime-config imports this module, so a
+			// static import of orders.ts would close the cycle at load time.
+			const { onOrderPaymentFailed } = await import('./orders');
+			for await (let order of collections.orders.find(
+				{ status: 'paid', 'payments.status': 'pending' },
+				{ session }
+			)) {
+				for (const { _id } of order.payments.filter((p) => p.status === 'pending')) {
+					const stale = order.payments.find((p) => p._id.equals(_id));
+					if (stale) {
+						order = await onOrderPaymentFailed(order, stale, 'canceled', { session });
+					}
+				}
+			}
+		}
 	}
 ];
 

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -407,6 +407,15 @@ export async function onOrderPayment(
 
 		order = ret.value;
 		if (order.status === 'paid') {
+			// Nothing is owed anymore: no other attempt on this order may go through.
+			// `order` is replaced on each pass, so the payment is looked up again —
+			// `onOrderPaymentFailed` rejects a payment absent from the order it is given.
+			for (const { _id } of order.payments.filter((p) => p.status === 'pending')) {
+				const stale = order.payments.find((p) => p._id.equals(_id));
+				if (stale) {
+					order = await onOrderPaymentFailed(order, stale, 'canceled', { session });
+				}
+			}
 			await updateAfterOrderPaid(order, session);
 		}
 


### PR DESCRIPTION
When an order is settled, any payment attempt still waiting on it is now closed.

Until now those attempts stayed open for ever. A waiter skipping a payment call instead of cancelling it, a card transaction left hanging on the terminal — the order was then settled another way, and the abandoned attempt kept sitting there, waiting for money nobody owed any more. It stayed visible next to the real payment in the order, and it was the source of the reporting discrepancy handled in #2730.

Deploying this version also closes the attempts already stranded on orders settled in the past, in a single pass at startup.

Fixes #2738