### PR TITLE
🆕🤖 Set a product variation from the URL, and hide it from the page (#2688)

### DIFF
--- a/src/lib/components/OrderSummary.svelte
+++ b/src/lib/components/OrderSummary.svelte
@@ -9,7 +9,7 @@
 		orderItemPrice
 	} from '$lib/types/Order';
 	import type { Picture } from '$lib/types/Picture';
-	import type { Product } from '$lib/types/Product';
+	import { productLabelWithVariations, type Product } from '$lib/types/Product';
 	import PictureComponent from './Picture.svelte';
 	import PriceTag from './PriceTag.svelte';
 	import ProductType from './ProductType.svelte';
@@ -94,13 +94,7 @@
 	{#each order.items as item}
 		<a href="/product/{item.product._id}">
 			<h3 class="text-base">
-				{item.chosenVariations
-					? item.product.name +
-					  ' - ' +
-					  Object.entries(item.chosenVariations)
-							.map(([key, value]) => item.product.variationLabels?.values[key][value])
-							.join(' - ')
-					: item.product.name}
+				{productLabelWithVariations(item.product, item.chosenVariations)}
 			</h3>
 		</a>
 

--- a/src/lib/components/ProductAddedToCart.svelte
+++ b/src/lib/components/ProductAddedToCart.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { BasicProductFrontend } from '$lib/types/Product';
+	import { productLabelWithVariations, type BasicProductFrontend } from '$lib/types/Product';
 	import type { Picture as PictureType } from '$lib/types/Picture';
 	import Picture from './Picture.svelte';
 	import PriceTag from './PriceTag.svelte';
@@ -32,13 +32,7 @@
 	<div class="flex flex-col grow gap-1">
 		<h2 class="body-title text-[18px] font-medium">{t('product.addedToCart')}</h2>
 		<h3 class="text-base font-light">
-			{chosenVariations
-				? product.name +
-				  ' - ' +
-				  Object.entries(chosenVariations)
-						.map(([key, value]) => product.variationLabels?.values[key][value])
-						.join(' - ')
-				: product.name}
+			{productLabelWithVariations(product, chosenVariations)}
 		</h3>
 		{#if !removePopinProductPrice}
 			<PriceTag

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -417,6 +417,55 @@
 	}
 
 	/**
+	 * Families the saved variations actually use, in the order they appear.
+	 *
+	 * Derived rather than stored: a family only exists because some variation carries its
+	 * name, so deleting the last variation of a family must retire the family with it.
+	 */
+	$: variationFamilies = [...new Set((product.variations ?? []).map((vari) => vari.name))].filter(
+		Boolean
+	);
+
+	/**
+	 * Link that lands on the product page with this variation already chosen.
+	 *
+	 * The value id is not the label the shop typed: a purely numeric value is prefixed with its
+	 * family name, because a key that looks like an array index would be reordered by the
+	 * browser. Typing `10` on a `load` family therefore stores `load10`, and nothing in this form
+	 * used to show it — so the link is offered ready-made rather than left to be guessed.
+	 */
+	function variationLink(variation: { name: string; value: string }): string {
+		const path = `/product/${product._id}?${encodeURIComponent(
+			variation.name
+		)}=${encodeURIComponent(variation.value)}`;
+
+		return typeof window === 'undefined' ? path : new URL(path, window.location.origin).href;
+	}
+
+	function variationLinkKey(variation: { name: string; value: string }): string {
+		return `${variation.name}:${variation.value}`;
+	}
+
+	function variationLinkTitle(variation: { name: string; value: string }): string {
+		return `Copy the link that preselects this variation — ${variationLink(variation)}`;
+	}
+
+	/** Which row last got copied, so its icon can acknowledge the click. */
+	let copiedVariationLink = '';
+
+	async function copyVariationLink(variation: { name: string; value: string }) {
+		try {
+			await navigator.clipboard.writeText(variationLink(variation));
+			copiedVariationLink = variationLinkKey(variation);
+			setTimeout(() => (copiedVariationLink = ''), 2000);
+		} catch {
+			// Clipboard access is denied outside a secure context, and a shop admin served over
+			// plain HTTP would otherwise get a button that silently does nothing.
+			prompt('Copy this link:', variationLink(variation));
+		}
+	}
+
+	/**
 	 * Moves a variation up or down in the list by swapping positions.
 	 *
 	 * Used by 🔺 (move up) and 🔻 (move down) buttons on saved variations.
@@ -1055,6 +1104,14 @@
 								{#if variation.name && variation.value}
 									<button
 										type="button"
+										class="px-2 py-2 hover:bg-blue-50 rounded-md"
+										on:click={() => copyVariationLink(variation)}
+										title={variationLinkTitle(variation)}
+									>
+										{copiedVariationLink === variationLinkKey(variation) ? '✅' : '🔗'}
+									</button>
+									<button
+										type="button"
 										class="px-2 py-2 hover:bg-green-50 rounded-md"
 										on:click={() => duplicateVariation(i, variation)}
 										title="Duplicate variation"
@@ -1097,6 +1154,53 @@
 							Add variation
 						</button>
 					</div>
+
+					{#if variationFamilies.length}
+						<div class="bg-purple-50 p-4 rounded-lg space-y-3">
+							<p class="text-sm font-medium text-gray-700">Variation families:</p>
+							<p class="text-sm text-gray-600">
+								A family hidden from the product page can only be set through the URL —
+								<code>/product/{product._id || 'slug'}?family=value</code> — which is how a value nobody
+								should be able to pick from a list gets onto an order.
+							</p>
+							{#each variationFamilies as family}
+								<div class="flex gap-4 items-center flex-wrap">
+									<span class="flex-1 font-medium"
+										>{product.variationLabels?.names[family] || family}</span
+									>
+									<label class="flex items-center gap-2">
+										<input
+											class="form-checkbox"
+											type="checkbox"
+											name="variationFamilies[{family}].hiddenFromUI"
+											checked={product.variationFamilies?.[family]?.hiddenFromUI}
+										/>
+										Hide from the product page
+									</label>
+									<label class="flex items-center gap-2">
+										<input
+											class="form-checkbox"
+											type="checkbox"
+											name="variationFamilies[{family}].hiddenFromCustomer"
+											checked={product.variationFamilies?.[family]?.hiddenFromCustomer}
+										/>
+										Hide from cart and order
+									</label>
+								</div>
+							{/each}
+							<label class="form-label">
+								When the URL asks for a variation that does not exist
+								<select name="variationUrlPolicy" class="form-input">
+									<option value="error" selected={product.variationUrlPolicy !== 'ignore'}>
+										Refuse the page
+									</option>
+									<option value="ignore" selected={product.variationUrlPolicy === 'ignore'}>
+										Ignore it and show the dropdown
+									</option>
+								</select>
+							</label>
+						</div>
+					{/if}
 				{/if}
 
 				{#if product.type === 'subscription'}

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -411,6 +411,14 @@
 	 */
 	let variationLabelsNames: string[] = [];
 	let variationLabelsValues: string[] = [];
+	/**
+	 * The identifier of each existing variation, editable.
+	 *
+	 * It used to be resubmitted as stored, so a shop could read a bracelet code on screen, retype
+	 * it, save, and change nothing — the field it was typing into was the label. Changing it here
+	 * rewrites `variations[].value` and moves the label with it.
+	 */
+	let variationValueIds: string[] = (product.variations ?? []).map((v) => v.value);
 
 	function isNumber(value: string) {
 		return !isNaN(Number(value)) && value.trim() !== '';
@@ -1002,6 +1010,15 @@
 										<input disabled type="text" class="form-input" value={variation.name} />
 									</label>
 									<label class="form-label flex-1">
+										Value Id
+										<input
+											type="text"
+											class="form-input"
+											bind:value={variationValueIds[i]}
+											placeholder={variation.value}
+										/>
+									</label>
+									<label class="form-label flex-1">
 										Category Name
 										<input
 											type="text"
@@ -1017,7 +1034,8 @@
 										Value
 										<input
 											type="text"
-											name="variationLabels.values[{variation.name}][{variation.value}]"
+											name="variationLabels.values[{variation.name}][{variationValueIds[i] ||
+												variation.value}]"
 											class="form-input"
 											value={product.variationLabels?.values[variation.name]?.[variation.value]}
 											bind:this={variationInput[i]}
