### PR TITLE
🐛🤖 Honour "Disable VAT for my be-BOP" everywhere a rate is shown (#2649)

### DIFF
--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -155,7 +155,8 @@ function computeVatForItem(
 		vatProfiles: params.vatProfiles,
 		bebopCountry: params.bebopCountry,
 		userCountry: params.userCountry,
-		vatSingleCountry: params.vatSingleCountry
+		vatSingleCountry: params.vatSingleCountry,
+		vatExempted: params.vatExempted
 	});
 	const freeUnits = params.freeUnits ?? 0;
 	const { amount: amountToBill, currency, usedFreeUnits } = priceToBillForItem(item, { freeUnits });
@@ -275,6 +276,7 @@ function computeDeliveryFeesHt(params: {
 	bebopCountry: CountryAlpha2 | undefined;
 	userCountry: CountryAlpha2 | undefined;
 	vatSingleCountry: boolean;
+	vatExempted?: boolean;
 	vatProfiles: Array<{
 		_id: string | ObjectId;
 		rates: Partial<Record<CountryAlpha2, number>>;
@@ -288,7 +290,8 @@ function computeDeliveryFeesHt(params: {
 		vatProfiles: params.vatProfiles,
 		bebopCountry: params.bebopCountry,
 		userCountry: params.userCountry,
-		vatSingleCountry: params.vatSingleCountry
+		vatSingleCountry: params.vatSingleCountry,
+		vatExempted: params.vatExempted
 	});
 	return {
 		amount: extractVat(params.deliveryFees.amount, rate),
@@ -382,6 +385,7 @@ export function computePriceInfo(
 		bebopCountry: params.bebopCountry,
 		userCountry: params.userCountry,
 		vatSingleCountry: params.vatSingleCountry,
+		vatExempted: params.vatExempted,
 		vatProfiles: params.vatProfiles
 	});
 

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -174,7 +174,8 @@
 		vatProfiles,
 		bebopCountry: $page.data.vatCountry,
 		userCountry: $page.data.vatCountry,
-		vatSingleCountry: true
+		vatSingleCountry: true,
+		vatExempted: $page.data.vatExempted
 	});
 	$: vatProfileLabel =
 		vatProfiles.find((p) => p._id === vatProfileId)?.name ?? 'No custom VAT profile';

--- a/src/lib/server/cms.ts
+++ b/src/lib/server/cms.ts
@@ -854,6 +854,7 @@ async function buildSearchlistViews(searchlistSlugs: string[], locals: App.Local
 		bebopCountry: runtimeConfig.vatCountry,
 		userCountry: locals.countryCode,
 		vatSingleCountry: runtimeConfig.vatSingleCountry,
+		vatExempted: runtimeConfig.vatExempted,
 		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
 	};
 

--- a/src/lib/server/searchlist.ts
+++ b/src/lib/server/searchlist.ts
@@ -193,6 +193,7 @@ export type VatContext = {
 	bebopCountry: CountryAlpha2 | undefined;
 	userCountry: CountryAlpha2 | undefined;
 	vatSingleCountry: boolean;
+	vatExempted: boolean;
 	displayVatIncluded: boolean;
 };
 
@@ -256,7 +257,8 @@ export async function searchProducts(
 					vatProfiles: vat.vatProfiles,
 					bebopCountry: vat.bebopCountry,
 					userCountry: vat.userCountry,
-					vatSingleCountry: vat.vatSingleCountry
+					vatSingleCountry: vat.vatSingleCountry,
+					vatExempted: vat.vatExempted
 				});
 				const branches = vat.vatProfiles.map((vp) => ({
 					case: { $eq: ['$vatProfileId', new ObjectId(vp._id)] },
@@ -267,7 +269,8 @@ export async function searchProducts(
 							vatProfiles: vat.vatProfiles,
 							bebopCountry: vat.bebopCountry,
 							userCountry: vat.userCountry,
-							vatSingleCountry: vat.vatSingleCountry
+							vatSingleCountry: vat.vatSingleCountry,
+							vatExempted: vat.vatExempted
 						}) /
 							100
 				}));

