### PR TITLE
🐛🤖 Give every concurrent settlement its own invoice number (#2743)

### DIFF
--- a/src/lib/server/migrations.ts
+++ b/src/lib/server/migrations.ts
@@ -988,6 +988,40 @@ export const migrations = [
 				);
 			}
 		}
+	},
+	{
+		_id: new ObjectId('68b9a4c17d2f4e0a3c5b1d90'),
+		name: 'Seed the invoice number counter from the invoices already issued',
+		run: async (session: ClientSession) => {
+			// Invoice numbers used to be derived by reading the highest one already stored (#2743).
+			// The counter has to start past that, or the first invoice issued after this migration
+			// would reuse a number the shop has already given out.
+			const highest = await collections.orders
+				.aggregate<{ payments: Array<{ invoice?: { number: number } }> }>(
+					[
+						{ $match: { 'payments.invoice.number': { $exists: true } } },
+						{ $sort: { 'payments.invoice.number': -1 } },
+						{ $limit: 1 },
+						{ $project: { 'payments.invoice.number': 1 } }
+					],
+					{ session }
+				)
+				.next();
+
+			const highestNumber = Math.max(
+				0,
+				...(highest?.payments ?? []).map((payment) => payment.invoice?.number ?? 0)
+			);
+
+			await collections.runtimeConfig.updateOne(
+				{ _id: 'invoiceNumber' },
+				{
+					$set: { data: highestNumber as never, updatedAt: new Date() },
+					$setOnInsert: { createdAt: new Date() }
+				},
+				{ upsert: true, session }
+			);
+		}
 	}
 ];
 

--- a/src/lib/server/order.test.ts
+++ b/src/lib/server/order.test.ts
@@ -242,6 +242,43 @@ describe('order', () => {
 		expect(order1?.payments[1].invoice?.number).toBe(3);
 	});
 
+	it('gives every concurrent settlement its own invoice number', async () => {
+		// #2743: invoice numbers were derived by reading back the highest one already stored, so
+		// settlements landing together computed the same next number. The unique index let one
+		// through and the rest lost their payment, leaving those orders pending at zero.
+		const orderIds = await Promise.all(
+			Array.from({ length: 8 }, (_, i) =>
+				createOrder([{ product: TEST_DIGITAL_PRODUCT, quantity: 1 }], 'point-of-sale', {
+					locale: 'en',
+					user: { sessionId: `concurrent-session-${i}` },
+					shippingAddress: null,
+					userVatCountry: 'FR'
+				})
+			)
+		);
+
+		const orders = await Promise.all(
+			orderIds.map(async (id) => {
+				const order = await collections.orders.findOne({ _id: id });
+				if (!order) {
+					throw new Error(`Order ${id} not found`);
+				}
+				return order;
+			})
+		);
+
+		await Promise.all(
+			orders.map((order) => onOrderPayment(order, order.payments[0], order.payments[0].price))
+		);
+
+		const settled = await collections.orders.find({ _id: { $in: orderIds } }).toArray();
+		const invoiceNumbers = settled.map((order) => order.payments[0].invoice?.number);
+
+		expect(invoiceNumbers.every((number) => typeof number === 'number')).toBe(true);
+		expect(new Set(invoiceNumbers).size).toBe(orderIds.length);
+		expect(settled.every((order) => order.payments[0].status === 'paid')).toBe(true);
+	});
+
 	it('should allow free method payment when only item is fully discounted due to an active subscription', async () => {
 		await createPaidSubscription(TEST_SUBSCRIPTION_PRODUCT._id, {
 			sessionId: 'test-session-id'

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -120,6 +120,32 @@ async function generateOrderNumber(session?: ClientSession): Promise<number> {
 	return res.value.data as number;
 }
 
+/**
+ * Next invoice number, from a counter of its own.
+ *
+ * It used to be read back off the orders themselves — the highest number already stored, plus
+ * one. Two settlements landing together read the same highest number, computed the same next
+ * one, and the unique index on `payments.invoice.number` let only one of them through: the
+ * others lost their payment and stayed pending (#2743). A single atomic increment cannot hand
+ * the same value to two callers.
+ *
+ * The counter is seeded past the highest number already issued when the shop starts up, so
+ * numbering continues where the shop left it rather than colliding with its own history.
+ */
+async function generateInvoiceNumber(session?: ClientSession): Promise<number> {
+	const res = await collections.runtimeConfig.findOneAndUpdate(
+		{ _id: 'invoiceNumber' },
+		{ $inc: { data: 1 as never } },
+		{ upsert: true, returnDocument: 'after', session }
+	);
+
+	if (!res.value) {
+		throw new Error('Failed to increment invoice number');
+	}
+
+	return res.value.data as number;
+}
+
 export function isOrderFullyPaid(order: Order, opts?: { includePendingOrders?: boolean }): boolean {
 	const unit = CURRENCY_UNIT[order.currencySnapshot.main.totalPrice.currency];
 	// Special case: no payments yet and order of 0.01€ => it's not fully paid
@@ -155,7 +181,7 @@ export async function onOrderPayment(
 		firstPaidTransition?: boolean;
 	}
 ): Promise<Order> {
-	const invoiceNumber = ((await lastInvoiceNumber()) ?? 0) + 1;
+	const invoiceNumber = await generateInvoiceNumber(params?.providedSession);
 
 	if (!order.payments.includes(payment)) {
 		throw new Error('Sync broken between order and payment');
@@ -677,6 +703,12 @@ export async function anonymizeOrderData(orderId: string): Promise<boolean> {
 	return result.modifiedCount > 0;
 }
 
+/**
+ * Highest invoice number actually stored on an order.
+ *
+ * No longer what issues the next one — see `generateInvoiceNumber`. Kept as a read: it answers
+ * "what has this shop given out", which is what the seeding migration and the tests ask.
+ */
 export async function lastInvoiceNumber(): Promise<number | undefined> {
 	return (
 		await collections.orders

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -80,6 +80,8 @@ const baseConfig = {
 	priceReferenceCurrency: 'SAT' as Currency,
 	accountingCurrency: null as Currency | null,
 	orderNumber: 0,
+	/** Counter behind invoice numbers. Seeded from the invoices already issued (#2743). */
+	invoiceNumber: 0,
 	paymentMethods: { order: [] as PaymentMethod[], disabled: [] as PaymentMethod[] },
 	paymentProcessorPreferences: {} as Partial<Record<PaymentMethod, PaymentProcessor>>,
 	/**


### PR DESCRIPTION
Settling several payments at the same moment recorded one of them and lost the others: those orders stayed pending, showing nothing paid and carrying no invoice, while the caller was told the order had been created. A person at a till never hits this — two sales cannot be settled in the same instant — but an automated flow of payments does, and a shop taking payments that way was short by the lost sales with no sign of it anywhere.

Invoice numbers were worked out by reading back the highest one already on an order and adding one. Settlements landing together read the same highest number and computed the same next one, and only one of them could be stored. They now come from a counter of their own, which cannot hand the same number to two callers, the same way order numbers already worked.

Shops that have already issued invoices keep their numbering: the counter starts past the highest number given out, read once when the shop next starts.

Fixes #2743
