### PR TITLE
🦋🤖 Let a customer subscribe and buy the discounted product in one order (#2718)

### DIFF
--- a/src/lib/server/discount.test.ts
+++ b/src/lib/server/discount.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isPublicZeroCriteriaDiscount, publicDiscountPriceSnapshot } from './discount';
+import {
+	evaluateDiscountConditions,
+	isPublicZeroCriteriaDiscount,
+	publicDiscountPriceSnapshot
+} from './discount';
+import type { DiscountContext } from './discount';
 import type { Discount } from '$lib/types/Discount';
 
 /** Minimal valid public percentage discount; override any field per test. */
@@ -89,5 +94,80 @@ describe('publicDiscountPriceSnapshot', () => {
 			wholeCatalog: false,
 			productIds: ['p1', 'p2']
 		});
+	});
+});
+
+/** Cart context with no conditions met beyond what a test sets. */
+function context(overrides: Partial<DiscountContext> = {}): DiscountContext {
+	return {
+		userSubscriptionIds: [],
+		userContactAddresses: [],
+		cartItems: [],
+		isLoggedIn: false,
+		...overrides
+	};
+}
+
+describe('evaluateDiscountConditions — required subscription', () => {
+	const membership = discount({ subscriptionIds: ['membership'] });
+
+	it('passes when the subscription is already active', () => {
+		expect(
+			evaluateDiscountConditions(membership, context({ userSubscriptionIds: ['membership'] }))
+		).toBe(true);
+	});
+
+	it('fails when the customer has no such subscription', () => {
+		expect(evaluateDiscountConditions(membership, context())).toBe(false);
+	});
+
+	// #2718: without the opt-in, a subscription sitting in the cart is not a subscription the
+	// customer holds — an existing members-only discount must keep meaning paid-up members.
+	it('ignores the subscription sitting in the cart by default', () => {
+		expect(
+			evaluateDiscountConditions(
+				membership,
+				context({ cartItems: [{ productId: 'membership', quantity: 1 }] })
+			)
+		).toBe(false);
+	});
+
+	it('accepts the subscription sitting in the cart once the shop opts in', () => {
+		expect(
+			evaluateDiscountConditions(
+				discount({ subscriptionIds: ['membership'], acceptSubscriptionInCart: true }),
+				context({ cartItems: [{ productId: 'membership', quantity: 1 }] })
+			)
+		).toBe(true);
+	});
+
+	it('still fails with the opt-in when neither the cart nor the customer carries it', () => {
+		expect(
+			evaluateDiscountConditions(
+				discount({ subscriptionIds: ['membership'], acceptSubscriptionInCart: true }),
+				context({ cartItems: [{ productId: 'something-else', quantity: 1 }] })
+			)
+		).toBe(false);
+	});
+});
+
+describe('evaluateDiscountConditions — required product combinations', () => {
+	// #2718: combinations gate the discount and are matched against the cart, so a subscription
+	// works there like any other line once the admin form lets it be picked.
+	const combo = discount({
+		productCombinations: [{ products: [{ productId: 'membership', quantity: 1 }] }]
+	});
+
+	it('matches a subscription listed in a required combination', () => {
+		expect(
+			evaluateDiscountConditions(
+				combo,
+				context({ cartItems: [{ productId: 'membership', quantity: 1 }] })
+			)
+		).toBe(true);
+	});
+
+	it('does not match when the combination is absent from the cart', () => {
+		expect(evaluateDiscountConditions(combo, context())).toBe(false);
 	});
 });

