### PR TITLE
🆕🤖 Restrict a product to a whitelist of customers (#2143)

### DIFF
--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -63,6 +63,7 @@
 	export let defaultActionSettings: ProductActionSettings;
 	export let availablePaymentMethods: PaymentMethod[];
 	export let productsWithStock: { _id: string; name: string }[] = [];
+	export let subscriptionProducts: { _id: string; name: string }[] = [];
 	export let currentBookings: BookingSummary[] = [];
 	export let upcomingBookings: BookingSummary[] = [];
 	export let allowPaidOrderWebhook = false;
@@ -135,6 +136,7 @@
 	let disableDateChange = !isNew;
 	let displayPreorderCustomText = !!product.customPreorderText;
 	let hasStock = !!product.stock;
+	let hasWhitelist = !!product.whitelist;
 	let allowDeposit = !!product.deposit;
 	let submitting = false;
 	let sellDisclaimerTitle = product.sellDisclaimer?.title || '';
@@ -1775,6 +1777,91 @@
 						bind:retailBasket={product.actionSettings.retail.canBeAddedToBasket}
 						bind:nostrBasket={product.actionSettings.nostr.canBeAddedToBasket}
 					/>
+				</div>
+
+				<div>
+					<h4 class="text-lg font-medium text-gray-900 mb-3">Whitelist</h4>
+					<div class="space-y-4">
+						<label class="checkbox-label">
+							<input
+								class="form-checkbox"
+								type="checkbox"
+								name="hasWhitelist"
+								bind:checked={hasWhitelist}
+							/>
+							Restrict who can order this product
+						</label>
+
+						{#if hasWhitelist}
+							<p class="text-sm text-gray-600">
+								Anyone matching at least one of the sources below can order the product. Everyone
+								else sees the product page, with the order and add-to-cart buttons disabled. Leaving
+								every source empty closes the product to everyone.
+							</p>
+
+							<label class="form-label">
+								Allowed e-mail addresses
+								<textarea
+									class="form-input"
+									name="whitelistEmails"
+									rows="4"
+									placeholder="One e-mail address per line"
+									value={product.whitelist?.emails?.join('\n') ?? ''}
+								/>
+							</label>
+
+							<label class="form-label">
+								Allowed npubs
+								<textarea
+									class="form-input"
+									name="whitelistNpubs"
+									rows="4"
+									placeholder="One npub per line"
+									value={product.whitelist?.npubs?.join('\n') ?? ''}
+								/>
+							</label>
+
+							<!-- svelte-ignore a11y-label-has-associated-control -->
+							<label class="form-label">
+								Allow the active subscribers of
+								<MultiSelect
+									--sms-options-bg="var(--body-mainPlan-backgroundColor)"
+									name="whitelistSubscriptionProductIds"
+									options={subscriptionProducts.map((subscriptionProduct) => ({
+										value: subscriptionProduct._id,
+										label: subscriptionProduct.name
+									}))}
+									selected={product.whitelist?.subscriptionProductIds?.map((productId) => ({
+										value: productId,
+										label:
+											subscriptionProducts.find(
+												(subscriptionProduct) => subscriptionProduct._id === productId
+											)?.name ?? productId
+									})) ?? []}
+								/>
+							</label>
+
+							<label class="checkbox-label">
+								<input
+									class="form-checkbox"
+									type="checkbox"
+									name="whitelistAllowEmployees"
+									checked={product.whitelist?.allowEmployees ?? false}
+								/>
+								Allow every employee, whatever their role
+							</label>
+
+							<label class="checkbox-label">
+								<input
+									class="form-checkbox"
+									type="checkbox"
+									name="whitelistAllowPosOverride"
+									checked={product.whitelist?.allowPosOverride ?? false}
+								/>
+								Let a point-of-sale employee add it for a customer who is not whitelisted
+							</label>
+						{/if}
+					</div>
 				</div>
 			</div>
 		</details>

--- a/src/lib/components/ProductWidget.svelte
+++ b/src/lib/components/ProductWidget.svelte
@@ -22,7 +22,12 @@
 	export { className as class };
 	export let displayOption = 'img-0';
 	$: canAddToCart =
-		canBuy && (!product.availableDate || product.availableDate <= new Date() || !!product.preorder);
+		canBuy &&
+		!product.restricted &&
+		(!product.availableDate || product.availableDate <= new Date() || !!product.preorder);
+	// Whitelisted product the visitor does not match: the CTA takes them to the product page,
+	// which is where the restriction is explained.
+	$: restrictedHref = product.restricted ? `/product/${product._id}` : undefined;
 	const widgets = {
 		'img-0': {
 			component: ProductWidgetVariation0
@@ -69,6 +74,7 @@
 		{pictures}
 		{hasDigitalFiles}
 		{canAddToCart}
+		{restrictedHref}
 		{externalUrl}
 		class={className}
 	/>

--- a/src/lib/components/ProductWidget/ProductWidgetProduct.ts
+++ b/src/lib/components/ProductWidget/ProductWidgetProduct.ts
@@ -17,4 +17,7 @@ export type ProductWidgetProduct = Pick<
 	| 'payWhatYouWant'
 	| 'bookingSpec'
 	| 'hasVariations'
->;
+> & {
+	/** Set by the server when the product carries a whitelist the visitor does not match */
+	restricted?: boolean;
+};

--- a/src/lib/components/ProductWidget/ProductWidgetVariation0.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation0.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let restrictedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -88,6 +89,12 @@
 		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
+			</div>
+		{:else if restrictedHref}
+			<div class="flex flex-row items-end justify-end">
+				<a href={restrictedHref} class="btn cartPreview-mainCTA">
+					{t('product.cta.view')}
+				</a>
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation1.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation1.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let restrictedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -89,6 +90,12 @@
 		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
+			</div>
+		{:else if restrictedHref}
+			<div class="flex flex-row items-end justify-end">
+				<a href={restrictedHref} class="btn cartPreview-mainCTA">
+					{t('product.cta.view')}
+				</a>
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation2.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation2.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let restrictedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -92,6 +93,12 @@
 		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
+			</div>
+		{:else if restrictedHref}
+			<div class="flex flex-row items-end justify-end">
+				<a href={restrictedHref} class="btn cartPreview-mainCTA">
+					{t('product.cta.view')}
+				</a>
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation3.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation3.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let restrictedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -74,6 +75,12 @@
 		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
+			</div>
+		{:else if restrictedHref}
+			<div class="flex flex-row items-end justify-end">
+				<a href={restrictedHref} class="btn cartPreview-mainCTA">
+					{t('product.cta.view')}
+				</a>
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation4.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation4.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let restrictedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -83,6 +84,12 @@
 		{:else if canAddToCart}
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
+			</div>
+		{:else if restrictedHref}
+			<div class="flex flex-row items-end justify-end">
+				<a href={restrictedHref} class="btn cartPreview-mainCTA">
+					{t('product.cta.view')}
+				</a>
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation5.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation5.svelte
@@ -13,6 +13,7 @@
 	export let product: ProductWidgetProduct;
 	export let pictures: Picture[] | [];
 	export let canAddToCart: boolean;
+	export let restrictedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 	let pictureId = 0;
 
@@ -60,6 +61,12 @@
 							detailBtn={true}
 						/>
 					</div>
+				</div>
+			{:else if restrictedHref}
+				<div class="flex flex-row items-end justify-end">
+					<a href={restrictedHref} class="btn cartPreview-mainCTA">
+						{t('product.cta.view')}
+					</a>
 				</div>
 			{/if}
 		</div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation6.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation6.svelte
@@ -13,6 +13,7 @@
 	export let product: ProductWidgetProduct;
 	export let pictures: Picture[] | [];
 	export let canAddToCart: boolean;
+	export let restrictedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let pictureId = 0;
@@ -88,6 +89,12 @@
 							detailBtn={true}
 						/>
 					</div>
+				</div>
+			{:else if restrictedHref}
+				<div class="flex flex-row items-end justify-end">
+					<a href={restrictedHref} class="btn cartPreview-mainCTA">
+						{t('product.cta.view')}
+					</a>
 				</div>
 			{/if}
 		</div>

--- a/src/lib/server/cart.ts
+++ b/src/lib/server/cart.ts
@@ -9,6 +9,7 @@ import {
 import { error } from '@sveltejs/kit';
 import { runtimeConfig } from './runtime-config';
 import { amountOfStockReserved, refreshAvailableStockInDb } from './product';
+import { annotateProductsWithWhitelist, isProductAllowedForUser } from './productWhitelist';
 import type { Cart } from '$lib/types/Cart';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import { userQuery } from './user';
@@ -33,7 +34,8 @@ export const CART_ERROR_CODES = [
 	'OUT_OF_STOCK',
 	'STANDALONE_QTY_ONE',
 	'VARIATION_INVALID',
-	'MAX_PER_ORDER'
+	'MAX_PER_ORDER',
+	'NOT_WHITELISTED'
 ] as const;
 export type CartErrorCode = (typeof CART_ERROR_CODES)[number];
 
@@ -172,6 +174,15 @@ export async function addToCartInDb(
 ) {
 	if (!canAddToCart(product, params.user, params.mode)) {
 		cartError('NOT_FOR_SALE', "Product can't be added to basket ");
+	}
+
+	// Whitelisted products. Checked here rather than on the product page so that every way into
+	// the cart goes through it: the page, a pre-configured cart link, the POS alias field, NostR.
+	// A POS employee ringing up a walk-in customer can be allowed past it, per product.
+	if (product.whitelist && !(params.mode === 'pos' && product.whitelist.allowPosOverride)) {
+		if (!(await isProductAllowedForUser(product, params.user))) {
+			cartError('NOT_WHITELISTED', 'This product is reserved for selected customers');
+		}
 	}
 
 	if (params.customPrice && !product.payWhatYouWant) {
@@ -452,13 +463,37 @@ async function computeAvailableAmount(product: Product, cart: Cart): Promise<num
 export async function checkCartItems(
 	items: Array<{
 		quantity: number;
-		product: Pick<Product, 'stock' | '_id' | 'name' | 'maxQuantityPerOrder' | 'stockReference'>;
+		product: Pick<
+			Product,
+			'stock' | '_id' | 'name' | 'maxQuantityPerOrder' | 'stockReference' | 'whitelist'
+		>;
 	}>,
 	opts?: {
 		user?: UserIdentifier;
 	}
 ) {
 	const products = items.map((item) => item.product);
+
+	// Re-checked here, and not only on the way in: a cart filled before the shop owner drew the
+	// whitelist up, or before the customer's subscription lapsed, would otherwise still check
+	// out. Called from the cart page, the checkout page and order creation alike, so all three
+	// give the same answer. The subscription collection is queried once for the whole cart.
+	if (opts?.user) {
+		const user = opts.user;
+		const annotated = await annotateProductsWithWhitelist(products, user);
+		const refused = annotated.filter(
+			(product) =>
+				product.restricted && !(user.userHasPosOptions && product.whitelist?.allowPosOverride)
+		);
+		if (refused.length) {
+			cartError(
+				'NOT_WHITELISTED',
+				'This product is reserved for selected customers: ' +
+					refused.map((product) => product.name).join(', ')
+			);
+		}
+	}
+
 	const productById = Object.fromEntries(products.map((product) => [product._id, product]));
 
 	// be careful, there can be multiple lines for the same product due to product.standalone

--- a/src/lib/server/cms.ts
+++ b/src/lib/server/cms.ts
@@ -23,6 +23,8 @@ import { z } from 'zod';
 import type { ProductWidgetProduct } from '$lib/components/ProductWidget/ProductWidgetProduct';
 import { readUrlState, searchProducts, type VatContext } from './searchlist';
 import { runtimeConfig } from './runtime-config';
+import { annotateProductsWithWhitelist } from './productWhitelist';
+import { userIdentifier } from './user';
 import type { VatProfile } from '$lib/types/VatProfile';
 export type ExternalProductData = ProductWidgetProduct & {
 	externalUrl: string;
@@ -607,6 +609,7 @@ export async function cmsFromContent(
 							| 'payWhatYouWant'
 							| 'bookingSpec'
 							| 'hasVariations'
+							| 'whitelist'
 						>
 					>({
 						price: 1,
@@ -633,7 +636,8 @@ export async function cmsFromContent(
 						hasSellDisclaimer: 1,
 						payWhatYouWant: 1,
 						bookingSpec: 1,
-						hasVariations: 1
+						hasVariations: 1,
+						whitelist: 1
 					})
 					.toArray()
 			: [],
@@ -809,7 +813,7 @@ export async function cmsFromContent(
 		tokens,
 		challenges,
 		sliders,
-		products,
+		products: await annotateProductsWithWhitelist(products, userIdentifier(locals)),
 		externalProducts,
 		tags,
 		specifications,

--- a/src/lib/server/product.ts
+++ b/src/lib/server/product.ts
@@ -276,6 +276,16 @@ export async function getProductsWithStock() {
 }
 
 /**
+ * Subscription products, to pick from when whitelisting a product to their active subscribers.
+ */
+export async function getSubscriptionProducts() {
+	return collections.products
+		.find({ type: 'subscription' })
+		.project<Pick<Product, '_id' | 'name'>>({ _id: 1, name: 1 })
+		.toArray();
+}
+
+/**
  * Apply resolved stock to already loaded product.
  * Does NOT load from DB - works with existing product object.
  *

--- a/src/lib/server/productWhitelist.test.ts
+++ b/src/lib/server/productWhitelist.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { buildProductWhitelist, matchesWhitelist, type ProductWhitelist } from './productWhitelist';
+import { CUSTOMER_ROLE_ID, POS_ROLE_ID } from '$lib/types/User';
+import type { UserIdentifier } from '$lib/types/UserIdentifier';
+
+const emptyWhitelist: ProductWhitelist = {
+	emails: [],
+	npubs: [],
+	subscriptionProductIds: [],
+	allowEmployees: false,
+	allowPosOverride: false
+};
+
+describe('matchesWhitelist', () => {
+	it('lets a listed e-mail address through', () => {
+		const whitelist = { ...emptyWhitelist, emails: ['member@example.com'] };
+		const user: UserIdentifier = { email: 'member@example.com' };
+
+		expect(matchesWhitelist(whitelist, user, [])).toBe(true);
+	});
+
+	it('ignores case and surrounding spaces on e-mail addresses', () => {
+		const whitelist = { ...emptyWhitelist, emails: ['  Member@Example.com '] };
+		const user: UserIdentifier = { email: 'member@example.com' };
+
+		expect(matchesWhitelist(whitelist, user, [])).toBe(true);
+	});
+
+	it('matches on a secondary e-mail address too', () => {
+		const whitelist = { ...emptyWhitelist, emails: ['second@example.com'] };
+		const user: UserIdentifier = {
+			email: 'first@example.com',
+			secondaryEmails: ['second@example.com']
+		};
+
+		expect(matchesWhitelist(whitelist, user, [])).toBe(true);
+	});
+
+	it('lets a listed npub through', () => {
+		const whitelist = { ...emptyWhitelist, npubs: ['npub1abc'] };
+
+		expect(matchesWhitelist(whitelist, { npub: 'npub1abc' }, [])).toBe(true);
+	});
+
+	it('keeps out a visitor who matches nothing', () => {
+		const whitelist = { ...emptyWhitelist, emails: ['member@example.com'], npubs: ['npub1abc'] };
+		const user: UserIdentifier = { email: 'someone-else@example.com', npub: 'npub1zzz' };
+
+		expect(matchesWhitelist(whitelist, user, [])).toBe(false);
+	});
+
+	it('lets an active subscriber of a listed subscription through', () => {
+		const whitelist = { ...emptyWhitelist, subscriptionProductIds: ['gold-membership'] };
+
+		expect(matchesWhitelist(whitelist, {}, ['gold-membership'])).toBe(true);
+	});
+
+	it('keeps out a subscriber of another subscription', () => {
+		const whitelist = { ...emptyWhitelist, subscriptionProductIds: ['gold-membership'] };
+
+		expect(matchesWhitelist(whitelist, {}, ['silver-membership'])).toBe(false);
+	});
+
+	it('lets an employee through when the option is on', () => {
+		const whitelist = { ...emptyWhitelist, allowEmployees: true };
+
+		expect(matchesWhitelist(whitelist, { userRoleId: POS_ROLE_ID }, [])).toBe(true);
+	});
+
+	it('does not treat a plain customer account as an employee', () => {
+		const whitelist = { ...emptyWhitelist, allowEmployees: true };
+
+		expect(matchesWhitelist(whitelist, { userRoleId: CUSTOMER_ROLE_ID }, [])).toBe(false);
+	});
+
+	it('keeps an employee out when the option is off', () => {
+		expect(matchesWhitelist(emptyWhitelist, { userRoleId: POS_ROLE_ID }, [])).toBe(false);
+	});
+
+	it('lets nobody through when every source is empty', () => {
+		expect(matchesWhitelist(emptyWhitelist, { email: 'member@example.com' }, ['gold'])).toBe(false);
+	});
+});
+
+describe('buildProductWhitelist', () => {
+	const fields = {
+		hasWhitelist: true,
+		whitelistEmails: 'first@example.com\n  second@example.com  \n\n',
+		whitelistNpubs: 'npub1abc\n',
+		whitelistSubscriptionProductIds: ['gold-membership', ''],
+		whitelistAllowEmployees: true,
+		whitelistAllowPosOverride: false
+	};
+
+	it('splits the text areas on lines and drops the blanks', () => {
+		expect(buildProductWhitelist(fields)).toEqual({
+			emails: ['first@example.com', 'second@example.com'],
+			npubs: ['npub1abc'],
+			subscriptionProductIds: ['gold-membership'],
+			allowEmployees: true,
+			allowPosOverride: false
+		});
+	});
+
+	it('leaves the product open when the box is unticked', () => {
+		expect(buildProductWhitelist({ ...fields, hasWhitelist: false })).toBeUndefined();
+	});
+});

--- a/src/lib/server/productWhitelist.ts
+++ b/src/lib/server/productWhitelist.ts
@@ -1,0 +1,153 @@
+import type { Product } from '$lib/types/Product';
+import type { UserIdentifier } from '$lib/types/UserIdentifier';
+import { CUSTOMER_ROLE_ID } from '$lib/types/User';
+import { collections } from './database';
+import { collectUserAddresses } from './discount';
+import { userQuery } from './user';
+
+export type ProductWhitelist = NonNullable<Product['whitelist']>;
+
+function normalizeAddress(address: string): string {
+	return address.trim().toLowerCase();
+}
+
+function splitLines(value: string): string[] {
+	return value
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+/**
+ * Turns the admin form fields into the stored whitelist, or undefined when the product is left
+ * open to everyone. The two text areas hold one address per line, like the contact addresses of
+ * a discount.
+ */
+export function buildProductWhitelist(fields: {
+	hasWhitelist: boolean;
+	whitelistEmails: string;
+	whitelistNpubs: string;
+	whitelistSubscriptionProductIds: string[];
+	whitelistAllowEmployees: boolean;
+	whitelistAllowPosOverride: boolean;
+}): ProductWhitelist | undefined {
+	if (!fields.hasWhitelist) {
+		return undefined;
+	}
+
+	return {
+		emails: splitLines(fields.whitelistEmails),
+		npubs: splitLines(fields.whitelistNpubs),
+		subscriptionProductIds: fields.whitelistSubscriptionProductIds.filter(Boolean),
+		allowEmployees: fields.whitelistAllowEmployees,
+		allowPosOverride: fields.whitelistAllowPosOverride
+	};
+}
+
+/**
+ * True when the user is an employee, whatever their role. Plain customers and anonymous
+ * visitors are not: they never carry a role id.
+ */
+function isEmployee(user: UserIdentifier): boolean {
+	return !!user.userRoleId && user.userRoleId !== CUSTOMER_ROLE_ID;
+}
+
+/**
+ * Whether a whitelist lets a user through. Pure on purpose: the caller passes the subscription
+ * products the user currently holds, so pages that already loaded them do not query twice.
+ *
+ * The sources are a union — matching a single one is enough.
+ */
+export function matchesWhitelist(
+	whitelist: ProductWhitelist,
+	user: UserIdentifier,
+	activeSubscriptionProductIds: string[]
+): boolean {
+	if (whitelist.allowEmployees && isEmployee(user)) {
+		return true;
+	}
+
+	const listed = new Set(
+		[...whitelist.emails, ...whitelist.npubs].map(normalizeAddress).filter(Boolean)
+	);
+	if (
+		listed.size &&
+		collectUserAddresses(user)
+			.map(normalizeAddress)
+			.some((a) => listed.has(a))
+	) {
+		return true;
+	}
+
+	return whitelist.subscriptionProductIds.some((productId) =>
+		activeSubscriptionProductIds.includes(productId)
+	);
+}
+
+/**
+ * Subscription products the user holds an active — that is, still paid for — subscription to.
+ */
+export async function activeSubscriptionProductIds(user: UserIdentifier): Promise<string[]> {
+	const subscriptions = await collections.paidSubscriptions
+		.find({ ...userQuery(user), paidUntil: { $gt: new Date() } })
+		.project<{ productId: string }>({ productId: 1, _id: 0 })
+		.toArray();
+
+	return subscriptions.map((subscription) => subscription.productId);
+}
+
+/**
+ * Whether the user may order the product. Products without a whitelist are open to everyone,
+ * which is the case of every product predating the feature.
+ *
+ * `activeSubscriptions` lets a caller that already loaded them skip the extra query; the
+ * subscription collection is only hit when a whitelist actually targets subscribers and no
+ * cheaper source matched first.
+ */
+export async function isProductAllowedForUser(
+	product: Pick<Product, 'whitelist'>,
+	user: UserIdentifier,
+	options?: { activeSubscriptionProductIds?: string[] }
+): Promise<boolean> {
+	const whitelist = product.whitelist;
+	if (!whitelist) {
+		return true;
+	}
+
+	if (matchesWhitelist(whitelist, user, options?.activeSubscriptionProductIds ?? [])) {
+		return true;
+	}
+
+	if (options?.activeSubscriptionProductIds || !whitelist.subscriptionProductIds.length) {
+		return false;
+	}
+
+	return matchesWhitelist(whitelist, user, await activeSubscriptionProductIds(user));
+}
+
+/**
+ * Flags each product the user may not order, for listings that show many of them at once —
+ * CMS product widgets, tag widgets, search lists. The subscription collection is queried once
+ * for the whole page, and not at all when no product on it is whitelisted.
+ */
+export async function annotateProductsWithWhitelist<T extends Pick<Product, 'whitelist'>>(
+	products: T[],
+	user: UserIdentifier
+): Promise<Array<T & { restricted: boolean }>> {
+	const whitelisted = products.filter((product) => product.whitelist);
+	if (!whitelisted.length) {
+		return products.map((product) => ({ ...product, restricted: false }));
+	}
+
+	const needsSubscriptions = whitelisted.some(
+		(product) => product.whitelist?.subscriptionProductIds.length
+	);
+	const subscriptionProductIds = needsSubscriptions ? await activeSubscriptionProductIds(user) : [];
+
+	return products.map((product) => ({
+		...product,
+		restricted: product.whitelist
+			? !matchesWhitelist(product.whitelist, user, subscriptionProductIds)
+			: false
+	}));
+}

--- a/src/lib/server/searchlist.ts
+++ b/src/lib/server/searchlist.ts
@@ -1,5 +1,7 @@
 import { ObjectId, type Document, type Filter } from 'mongodb';
 import { collections } from './database';
+import { annotateProductsWithWhitelist } from './productWhitelist';
+import { userIdentifier } from './user';
 import type {
 	Searchlist,
 	SearchTargetKey,
@@ -163,27 +165,30 @@ export function buildSearchOrClauses(
 	return clauses;
 }
 
+export type SearchProduct = Pick<
+	Product,
+	| '_id'
+	| 'name'
+	| 'shortDescription'
+	| 'price'
+	| 'shipping'
+	| 'preorder'
+	| 'availableDate'
+	| 'standalone'
+	| 'tagIds'
+	| 'stock'
+	| 'actionSettings'
+	| 'type'
+	| 'free'
+	| 'isTicket'
+	| 'payWhatYouWant'
+	| 'maxQuantityPerOrder'
+	| 'mobile'
+	| 'whitelist'
+>;
+
 export type SearchResult = {
-	products: Pick<
-		Product,
-		| '_id'
-		| 'name'
-		| 'shortDescription'
-		| 'price'
-		| 'shipping'
-		| 'preorder'
-		| 'availableDate'
-		| 'standalone'
-		| 'tagIds'
-		| 'stock'
-		| 'actionSettings'
-		| 'type'
-		| 'free'
-		| 'isTicket'
-		| 'payWhatYouWant'
-		| 'maxQuantityPerOrder'
-		| 'mobile'
-	>[];
+	products: Array<SearchProduct & { restricted: boolean }>;
 	total: number;
 	totalPages: number;
 };
@@ -339,7 +344,8 @@ export async function searchProducts(
 		isTicket: 1,
 		payWhatYouWant: 1,
 		maxQuantityPerOrder: 1,
-		mobile: 1
+		mobile: 1,
+		whitelist: 1
 	};
 
 	const pipeline: Document[] = [
@@ -370,7 +376,7 @@ export async function searchProducts(
 		}
 	});
 
-	type ProductHit = SearchResult['products'][number];
+	type ProductHit = SearchProduct;
 	type FacetResult = {
 		products: ProductHit[];
 		count: Array<{ total: number }>;
@@ -388,7 +394,7 @@ export async function searchProducts(
 	}
 
 	return {
-		products,
+		products: await annotateProductsWithWhitelist(products, userIdentifier(locals)),
 		total,
 		totalPages: Math.max(1, Math.ceil(total / perPage))
 	};

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -988,6 +988,9 @@
 		"minimumForCurrency": "Der Mindestbetrag für {currency} beträgt {minimum}",
 		"nameYourPrice": "Nennen Sie Ihren Preis ({currency})",
 		"notForSale": "Dieses Produkt steht nicht zum Verkauf",
+		"whitelist": {
+			"restricted": "Dieses Produkt ist ausgewählten Kunden vorbehalten. Ihr Konto steht nicht auf der Liste."
+		},
 		"outOfStock": "Nicht auf Lager",
 		"preorderText": "Dies ist eine Vorbestellung, Ihr Produkt wird am {date} verfügbar sein",
 		"pricePlaceholder": "Preis",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -988,6 +988,9 @@
 		"minimumForCurrency": "The minimum amount for {currency} is {minimum}",
 		"nameYourPrice": "Name your price ({currency})",
 		"notForSale": "This product is not available for sale",
+		"whitelist": {
+			"restricted": "This product is reserved for selected customers. Your account is not on its list."
+		},
 		"outOfStock": "Out of stock",
 		"preorderText": "This is a preorder, your product will be available on {date}",
 		"pricePlaceholder": "Price",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -988,6 +988,9 @@
 		"minimumForCurrency": "El monto mínimo para {currency} es {minimum}",
 		"nameYourPrice": "Pon tu precio ({currency})",
 		"notForSale": "Este producto no está en venta",
+		"whitelist": {
+			"restricted": "Este producto está reservado para ciertos clientes. Su cuenta no está en la lista."
+		},
 		"outOfStock": "Agotado",
 		"preorderText": "Esta es una preorden, el producto estará disponible el {date}",
 		"pricePlaceholder": "Precio",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -988,6 +988,9 @@
 		"minimumForCurrency": "Le montant minimum en {currency} est {minimum}",
 		"nameYourPrice": "Choisissez votre prix ({currency})",
 		"notForSale": "Ce produit n'est pas disponible à la vente par cette plateforme, merci de nous contacter",
+		"whitelist": {
+			"restricted": "Ce produit est réservé à certains clients. Votre compte ne figure pas sur sa liste."
+		},
 		"outOfStock": "En rupture de stock, merci de nous contacter",
 		"preorderText": "En précommande, disponible le {date}",
 		"pricePlaceholder": "Prix",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -988,6 +988,9 @@
 		"minimumForCurrency": "La somma minima per {currency} è {minimum}",
 		"nameYourPrice": "Indica il tuo prezzo ({currency})",
 		"notForSale": "Questo prodotto non è disponibile alla vendita",
+		"whitelist": {
+			"restricted": "Questo prodotto è riservato ad alcuni clienti. Il tuo account non è nella lista."
+		},
 		"outOfStock": "Esaurito",
 		"preorderText": "Questo è un preordine, il tuo prodotto sarà disponibile il  {date}",
 		"pricePlaceholder": "Prezzo",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -988,6 +988,9 @@
 		"minimumForCurrency": "Het minimumbedrag voor {currency} is {minimum}",
 		"nameYourPrice": "Geef uw prijs een naam ({currency})",
 		"notForSale": "Dit product is niet te koop",
+		"whitelist": {
+			"restricted": "Dit product is voorbehouden aan bepaalde klanten. Uw account staat niet op de lijst."
+		},
 		"outOfStock": "Geen voorraad meer",
 		"preorderText": "Dit is een voorbestelling. Uw product is beschikbaar op {date}",
 		"pricePlaceholder": "Prijs",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -988,6 +988,9 @@
 		"minimumForCurrency": "O valor mínimo para {currency} é {minimum}",
 		"nameYourPrice": "Dê o seu preço ({currency})",
 		"notForSale": "Este produto não está disponível para venda",
+		"whitelist": {
+			"restricted": "Este produto é reservado a determinados clientes. A sua conta não está na lista."
+		},
 		"outOfStock": "Esgotado",
 		"preorderText": "Isto é uma pré-encomenda, o seu produto estará disponível em {date}",
 		"pricePlaceholder": "Preço",

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -50,6 +50,24 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 		productId: string;
 	};
 	vatProfileId?: ObjectId;
+	/**
+	 * When present, only whitelisted customers can order the product or add it to their cart.
+	 * The whitelist is the union of its sources: matching a single one is enough. Absent means
+	 * the product is open to everyone — an empty whitelist restricts it to nobody but employees
+	 * and the POS, if those two options say so.
+	 */
+	whitelist?: {
+		/** One contact e-mail per entry */
+		emails: string[];
+		/** One npub per entry */
+		npubs: string[];
+		/** Customers holding an active subscription to one of these products */
+		subscriptionProductIds: string[];
+		/** Every employee account, whatever its role, as opposed to plain customers */
+		allowEmployees: boolean;
+		/** A POS employee may add the product to a cart for a customer who is not whitelisted */
+		allowPosOverride: boolean;
+	};
 	maxQuantityPerOrder?: number;
 	type: 'subscription' | 'resource' | 'donation';
 	subscriptionDuration?: SubscriptionDuration;

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -13,10 +13,12 @@ import { hasMoreDecimalsThanCurrency } from '$lib/utils/currency-validation';
 import type { JsonObject } from 'type-fest';
 import { set } from '$lib/utils/set';
 import { productBaseSchema } from '../product-schema';
+import { buildProductWhitelist } from '$lib/server/productWhitelist';
 import {
 	amountOfStockReserved,
 	amountOfProductSold,
 	getProductsWithStock,
+	getSubscriptionProducts,
 	validateStockReference,
 	cleanVariationLabels
 } from '$lib/server/product';
@@ -44,6 +46,7 @@ export const load = async ({ params }) => {
 		.project<Pick<Tag, '_id' | 'name'>>({ _id: 1, name: 1 })
 		.toArray();
 	const productsWithStock = await getProductsWithStock();
+	const subscriptionProducts = await getSubscriptionProducts();
 	const now = new Date();
 	const scheduleId = productToScheduleId(params.id);
 
@@ -81,6 +84,7 @@ export const load = async ({ params }) => {
 		digitalFiles,
 		tags,
 		productsWithStock,
+		subscriptionProducts,
 		reserved,
 		sold,
 		scanned,
@@ -98,6 +102,11 @@ export const actions: Actions = {
 			set(json, key, value);
 		}
 		json.paymentMethods = formData.getAll('paymentMethods')?.map(String);
+		// MultiSelect posts a JSON array of {value,label}, like the product tag picker, not one
+		// form field per pick.
+		json.whitelistSubscriptionProductIds = JSON.parse(
+			String(formData.get('whitelistSubscriptionProductIds') || '[]')
+		).map((x: { value: string }) => x.value);
 
 		const product = await collections.products.findOne({ _id: params.id });
 
@@ -171,6 +180,7 @@ export const actions: Actions = {
 		const validVariations = variationsParsedPrice.filter(
 			(variation) => variation.name && variation.value
 		);
+		const whitelist = buildProductWhitelist(parsed);
 		const amountInCarts = await amountOfStockReserved(params.id);
 		const cleanedVariationLabels = cleanVariationLabels(parsed.variationLabels);
 		const hasVariations =
@@ -306,6 +316,7 @@ export const actions: Actions = {
 								productId: parsed.stockReferenceProductId
 							}
 						}),
+						...(whitelist && { whitelist }),
 						...(parsed.paidOrderWebhook && { paidOrderWebhook: parsed.paidOrderWebhook })
 					},
 					$unset: {
@@ -314,6 +325,7 @@ export const actions: Actions = {
 						...(!parsed.deliveryFees && { deliveryFees: '' }),
 						...(parsed.stock === undefined && { stock: '' }),
 						...(!parsed.stockReferenceProductId && { stockReference: '' }),
+						...(!whitelist && { whitelist: '' }),
 						...(!parsed.maxQuantityPerOrder && { maxQuantityPerOrder: '' }),
 						...(!parsed.depositPercentage && { deposit: '' }),
 						...(!parsed.vatProfileId && { vatProfileId: '' }),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
@@ -38,6 +38,7 @@
 	product={data.product}
 	tags={data.tags}
 	productsWithStock={data.productsWithStock}
+	subscriptionProducts={data.subscriptionProducts}
 	adminPrefix={data.adminPrefix}
 	reserved={data.reserved}
 	defaultActionSettings={data.productActionSettings}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -2,6 +2,7 @@ import { collections, withTransaction } from '$lib/server/database';
 import { generatePicture } from '$lib/server/picture';
 import {
 	getProductsWithStock,
+	getSubscriptionProducts,
 	validateStockReference,
 	cleanVariationLabels
 } from '$lib/server/product';
@@ -24,6 +25,7 @@ import { s3ProductPrefix, getS3Client } from '$lib/server/s3';
 import type { JsonObject } from 'type-fest';
 import { set } from '$lib/utils/set';
 import { productBaseSchema } from '../product-schema';
+import { buildProductWhitelist } from '$lib/server/productWhitelist';
 import { generateId } from '$lib/utils/generateId';
 import { CopyObjectCommand, DeleteObjectsCommand } from '@aws-sdk/client-s3';
 import type { Tag } from '$lib/types/Tag';
@@ -41,6 +43,7 @@ export const load = async ({ url }) => {
 		.project<Pick<Tag, '_id' | 'name'>>({ _id: 1, name: 1 })
 		.toArray();
 	const productsWithStock = await getProductsWithStock();
+	const subscriptionProducts = await getSubscriptionProducts();
 	if (productId) {
 		const product = await collections.products.findOne({ _id: productId });
 
@@ -62,13 +65,15 @@ export const load = async ({ url }) => {
 				digitalFiles,
 				tags,
 				productsWithStock,
+				subscriptionProducts,
 				currency: runtimeConfig.priceReferenceCurrency
 			};
 		}
 	}
 	return {
 		tags,
-		productsWithStock
+		productsWithStock,
+		subscriptionProducts
 	};
 };
 
@@ -81,6 +86,11 @@ export const actions: Actions = {
 			set(json, key, value);
 		}
 		json.paymentMethods = formData.getAll('paymentMethods')?.map(String);
+		// MultiSelect posts a JSON array of {value,label}, like the product tag picker, not one
+		// form field per pick.
+		json.whitelistSubscriptionProductIds = JSON.parse(
+			String(formData.get('whitelistSubscriptionProductIds') || '[]')
+		).map((x: { value: string }) => x.value);
 
 		const parsed = z
 			.object({
@@ -103,6 +113,8 @@ export const actions: Actions = {
 		if (parsed.paidOrderWebhook && !isPaidOrderWebhookEnabled()) {
 			throw error(403, 'Paid-order webhook feature is disabled');
 		}
+
+		const whitelist = buildProductWhitelist(parsed);
 
 		const priceAmount = parsed.free
 			? 0
@@ -210,6 +222,7 @@ export const actions: Actions = {
 									productId: parsed.stockReferenceProductId
 								}
 							}),
+							...(whitelist && { whitelist }),
 							...(parsed.depositPercentage !== undefined && {
 								deposit: {
 									percentage: parsed.depositPercentage,
@@ -332,6 +345,11 @@ export const actions: Actions = {
 			set(json, key, value);
 		}
 		json.paymentMethods = formData.getAll('paymentMethods')?.map(String);
+		// MultiSelect posts a JSON array of {value,label}, like the product tag picker, not one
+		// form field per pick.
+		json.whitelistSubscriptionProductIds = JSON.parse(
+			String(formData.get('whitelistSubscriptionProductIds') || '[]')
+		).map((x: { value: string }) => x.value);
 
 		const { duplicateFromId } = z
 			.object({ duplicateFromId: z.string() })
@@ -362,6 +380,8 @@ export const actions: Actions = {
 		if (parsed.paidOrderWebhook && !isPaidOrderWebhookEnabled()) {
 			throw error(403, 'Paid-order webhook feature is disabled');
 		}
+
+		const whitelist = buildProductWhitelist(parsed);
 
 		if (!parsed.availableDate) {
 			parsed.preorder = false;
@@ -454,6 +474,7 @@ export const actions: Actions = {
 						paymentMethods: parsed.paymentMethods ?? []
 					}),
 					...(parsed.paidOrderWebhook && { paidOrderWebhook: parsed.paidOrderWebhook }),
+					...(whitelist && { whitelist }),
 					tagIds: product.tagIds,
 					cta: product.cta,
 					externalResources: product.externalResources,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
@@ -19,6 +19,7 @@
 	duplicateFromId={data.product?._id}
 	tags={data.tags}
 	productsWithStock={data.productsWithStock}
+	subscriptionProducts={data.subscriptionProducts}
 	product={data.product ?? undefined}
 	defaultActionSettings={data.productActionSettings}
 	vatProfiles={data.vatProfiles}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -164,6 +164,12 @@ export const productBaseSchema = () => ({
 		.transform((val) => val || undefined)
 		.optional(),
 	maxQuantityPerOrder: z.number({ coerce: true }).int().min(1).optional(),
+	hasWhitelist: z.boolean({ coerce: true }).default(false),
+	whitelistEmails: z.string().default(''),
+	whitelistNpubs: z.string().default(''),
+	whitelistSubscriptionProductIds: z.string().array().default([]),
+	whitelistAllowEmployees: z.boolean({ coerce: true }).default(false),
+	whitelistAllowPosOverride: z.boolean({ coerce: true }).default(false),
 	eshopVisible: z.boolean({ coerce: true }).default(false),
 	retailVisible: z.boolean({ coerce: true }).default(false),
 	nostrVisible: z.boolean({ coerce: true }).default(false),

--- a/src/routes/(app)/cart/+page.server.ts
+++ b/src/routes/(app)/cart/+page.server.ts
@@ -84,6 +84,8 @@ function mapAddError(slug: string, body: AddErrorBody, product: ProductBadge | n
 			return { slug, key: 'cartFromUrl.errors.reasonVariationRequired', product };
 		case 'BOOKING_INFO_REQUIRED':
 			return { slug, key: 'cartFromUrl.errors.reasonBookingRequired', product };
+		case 'NOT_WHITELISTED':
+			return { slug, key: 'product.whitelist.restricted', product };
 		case 'MAX_PER_ORDER':
 			return {
 				slug,

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -1,4 +1,5 @@
 import { addToCartInDb } from '$lib/server/cart';
+import { isProductAllowedForUser } from '$lib/server/productWhitelist';
 import { cmsFromContent } from '$lib/server/cms';
 import { collections } from '$lib/server/database';
 import { applyResolvedStock, resolveStockProduct } from '$lib/server/product';
@@ -115,6 +116,7 @@ async function fetchProduct(
 	| 'bookingSpec'
 	| 'vatProfileId'
 	| 'stockReference'
+	| 'whitelist'
 	| 'tagIds'
 	| 'subscriptionDuration'
 	| 'pricingSchedule'
@@ -170,6 +172,7 @@ async function fetchProduct(
 				bookingSpec: 1,
 				vatProfileId: 1,
 				stockReference: 1,
+				whitelist: 1,
 				tagIds: 1,
 				subscriptionDuration: 1,
 				pricingSchedule: 1,
@@ -239,6 +242,10 @@ export const load = async ({ params, parent, locals }) => {
 		product.bookingSpec ? fetchProductScheduleEvents(productId) : [],
 		parent()
 	]);
+	const whitelisted = await isProductAllowedForUser(product, userIdentifier(locals), {
+		activeSubscriptionProductIds: userSubscriptions.map((subscription) => subscription.productId)
+	});
+
 	const totalFreeProducts = sum(
 		userSubscriptions.map((s) => s.freeProductsById?.[product._id]?.available ?? 0)
 	);
@@ -295,6 +302,7 @@ export const load = async ({ params, parent, locals }) => {
 		priceHistoryEnabled: runtimeConfig.priceHistoryEnabled,
 		websiteShortDescription: product.shortDescription,
 		freeProductsAvailable,
+		whitelisted,
 		adminPrefix: getAdminPrefix()
 	};
 };

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -229,6 +229,9 @@
 		? data.product.actionSettings.retail.canBeAddedToBasket
 		: data.product.actionSettings.eShop.canBeAddedToBasket;
 
+	// Whitelisted product the visitor does not match: the page stays readable, the CTAs don't work.
+	$: restricted = !data.whitelisted;
+
 	function getWeekDayFromDate(date: Date) {
 		return dayList[(date.getDay() + 6) % 7];
 	}
@@ -1183,7 +1186,14 @@
 									{t('ageWarning.agreement')}
 								</label>
 							{/if}
-							{#if amountAvailable === 0}
+							{#if restricted}
+								<p class="text-red-500">
+									{t('product.whitelist.restricted')}
+								</p>
+								<button class="btn body-cta body-mainCTA" disabled>
+									{t(`product.cta.${verb}`)}
+								</button>
+							{:else if amountAvailable === 0}
 								<p class="text-red-500">
 									<span class="font-bold">{t('product.outOfStock')}</span>
 									<br />


### PR DESCRIPTION
A product can now be reserved for a chosen audience. Its admin page carries a Whitelist section, off by default, where the shop owner lists who may order it.

Four sources, and matching a single one is enough: a free text area of e-mail addresses, one per line; a free text area of npubs, one per line; a pick of subscription products, whose active subscribers are all allowed without being listed by hand; and a checkbox for every employee account, whatever its role.

A visitor who matches none of them still reaches the product page and reads it in full, but the order and add-to-cart buttons are replaced by a message saying the product is reserved for selected customers. In product widgets, tag widgets and search lists, the button takes them to the product page rather than adding the product to their cart.

The restriction is enforced on every way into the cart, not only on the buttons: a pre-configured cart link, the point-of-sale alias field and NostR all go through it. A last option lets a point-of-sale employee ring the product up for a customer who is not on the list, for shops where the counter decides.

Products with no whitelist are untouched and stay open to everyone.

Fixes #2143