@@ -1065,7 +1083,11 @@
 								<label class="form-label">
 									{#if variation.name && variation.value}
 										<input type="hidden" name="variations[{i}].name" value={variation.name} />
-										<input type="hidden" name="variations[{i}].value" value={variation.value} />
+										<input
+											type="hidden"
+											name="variations[{i}].value"
+											value={variationValueIds[i] || variation.value}
+										/>
 									{:else}
 										<input
 											type="hidden"

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -1048,12 +1048,10 @@
 												(isNumber(variationLabelsNames[i]) ? 'name' : '') +
 													variationLabelsNames[i] || ''
 											).toLowerCase()}][{isNumber(variationLabelsValues[i])
-												? (
-														variationLabelsNames[i] +
-															(isNumber(variationLabelsNames[i]) ? '-' : '') +
-															variationLabelsValues[i] || ''
-												  ).toLowerCase()
-												: (variationLabelsValues[i] || '').toLowerCase()}]"
+												? variationLabelsNames[i] +
+														(isNumber(variationLabelsNames[i]) ? '-' : '') +
+														variationLabelsValues[i] || ''
+												: variationLabelsValues[i] || ''}]"
 											class="form-input"
 											bind:value={variationLabelsValues[i]}
 											bind:this={variationInput[i]}
@@ -1081,12 +1079,10 @@
 											type="hidden"
 											name="variations[{i}].value"
 											value={isNumber(variationLabelsValues[i])
-												? (
-														variationLabelsNames[i] +
-															(isNumber(variationLabelsNames[i]) ? '-' : '') +
-															variationLabelsValues[i] || ''
-												  ).toLowerCase()
-												: (variationLabelsValues[i] || '').toLowerCase()}
+												? variationLabelsNames[i] +
+														(isNumber(variationLabelsNames[i]) ? '-' : '') +
+														variationLabelsValues[i] || ''
+												: variationLabelsValues[i] || ''}
 										/>
 									{/if}
 									Price difference