--- a/src/lib/utils/vat.test.ts
+++ b/src/lib/utils/vat.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { computeVatRate } from './vat';
+
+const CH_PROFILE = { _id: 'profile-ch', rates: { CH: 2.6 } } as const;
+
+describe('computeVatRate', () => {
+	it('falls back to the country rate when no profile is set', () => {
+		expect(
+			computeVatRate({
+				productVatProfileId: undefined,
+				vatProfiles: [],
+				bebopCountry: 'CH',
+				userCountry: 'CH',
+				vatSingleCountry: true
+			})
+		).toBeGreaterThan(0);
+	});
+
+	it('prefers the profile rate over the country rate', () => {
+		expect(
+			computeVatRate({
+				productVatProfileId: CH_PROFILE._id,
+				vatProfiles: [CH_PROFILE],
+				bebopCountry: 'CH',
+				userCountry: 'CH',
+				vatSingleCountry: true
+			})
+		).toBe(2.6);
+	});
+
+	// #2649: a shop that turned VAT off was still shown the country rate, and a price entered
+	// VAT-included was divided by a tax it does not charge. The exemption wins over everything,
+	// so any fee routed through here — a product, delivery, whatever comes next — inherits it.
+	describe('when the shop is VAT exempt', () => {
+		it('returns zero instead of the country rate', () => {
+			expect(
+				computeVatRate({
+					productVatProfileId: undefined,
+					vatProfiles: [],
+					bebopCountry: 'CH',
+					userCountry: 'CH',
+					vatSingleCountry: true,
+					vatExempted: true
+				})
+			).toBe(0);
+		});
+
+		it('returns zero even when a custom profile carries a rate', () => {
+			expect(
+				computeVatRate({
+					productVatProfileId: CH_PROFILE._id,
+					vatProfiles: [CH_PROFILE],
+					bebopCountry: 'CH',
+					userCountry: 'CH',
+					vatSingleCountry: true,
+					vatExempted: true
+				})
+			).toBe(0);
+		});
+
+		it('returns zero whatever the customer country', () => {
+			expect(
+				computeVatRate({
+					productVatProfileId: undefined,
+					vatProfiles: [],
+					bebopCountry: 'CH',
+					userCountry: 'FR',
+					vatSingleCountry: false,
+					vatExempted: true
+				})
+			).toBe(0);
+		});
+	});
+});

--- a/src/lib/utils/vat.ts
+++ b/src/lib/utils/vat.ts
@@ -4,6 +4,13 @@ import type { ObjectId } from 'mongodb';
 
 /**
  * Computes the VAT rate for a product considering custom VAT profiles
+ *
+ * Every rate the shop shows or bills goes through here — a product, a delivery fee, and
+ * whatever fee is added next. That is deliberate: the shop-wide exemption is settled once,
+ * at the top of this function, so a new kind of fee inherits it without anyone remembering to
+ * ask. Before that, "Disable VAT for my be-BOP" was honoured when the order was priced but not
+ * when a rate was shown, and a shop entering a VAT-included price had it divided by a tax it
+ * does not charge (#2649).
  */
 export function computeVatRate(params: {
 	productVatProfileId: string | ObjectId | undefined;
@@ -14,7 +21,13 @@ export function computeVatRate(params: {
 	bebopCountry: CountryAlpha2 | undefined;
 	userCountry: CountryAlpha2 | undefined;
 	vatSingleCountry: boolean;
+	/** "Disable VAT for my be-BOP". Nothing is taxed, whatever the country or profile says. */
+	vatExempted?: boolean;
 }): number {
+	if (params.vatExempted) {
+		return 0;
+	}
+
 	const country = params.vatSingleCountry
 		? params.bebopCountry
 		: params.userCountry ?? params.bebopCountry;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.svelte
@@ -18,7 +18,8 @@
 		vatProfiles: data.vatProfiles,
 		bebopCountry: data.vatCountry,
 		userCountry: data.vatCountry,
-		vatSingleCountry: true
+		vatSingleCountry: true,
+		vatExempted: data.vatExempted
 	});
 </script>
 

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -157,7 +157,8 @@
 		vatProfiles: data.vatProfiles,
 		bebopCountry: data.vatCountry,
 		userCountry: isDigital ? digitalCountry : country,
-		vatSingleCountry: data.vatSingleCountry
+		vatSingleCountry: data.vatSingleCountry,
+		vatExempted: data.vatExempted
 	});
 	$: deliveryFeesToDisplay = data.deliveryFees.vatIncludedReference
 		? extractVat(deliveryFeesToBill, deliveryFeesVatRate)

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -103,7 +103,8 @@
 			vatProfiles: data.vatProfiles,
 			bebopCountry: data.vatCountry,
 			userCountry: data.countryCode,