--- a/src/lib/server/discount.ts
+++ b/src/lib/server/discount.ts
@@ -47,11 +47,19 @@ export async function getActivePercentageDiscounts(): Promise<Discount[]> {
  * Each non-empty condition must pass. Empty/undefined = "true" (no filter).
  */
 export function evaluateDiscountConditions(discount: Discount, ctx: DiscountContext): boolean {
-	if (
-		discount.subscriptionIds?.length &&
-		!discount.subscriptionIds.some((id) => ctx.userSubscriptionIds.includes(id))
-	) {
-		return false;
+	if (discount.subscriptionIds?.length) {
+		const hasActiveSubscription = discount.subscriptionIds.some((id) =>
+			ctx.userSubscriptionIds.includes(id)
+		);
+		// Buying the subscription right now counts, when the shop allows it: otherwise a new
+		// customer has to order the membership, come back logged in, and order again (#2718).
+		const isSubscribingNow =
+			!!discount.acceptSubscriptionInCart &&
+			discount.subscriptionIds.some((id) => ctx.cartItems.some((item) => item.productId === id));
+
+		if (!hasActiveSubscription && !isSubscribingNow) {
+			return false;
+		}
 	}
 
 	if (discount.promoCode && discount.promoCode.toLowerCase() !== ctx.promoCode?.toLowerCase()) {

--- a/src/lib/types/Discount.ts
+++ b/src/lib/types/Discount.ts
@@ -14,6 +14,15 @@ export type Discount = Timestamps & {
 	name: string;
 	/** If set, user must have at least one of these active subscriptions */
 	subscriptionIds?: string[];
+	/**
+	 * Accept a `subscriptionIds` subscription sitting in the cart as if it were already active,
+	 * so a customer can subscribe and buy the discounted product in one order (#2718).
+	 *
+	 * Off unless the shop turns it on: a membership discount that already exists means "paid-up
+	 * members only", and flipping that for every shop at once would start applying discounts on
+	 * a membership nobody has paid for yet.
+	 */
+	acceptSubscriptionInCart?: boolean;
 	/** Promo code (case-insensitive match). Percentage mode only */
 	promoCode?: string;
 	/** Sales channels where this discount applies */

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.server.ts
@@ -70,6 +70,7 @@ export const actions = {
 		const base = z.object({
 			name: z.string().min(1).max(MAX_NAME_LIMIT),
 			subscriptionIds: z.string().array(), // was .min(1), now optional
+			acceptSubscriptionInCart: z.boolean({ coerce: true }).default(false),
 			productIds: z.string().array(),
 			wholeCatalog: z.boolean({ coerce: true }).default(false),
 			beginsAt: z.date({ coerce: true }),
@@ -92,6 +93,7 @@ export const actions = {
 			subscriptionIds: JSON.parse(String(formData.get('subscriptionIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),
+			acceptSubscriptionInCart: formData.get('acceptSubscriptionInCart'),
 			productIds: JSON.parse(String(formData.get('productIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.svelte
@@ -17,6 +17,10 @@
 	let endsAtElement: HTMLInputElement;
 	let availableProductList = data.products;
 	let subscriptions = data.subscriptions;
+	// Required combinations gate the discount, they are not what gets discounted — so a
+	// subscription belongs here even though it can never be the discounted product itself.
+	// That is what lets a customer subscribe and buy in the same order (#2718).
+	$: combinationProductList = [...availableProductList, ...subscriptions];
 	let wholeCatalog = data.discount.wholeCatalog;
 	let mode = data.discount.mode;
 	let productFree: string[] = [];
@@ -181,6 +185,20 @@
 		/>
 	</label>
 
+	<label class="form-label flex flex-row items-center gap-2">
+		<input
+			class="form-checkbox"
+			type="checkbox"
+			name="acceptSubscriptionInCart"
+			checked={data.discount.acceptSubscriptionInCart}
+		/>
+		Accept the subscription when it is in the cart, not only when it is already active
+	</label>
+	<p class="text-sm text-gray-600 -mt-2">
+		Lets a new customer subscribe and buy the discounted product in the same order, instead of
+		ordering the subscription, coming back logged in, and ordering again.
+	</p>
+
 	{#if mode === 'percentage'}
 		<label class="form-label">
 			Required code (optional)
@@ -262,7 +280,7 @@
 							{product}
 							{comboIdx}
 							{prodIdx}
-							{availableProductList}
+							availableProductList={combinationProductList}
 							on:change={() => (combinations = combinations)}
 							on:remove={() => {
 								combo.products = combo.products.filter((_, idx) => idx !== prodIdx);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.server.ts
@@ -52,6 +52,7 @@ export const actions: Actions = {
 		const base = z.object({
 			name: z.string().min(1).max(MAX_NAME_LIMIT),
 			subscriptionIds: z.string().array(), // was .min(1), now optional
+			acceptSubscriptionInCart: z.boolean({ coerce: true }).default(false),
 			productIds: z.string().array(),
 			wholeCatalog: z.boolean({ coerce: true }).default(false),
 			beginsAt: z.date({ coerce: true }),
@@ -75,6 +76,7 @@ export const actions: Actions = {
 			subscriptionIds: JSON.parse(String(formData.get('subscriptionIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),
+			acceptSubscriptionInCart: formData.get('acceptSubscriptionInCart'),
 			productIds: JSON.parse(String(formData.get('productIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.svelte
@@ -17,6 +17,10 @@
 	let endsAtElement: HTMLInputElement;
 	let availableProductList = data.products;
 	let subscriptions = data.subscriptions;
+	// Required combinations gate the discount, they are not what gets discounted — so a
+	// subscription belongs here even though it can never be the discounted product itself.
+	// That is what lets a customer subscribe and buy in the same order (#2718).
+	$: combinationProductList = [...availableProductList, ...subscriptions];
 	let wholeCatalog = false;
 	let mode = 'percentage';
 	let productFreeLine = 2;
@@ -133,6 +137,15 @@
 		/>
 	</label>
 
+	<label class="form-label flex flex-row items-center gap-2">
+		<input class="form-checkbox" type="checkbox" name="acceptSubscriptionInCart" />
+		Accept the subscription when it is in the cart, not only when it is already active
+	</label>
+	<p class="text-sm text-gray-600 -mt-2">
+		Lets a new customer subscribe and buy the discounted product in the same order, instead of
+		ordering the subscription, coming back logged in, and ordering again.
+	</p>
+
 	{#if mode === 'percentage'}
 		<label class="form-label">
 			Required code (optional)
@@ -202,7 +215,7 @@
 							{product}
 							{comboIdx}
 							{prodIdx}
-							{availableProductList}
+							availableProductList={combinationProductList}
 							on:change={() => (combinations = combinations)}
 							on:remove={() => {
 								combo.products = combo.products.filter((_, idx) => idx !== prodIdx);


### PR DESCRIPTION
A discount reserved for members only recognised a subscription that had already been paid for. A new customer had to order the membership, wait, come back logged in, and place a second order to get the discount — three steps to buy one thing.

Two changes make the single order possible.

A discount that requires certain products in the cart can now list a subscription among them. The picker excluded subscriptions because it was the same list used to choose what gets discounted, where a subscription has no place; requiring one as a condition is a different question, and it now has its own list.

And a members-only discount can accept the membership sitting in the cart rather than an already active one. That is a checkbox on the discount, off unless the shop turns it on: an existing members-only discount means paid-up members, and turning that on for every shop at once would start granting discounts on a membership nobody has paid for yet.

Nothing changes for discounts already configured.

Fixes #2718