--- a/src/lib/server/product.ts
+++ b/src/lib/server/product.ts
@@ -349,3 +349,33 @@ export function cleanVariationLabels(variationLabels?: {
 
 	return { names, values };
 }
+
+/**
+ * Keep only the family options whose family still has at least one variation, and only those
+ * that actually turn something on.
+ *
+ * The form posts a checkbox pair for every family it displayed. Storing the false ones would
+ * leave a record of families behind after their last variation is deleted, and the product
+ * page would then look up options for families that no longer exist.
+ */
+export function cleanVariationFamilies(
+	variationFamilies:
+		| Record<string, { hiddenFromUI?: boolean; hiddenFromCustomer?: boolean }>
+		| undefined,
+	variations: Array<{ name: string }>
+): Record<string, { hiddenFromUI?: boolean; hiddenFromCustomer?: boolean }> {
+	const known = new Set(variations.map((variation) => variation.name));
+
+	return Object.fromEntries(
+		Object.entries(variationFamilies ?? {})
+			.filter(([family]) => known.has(family))
+			.map(([family, options]) => [
+				family,
+				{
+					...(options.hiddenFromUI && { hiddenFromUI: true }),
+					...(options.hiddenFromCustomer && { hiddenFromCustomer: true })
+				}
+			])
+			.filter(([, options]) => Object.keys(options).length > 0)
+	);
+}

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -154,6 +154,26 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 		value: string;
 		price?: number;
 	}[];