-			vatSingleCountry: data.vatSingleCountry
+			vatSingleCountry: data.vatSingleCountry,
+			vatExempted: data.vatExempted
 		});
 		return toCurrency(
 			data.currencies.main,

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -262,7 +262,8 @@ export const load = async ({ params, parent, locals }) => {
 		vatProfiles: parentData.vatProfiles,
 		bebopCountry: runtimeConfig.vatCountry,
 		userCountry: locals.countryCode,
-		vatSingleCountry: runtimeConfig.vatSingleCountry
+		vatSingleCountry: runtimeConfig.vatSingleCountry,
+		vatExempted: runtimeConfig.vatExempted
 	});
 
 	return {
@@ -373,7 +374,8 @@ async function addToCart({ params, request, locals }: RequestEvent) {
 			vatProfiles,
 			bebopCountry: runtimeConfig.vatCountry,
 			userCountry: locals.countryCode,
-			vatSingleCountry: runtimeConfig.vatSingleCountry
+			vatSingleCountry: runtimeConfig.vatSingleCountry,
+			vatExempted: runtimeConfig.vatExempted
 		});
 
 		// Extract VAT: entered price is WITH VAT, we need to store WITHOUT VAT

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -641,14 +641,19 @@
 						<!-- svelte-ignore a11y-click-events-have-key-events -->
 						<!-- svelte-ignore a11y-no-static-element-interactions -->
 						<div
-							class="flex flex-col gap-1 cursor-pointer"
-							on:click={() => (showExclTax = !showExclTax)}
+							class="flex flex-col gap-1"
+							class:cursor-pointer={!data.vatExempted}
+							on:click={() => (showExclTax = !data.vatExempted && !showExclTax)}
 						>
-							<span class="text-sm"
-								>{t('product.vatIncluded')} ({t('cart.vat')}
-								{vatRate}%)
-								<span class="text-gray-400 text-xs ml-1">{showExclTax ? '▲' : '▼'}</span></span
-							>
+							<!-- A shop with VAT turned off has nothing to say about it: no rate, no caption,
+							     and no toggle to a breakdown that would be empty. -->
+							{#if !data.vatExempted}
+								<span class="text-sm"
+									>{t('product.vatIncluded')} ({t('cart.vat')}
+									{vatRate}%)
+									<span class="text-gray-400 text-xs ml-1">{showExclTax ? '▲' : '▼'}</span></span
+								>
+							{/if}
 							<div class="flex items-center gap-2">
 								<PriceTag
 									currency={data.product.price.currency}
@@ -699,7 +704,7 @@
 							/>
 						</div>
 
-						{#if showExclTax}
+						{#if showExclTax && !data.vatExempted}
 							<hr class="border-gray-400 mt-2 w-full" />
 							<span class="text-sm mt-1"
 								>{t('product.vatExcludedEstimate')} ({t('cart.vat')} {vatRate}%)</span
@@ -788,7 +793,9 @@
 							secondary
 							class="text-base"
 						/>
-						<span class="font-semibold text-sm">{t('product.vatExcluded')}</span>
+						{#if !data.vatExempted}
+							<span class="font-semibold text-sm">{t('product.vatExcluded')}</span>
+						{/if}
 					</div>
 				{/if}
 

--- a/src/routes/(app)/searchlist/[slug]/+page.server.ts
+++ b/src/routes/(app)/searchlist/[slug]/+page.server.ts
@@ -35,6 +35,7 @@ export const load = async ({ params, url, locals }) => {
 		bebopCountry: runtimeConfig.vatCountry,
 		userCountry: locals.countryCode,
 		vatSingleCountry: runtimeConfig.vatSingleCountry,
+		vatExempted: runtimeConfig.vatExempted,
 		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
 	};
 
@@ -97,6 +98,7 @@ export const load = async ({ params, url, locals }) => {
 		totalPages,
 		allowedTags,
 		basePath: `/searchlist/${params.slug}`,
+		vatExempted: runtimeConfig.vatExempted,
 		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
 	};
 };


### PR DESCRIPTION
A shop that turned VAT off was still shown its country's rate. Creating a product on a VAT-free shop displayed 8.1%, and the only way to get a VAT-free product was to build a custom profile with a zero rate and pick it by hand, on every product.

Worse than the wrong figure: the product form uses that rate to work back from a VAT-included price. A shop typing what it actually charges had the amount divided by a tax it does not collect, and the price recorded — and later billed — came out lower than the one entered.

Orders were already priced VAT-free; it was every displayed rate that ignored the setting. The exemption is now settled once, at the top of the single function every rate goes through, so the product page, the catalogue listings, the touch till, the checkout and the delivery fees all agree — and a fee added later inherits it without anyone having to remember.

Nothing already recorded is altered: a product carrying a VAT profile keeps it, and a shop that has not turned VAT off is priced exactly as before.

Fixes #2649