+	/**
+	 * Per-family display options, keyed by the family id used in `variations[].name`.
+	 * A family absent from this record behaves as it always has: a dropdown on the product
+	 * page, and the chosen value shown to the customer.
+	 */
+	variationFamilies?: Record<
+		string,
+		{
+			/** No dropdown on the product page. The value can then only come from the URL. */
+			hiddenFromUI?: boolean;
+			/** Never shown to the customer: cart, mini-cart, add-to-cart popup, order summary. */
+			hiddenFromCustomer?: boolean;
+		}
+	>;
+	/**
+	 * What to do when the URL asks for a variation the product does not have, or leaves a
+	 * family hidden from the product page unset. `error` refuses the page; `ignore` drops the
+	 * bad parameter and falls back to a dropdown. Defaults to `error`.
+	 */
+	variationUrlPolicy?: 'error' | 'ignore';
 	hasSellDisclaimer?: boolean;
 	hideFromSEO?: boolean;
 	event?: {
@@ -223,4 +243,79 @@ export function checkProductVariationsIntegrity(
 		variationNamesInDB.every((name) => chosenVariationNames.includes(name));
 
 	return allVariationsChosen;
+}
+
+export type VariationUrlError =
+	| { reason: 'unknownFamily'; family: string }
+	| { reason: 'unknownValue'; family: string; value: string }
+	| { reason: 'missingHiddenFamily'; family: string };
+
+/**
+ * Reads variation choices off the query string: `?color=red&size=xxl`. The family is the id
+ * held in `variations[].name`, the value the id held in `variations[].value`.
+ *
+ * A family whose value comes from the URL loses its dropdown — the choice is already made.
+ * A family flagged `hiddenFromUI` has no dropdown at all, so the URL is its only source;
+ * leaving it unset is reported rather than silently yielding an unbuyable product.
+ *
+ * Only parameters naming a family the shop declared are judged. Anything else on the query
+ * string — a campaign tag, a tracking id — is none of this function's business, and treating
+ * it as a bad variation would make every marketing link break the product page.
+ */
+export function resolveVariationsFromUrl(
+	product: Pick<Product, 'variations' | 'variationFamilies'>,
+	searchParams: URLSearchParams
+): { forced: Record<string, string>; errors: VariationUrlError[] } {
+	const families = new Map<string, Set<string>>();
+	for (const variation of product.variations ?? []) {
+		const values = families.get(variation.name) ?? new Set<string>();
+		values.add(variation.value);
+		families.set(variation.name, values);
+	}
+
+	const forced: Record<string, string> = {};
+	const errors: VariationUrlError[] = [];
+
+	for (const [family, value] of searchParams) {
+		const values = families.get(family);
+		if (!values) {
+			if (product.variationFamilies?.[family]) {
+				errors.push({ reason: 'unknownFamily', family });
+			}
+			continue;
+		}
+		if (!values.has(value)) {
+			errors.push({ reason: 'unknownValue', family, value });
+			continue;
+		}
+		forced[family] = value;
+	}
+
+	for (const family of families.keys()) {
+		if (product.variationFamilies?.[family]?.hiddenFromUI && !(family in forced)) {
+			errors.push({ reason: 'missingHiddenFamily', family });
+		}
+	}
+
+	return { forced, errors };
+}
+
+/**
+ * Product name suffixed with the chosen variations the customer is allowed to see.
+ *
+ * Shared by every customer-facing listing so that a family hidden from the cart is hidden
+ * from all of them at once: cart, mini-cart, add-to-cart popup, order summary.
+ */
+export function productLabelWithVariations(
+	product: Pick<Product, 'name' | 'variationLabels' | 'variationFamilies'>,
+	chosenVariations: Record<string, string> | undefined
+): string {
+	if (!chosenVariations) {
+		return product.name;
+	}
+	const shown = Object.entries(chosenVariations)
+		.filter(([family]) => !product.variationFamilies?.[family]?.hiddenFromCustomer)
+		.map(([family, value]) => product.variationLabels?.values[family]?.[value] ?? value);
+
+	return shown.length ? `${product.name} - ${shown.join(' - ')}` : product.name;
 }

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -135,6 +135,7 @@ export async function load(params) {
 							| 'vatProfileId'
 							| 'paymentMethods'
 							| 'variationLabels'
+							| 'variationFamilies'
 							| 'bookingSpec.slotMinutes'
 							| 'subscriptionDuration'
 						>
@@ -165,7 +166,8 @@ export async function load(params) {
 						subscriptionDuration: 1,
 						variationLabels: {
 							$ifNull: [`$translations.${locals.language}.variationLabels`, '$variationLabels']
-						}
+						},
+						variationFamilies: 1
 					})
 					.map((p) =>
 						runtimeConfig.deliveryFees.mode !== 'perItem' ? { ...p, deliveryFees: undefined } : p

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -35,7 +35,7 @@
 	import CmsDesign from '$lib/components/CmsDesign.svelte';
 	import { toCurrency } from '$lib/utils/toCurrency.js';
 	import IconSystem from '$lib/components/icons/IconSystem.svelte';
-	import { oneMaxPerLine } from '$lib/types/Product.js';
+	import { oneMaxPerLine, productLabelWithVariations } from '$lib/types/Product.js';
 
 	export let data;
 
@@ -360,16 +360,7 @@
 											<div class="flex flex-col">
 												<a href="/product/{item.product._id}">
 													<h3 class="text-base font-medium">
-														{item.chosenVariations
-															? item.product.name +
-															  ' - ' +
-															  Object.entries(item.chosenVariations)
-																	.map(
-																		([key, value]) =>
-																			item.product.variationLabels?.values[key][value]
-																	)
-																	.join(' - ')
-															: item.product.name}
+														{productLabelWithVariations(item.product, item.chosenVariations)}
 													</h3>
 												</a>
 												{#if !oneMaxPerLine(item.product)}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -18,7 +18,8 @@ import {
 	amountOfProductSold,
 	getProductsWithStock,
 	validateStockReference,
-	cleanVariationLabels
+	cleanVariationLabels,
+	cleanVariationFamilies
 } from '$lib/server/product';
 import type { Tag } from '$lib/types/Tag';
 import { adminPrefix } from '$lib/server/admin';
@@ -289,7 +290,12 @@ export const actions: Actions = {
 						...(hasVariations &&
 							validVariations.length > 0 && {
 								variations: validVariations,
-								variationLabels: cleanedVariationLabels
+								variationLabels: cleanedVariationLabels,
+								variationFamilies: cleanVariationFamilies(
+									parsed.variationFamilies,
+									validVariations
+								),
+								variationUrlPolicy: parsed.variationUrlPolicy
 							}),
 						hasSellDisclaimer: parsed.hasSellDisclaimer,
 						...(parsed.hasSellDisclaimer &&
@@ -332,7 +338,9 @@ export const actions: Actions = {
 						...(parsed.hasVariations &&
 							validVariations.length === 0 && {
 								variations: '',
-								variationLabels: ''
+								variationLabels: '',
+								variationFamilies: '',
+								variationUrlPolicy: ''
 							}),
 						...(!parsed.paidOrderWebhook && { paidOrderWebhook: '' })
 					}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -251,6 +251,16 @@ export const productBaseSchema = () => ({
 		)
 		.optional()
 		.default([]),
+	variationFamilies: z
+		.record(
+			z.string(),
+			z.object({
+				hiddenFromUI: z.boolean({ coerce: true }).default(false),
+				hiddenFromCustomer: z.boolean({ coerce: true }).default(false)
+			})
+		)
+		.optional(),
+	variationUrlPolicy: z.enum(['error', 'ignore']).default('error'),
 	variationLabels: z
 		.object({
 			names: z.record(z.string().trim(), z.string().trim()),

--- a/src/routes/(app)/cart/+page.svelte
+++ b/src/routes/(app)/cart/+page.svelte
@@ -15,7 +15,7 @@
 	import { computeDeliveryFees } from '$lib/cart';
 	import { isAlpha2CountryCode } from '$lib/types/Country.js';
 	import { UNDERLYING_CURRENCY } from '$lib/types/Currency.js';
-	import { oneMaxPerLine } from '$lib/types/Product.js';
+	import { oneMaxPerLine, productLabelWithVariations } from '$lib/types/Product.js';
 	import { UrlDependency } from '$lib/types/UrlDependency.js';
 	import CmsDesign from '$lib/components/CmsDesign.svelte';
 	import { CUSTOMER_ROLE_ID } from '$lib/types/User';
@@ -217,13 +217,7 @@
 						<!-- Mobile-only title (lg+: shown inside info column instead) -->
 						<a href="/product/{item.product._id}" class="block mb-4 lg:hidden">
 							<h2 class="text-2xl">
-								{item.chosenVariations
-									? item.product.name +
-									  ' - ' +
-									  Object.entries(item.chosenVariations)
-											.map(([key, value]) => item.product.variationLabels?.values[key][value])
-											.join(' - ')
-									: item.product.name}
+								{productLabelWithVariations(item.product, item.chosenVariations)}
 							</h2>
 						</a>
 
@@ -290,13 +284,7 @@
 						<div class="hidden lg:flex flex-col lg:gap-2">
 							<a href="/product/{item.product._id}">
 								<h2 class="text-2xl">
-									{item.chosenVariations
-										? item.product.name +
-										  ' - ' +
-										  Object.entries(item.chosenVariations)
-												.map(([key, value]) => item.product.variationLabels?.values[key][value])
-												.join(' - ')
-										: item.product.name}
+									{productLabelWithVariations(item.product, item.chosenVariations)}
 								</h2>
 							</a>
 							<p class="text-sm">{item.product.shortDescription}</p>

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { applyAction, enhance } from '$app/forms';
+	import { productLabelWithVariations } from '$lib/types/Product';
 	import { goto } from '$app/navigation';
 	import Picture from '$lib/components/Picture.svelte';
 	import PriceTag from '$lib/components/PriceTag.svelte';
@@ -828,13 +829,10 @@
 						{/if}
 						<a href="/product/{item.product._id}">
 							<h3 class="text-base">
-								{item.chosenVariations
-									? item.product.name +
-									  ' - ' +
-									  Object.entries(item.chosenVariations)
-											.map(([key, value]) => item.product.variationLabels?.values[key][value])
-											.join(' - ')
-									: item.product.name}{#if item.quantity > 1 && !item.product.bookingSpec}<span
+								{productLabelWithVariations(
+									item.product,
+									item.chosenVariations
+								)}{#if item.quantity > 1 && !item.product.bookingSpec}<span
 										class="text-gray-500 ml-1">× {item.quantity}</span
 									>{/if}
 							</h3>

--- a/src/routes/(app)/order/[id]/fetchOrderForUser.ts
+++ b/src/routes/(app)/order/[id]/fetchOrderForUser.ts
@@ -177,6 +177,9 @@ export async function fetchOrderForUser(orderId: string, params?: { userRoleId?:
 				paymentMethods: item.product.paymentMethods,
 				isTicket: item.product.isTicket,
 				variationLabels: item.product.variationLabels,
+				// Without the families, productLabelWithVariations has nothing to hide a family by,
+				// and the order pages spell out what the product page keeps to itself.
+				variationFamilies: item.product.variationFamilies,
 				externalResources: item.product.externalResources?.map((externalResource) => ({
 					label: externalResource.label,
 					href: order.status === 'paid' ? externalResource.href : undefined

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Picture from '$lib/components/Picture.svelte';
+	import { productLabelWithVariations } from '$lib/types/Product';
 	import PriceTag from '$lib/components/PriceTag.svelte';
 	import Trans from '$lib/components/Trans.svelte';
 	import { useI18n } from '$lib/i18n.js';
@@ -216,13 +217,7 @@
 				<tr style:background-color={i % 2 === 0 ? '#fef2cc' : '#e7e6e6'}>
 					<td class="text-center border border-white px-2">{i + 1}</td>
 					<td class="text-center border border-white px-2"
-						>{item.chosenVariations
-							? item.product.name +
-							  ' - ' +
-							  Object.entries(item.chosenVariations)
-									.map(([key, value]) => item.product.variationLabels?.values[key][value])
-									.join(' - ')
-							: item.product.name}</td
+						>{productLabelWithVariations(item.product, item.chosenVariations)}</td
 					>
 					<td class="text-center border border-white px-2"
 						>{paidQuantity}

--- a/src/routes/(app)/order/[id]/summary/+page.svelte
+++ b/src/routes/(app)/order/[id]/summary/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Picture from '$lib/components/Picture.svelte';
+	import { productLabelWithVariations } from '$lib/types/Product';
 	import PriceTag from '$lib/components/PriceTag.svelte';
 	import Trans from '$lib/components/Trans.svelte';
 	import { useI18n } from '$lib/i18n.js';
@@ -129,13 +130,7 @@
 			<tr style:background-color={i % 2 === 0 ? '#fef2cc' : '#e7e6e6'}>
 				<td class="text-center border border-white px-2">{i + 1}</td>
 				<td class="text-center border border-white px-2"
-					>{item.chosenVariations
-						? item.product.name +
-						  ' - ' +
-						  Object.entries(item.chosenVariations)
-								.map(([key, value]) => item.product.variationLabels?.values[key][value])
-								.join(' - ')
-						: item.product.name}</td
+					>{productLabelWithVariations(item.product, item.chosenVariations)}</td
 				>
 				<td class="text-center border border-white px-2">{item.quantity}</td>
 				<td class="text-center border border-white px-2">

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -7,7 +7,12 @@ import { runtimeConfig } from '$lib/server/runtime-config';
 import { adminPrefix as getAdminPrefix } from '$lib/server/admin';
 import { userIdentifier, userQuery } from '$lib/server/user';
 import { CURRENCIES, parsePriceAmount } from '$lib/types/Currency';
-import { DEFAULT_MAX_QUANTITY_PER_ORDER, type Product } from '$lib/types/Product';
+import {
+	DEFAULT_MAX_QUANTITY_PER_ORDER,
+	resolveVariationsFromUrl,
+	type VariationUrlError,
+	type Product
+} from '$lib/types/Product';
 import { computeVatRate, extractVat } from '$lib/utils/vat';
 import { productToScheduleId, type ScheduleEvent } from '$lib/types/Schedule';
 import { set } from '$lib/utils/set';
@@ -107,6 +112,8 @@ async function fetchProduct(
 	| 'mobile'
 	| 'hasVariations'
 	| 'variations'
+	| 'variationFamilies'
+	| 'variationUrlPolicy'
 	| 'variationLabels'
 	| 'sellDisclaimer'
 	| 'hasSellDisclaimer'
@@ -157,6 +164,8 @@ async function fetchProduct(
 					$ifNull: [`$translations.${language}.variationLabels`, '$variationLabels']
 				},
 				variations: 1,
+				variationFamilies: 1,
+				variationUrlPolicy: 1,
 				maximumPrice: 1,
 				recommendedPWYWAmount: 1,
 				mobile: 1,
@@ -197,6 +206,18 @@ async function fetchProductSchedule(productId: string) {
 	return collections.schedules.findOne({ _id: productToScheduleId(productId) });
 }
 
+/** Plain-English like the other product-page errors; those are not translated either. */
+function variationUrlErrorMessage(error: VariationUrlError): string {
+	switch (error.reason) {
+		case 'unknownFamily':
+			return `This product has no "${error.family}" option.`;
+		case 'unknownValue':
+			return `"${error.value}" is not a valid ${error.family} for this product.`;
+		case 'missingHiddenFamily':
+			return `This product needs a ${error.family} to be set from the link you followed.`;
+	}
+}
+
 async function fetchProductScheduleEvents(productId: string) {
 	return collections.scheduleEvents
 		.find({
@@ -213,11 +234,24 @@ async function fetchProductScheduleEvents(productId: string) {
 		.toArray();
 }
 
-export const load = async ({ params, parent, locals }) => {
+export const load = async ({ params, url, parent, locals }) => {
 	const productId = params.id;
 	const product = await fetchProduct(productId, locals.language);
 	if (!product) {
 		throw error(404, 'Page not found');
+	}
+
+	// A variation can be settled by the URL — `?color=red` — instead of by a dropdown. That is
+	// the only way to set a family the shop hid from the page, which is what lets a value nobody
+	// should be able to pick from a list reach an order.
+	const { forced: forcedVariations, errors: variationErrors } = resolveVariationsFromUrl(
+		product,
+		url.searchParams
+	);
+	if (variationErrors.length && (product.variationUrlPolicy ?? 'error') !== 'ignore') {
+		// Refusing the page rather than falling back keeps the shop out of default-value and
+		// silent-substitution territory: a wrong link is wrong, and says so.
+		throw error(400, variationUrlErrorMessage(variationErrors[0]));
 	}
 	if (
 		locals.user?.hasPosOptions
@@ -266,6 +300,7 @@ export const load = async ({ params, parent, locals }) => {
 	});
 
 	return {
+		forcedVariations,
 		product: {
 			...product,
 			vatProfileId: product.vatProfileId?.toString(),

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -474,7 +474,9 @@
 		isZoomed = !isZoomed;
 	}
 
-	let selectedVariations: Record<string, string> = {};
+	// Seeded from the URL so the price preview and the POST body carry the forced values even
+	// though no dropdown was ever rendered for them.
+	let selectedVariations: Record<string, string> = { ...data.forcedVariations };
 	$: if (data.product.hasVariations) {
 		customAmount = productPriceWithVariations(data.product, selectedVariations);
 	}
@@ -977,17 +979,27 @@
 							{/if}
 							{#if data.product.standalone && data.product.hasVariations && data.product.variationLabels}
 								{#each Object.keys(data.product.variationLabels.values) as key}
-									<label class="mb-2" for={key}>{data.product.variationLabels.names[key]}</label>
-									<select
-										bind:value={selectedVariations[key]}
-										id={key}
-										name="chosenVariations[{key}]"
-										class="form-input w-full inline cursor-pointer"
-									>
-										{#each Object.entries(data.product.variationLabels.values[key]) as [valueKey, valueLabel]}
-											<option value={valueKey}>{valueLabel}</option>
-										{/each}
-									</select>
+									{#if key in data.forcedVariations || data.product.variationFamilies?.[key]?.hiddenFromUI}
+										<!-- Settled by the URL, or never offered as a choice: no dropdown, but the
+										     value still has to reach the add-to-cart POST. -->
+										<input
+											type="hidden"
+											name="chosenVariations[{key}]"
+											value={selectedVariations[key]}
+										/>
+									{:else}
+										<label class="mb-2" for={key}>{data.product.variationLabels.names[key]}</label>
+										<select
+											bind:value={selectedVariations[key]}
+											id={key}
+											name="chosenVariations[{key}]"
+											class="form-input w-full inline cursor-pointer"
+										>
+											{#each Object.entries(data.product.variationLabels.values[key]) as [valueKey, valueLabel]}
+												<option value={valueKey}>{valueLabel}</option>
+											{/each}
+										</select>
+									{/if}
 								{/each}
 							{/if}
 							{#if !oneMaxPerLine(data.product) && amountAvailable > 0}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,11 @@ export default defineConfig(({ command }) => {
 			})
 		],
 		test: {
-			include: ['src/**/*.{test,spec}.{js,ts}']
+			include: ['src/**/*.{test,spec}.{js,ts}'],
+			// One database, shared by every suite that touches Mongo, and several of them wipe it
+			// clean between tests. Run in parallel, one file's cleanDb() empties the collection
+			// another has just seeded, and the failure lands on whichever file was unlucky.
+			poolOptions: { threads: { singleThread: true } }
 		},
 		// LayerCake ships uncompiled .svelte files; let Vite transform them for SSR
 		// instead of Node trying to import the raw .svelte (ERR_UNKNOWN_FILE_EXTENSION).


### PR DESCRIPTION
A product sold in several variations could only be bought by picking each one from a dropdown. Handing someone a link that already carries the choice was not possible, and neither was selling something whose variation nobody should be able to pick from a list — a numbered seat, a bracelet, an artifact with its own identifier.

A variation can now be set from the address: /product/artifact?color=red, or several at once with ?color=red&size=xxl. A variation settled that way loses its dropdown — the choice is already made — and follows the purchase through to the cart and the order exactly as if it had been picked by hand.

Two settings sit under the variations block on the product page, one line per family:

- Hide from the product page. The family never appears as a dropdown, so the link is the only way to set it. Someone landing on the bare product address cannot pick a value, and cannot guess one from a list.
- Hide from cart and order. The value is recorded but never shown back to the customer, on any page.

A link that asks for something the product does not have — an unknown family, an unknown value, or nothing at all for a family that has no dropdown — refuses the page and says why, rather than quietly falling back to some other value. A product can be set to ignore the bad parameter and show its dropdowns instead. Parameters that name no variation at all, such as campaign tags, are left alone.

Each variation row carries a link button that copies the address landing on the product with that variation already chosen. The value a link has to carry is not always the label that was typed — a purely numeric value is prefixed with its family name, so typing 10 on a "load" family stores load10 — and nothing in the form showed it, which left the link to be guessed.

Fixes #2688
