### PR TITLE
🆕🤖 Add new product property "Maximum quantity for an unique user" (#2…

### DIFF
--- a/docs/fr/WIP-product-management.md
+++ b/docs/fr/WIP-product-management.md
@@ -58,6 +58,10 @@ Accessible via **Admin** > **Merch** > **Product**, cette section vous permet d'
   - [ ] **Enable preorders before available date** : Autorisez les précommandes.
   - [ ] **Display custom text instead of date for preorder** : Afficher un autre text à la place de la date de disponibilité.
 - **Max quantity per order** : Limite le nombre d’unités par commande.
+- **Maximum quantity for an unique user** : Limite le nombre d’unités qu’une même personne peut
+  acheter, toutes commandes confondues. Laissez vide pour ne pas plafonner. Les commandes en
+  attente de paiement sont comptées. Un abonnement est toujours limité à un par personne et par
+  produit.
 
   ![image](https://github.com/user-attachments/assets/146c241f-292f-4ef2-87a4-0a852cffbb58)
 

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -8,6 +8,7 @@
 	import {
 		DEFAULT_MAX_QUANTITY_PER_ORDER,
 		MAX_NAME_LIMIT,
+		MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION,
 		MAX_SHORT_DESCRIPTION_LIMIT,
 		type Product
 	} from '$lib/types/Product';
@@ -1400,6 +1401,28 @@
 							value={product.maxQuantityPerOrder || DEFAULT_MAX_QUANTITY_PER_ORDER}
 						/>
 					</label>
+
+					<label class="form-label">
+						Maximum quantity for an unique user
+						<input
+							class="form-input"
+							type="number"
+							name="maxQuantityPerUser"
+							placeholder="No limit"
+							step="1"
+							min="1"
+							value={product.maxQuantityPerUser ?? ''}
+						/>
+						<span class="text-sm text-gray-600">
+							Across all their orders, not per order. Leave empty for no limit. Orders awaiting
+							payment count towards it.
+						</span>
+					</label>
+				{:else}
+					<p class="text-sm text-gray-600">
+						Maximum quantity for an unique user: {MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION} — a subscription
+						is limited to one per person and per product.
+					</p>
 				{/if}
 			</div>
 			<input type="hidden" name="changedDate" value={changedDate} />

--- a/src/lib/server/cart.ts
+++ b/src/lib/server/cart.ts
@@ -3,6 +3,7 @@ import { collections, withTransaction } from './database';
 import {
 	checkProductVariationsIntegrity,
 	DEFAULT_MAX_QUANTITY_PER_ORDER,
+	maxQuantityPerUser,
 	productPriceWithVariations,
 	type Product
 } from '$lib/types/Product';
@@ -19,6 +20,7 @@ import type { Currency } from '$lib/types/Currency';
 import { toCurrency } from '$lib/utils/toCurrency';
 import { sum } from '$lib/utils/sum';
 import { deepEquals } from '$lib/utils/deep-equals';
+import { quantityAlreadyTakenByUser } from './maxQuantityPerUser';
 
 export const CART_ERROR_CODES = [
 	'NOT_FOR_SALE',
@@ -33,7 +35,8 @@ export const CART_ERROR_CODES = [
 	'OUT_OF_STOCK',
 	'STANDALONE_QTY_ONE',
 	'VARIATION_INVALID',
-	'MAX_PER_ORDER'
+	'MAX_PER_ORDER',
+	'MAX_PER_USER'
 ] as const;
 export type CartErrorCode = (typeof CART_ERROR_CODES)[number];
 
@@ -306,6 +309,21 @@ export async function addToCartInDb(
 		}
 	}
 
+	// Cap per person, across their whole history — what is already paid or awaiting payment
+	// leaves that much less room in the cart. Only queried when the product carries a cap,
+	// so uncapped products keep their current number of round-trips.
+	const maxPerUser = maxQuantityPerUser(product);
+	const alreadyTakenByUser =
+		maxPerUser === undefined ? 0 : await quantityAlreadyTakenByUser(product, params.user);
+	const failWhenOverUserCap = (quantityInCart: number) => {
+		if (maxPerUser !== undefined && quantityInCart + alreadyTakenByUser > maxPerUser) {
+			cartError('MAX_PER_USER', `You can only order ${maxPerUser} of this product in total`, {
+				max: maxPerUser,
+				alreadyTaken: alreadyTakenByUser
+			});
+		}
+	};
+
 	if (existingItem && !product.standalone && !product.bookingSpec) {
 		existingItem.quantity = params.totalQuantity ? quantity : existingItem.quantity + quantity;
 
@@ -317,6 +335,10 @@ export async function addToCartInDb(
 		if (totalQuantityInCart() > max) {
 			cartError('MAX_PER_ORDER', `You can only order ${max} of this product`, { max });
 		}
+
+		// A subscription line is clamped to 1 just below, whatever was asked, so 1 is what it
+		// weighs against the per-person cap.
+		failWhenOverUserCap(product.type === 'subscription' ? 1 : totalQuantityInCart());
 
 		if (product.type === 'subscription') {
 			existingItem.quantity = 1;
@@ -333,6 +355,7 @@ export async function addToCartInDb(
 		if (totalQuantityInCart() + quantity > max) {
 			cartError('MAX_PER_ORDER', `You can only order ${max} of this product`, { max });
 		}
+		failWhenOverUserCap(product.type === 'subscription' ? 1 : totalQuantityInCart() + quantity);
 		cart.items.push({
 			_id: crypto.randomUUID(),
 			productId: product._id,

--- a/src/lib/server/maxQuantityPerUser.test.ts
+++ b/src/lib/server/maxQuantityPerUser.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { addSeconds, subSeconds } from 'date-fns';
+import { maxQuantityPerUser, MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION } from '$lib/types/Product';
+import { subscriptionOccupiesSlot } from './maxQuantityPerUser';
+
+const NOW = new Date('2026-09-07T12:00:00Z');
+const ONE_DAY = 24 * 3600;
+
+describe('maxQuantityPerUser', () => {
+	it('is undefined when the product carries no cap', () => {
+		expect(maxQuantityPerUser({ type: 'resource' })).toBeUndefined();
+	});
+
+	it('is the stored value on a regular product', () => {
+		expect(maxQuantityPerUser({ type: 'resource', maxQuantityPerUser: 3 })).toBe(3);
+	});
+
+	it('is one on a subscription, whatever the document says', () => {
+		expect(maxQuantityPerUser({ type: 'subscription', maxQuantityPerUser: 5 })).toBe(
+			MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION
+		);
+		expect(maxQuantityPerUser({ type: 'subscription' })).toBe(1);
+	});
+});
+
+describe('subscriptionOccupiesSlot', () => {
+	const product = { subscriptionReminderSeconds: ONE_DAY };
+
+	it('holds the slot while the subscription runs and renewal is not open yet', () => {
+		expect(
+			subscriptionOccupiesSlot({ paidUntil: addSeconds(NOW, 30 * ONE_DAY) }, product, NOW)
+		).toBe(true);
+	});
+
+	it('frees the slot once inside the renewal window', () => {
+		// paidUntil is in the future, but less than the reminder offset away: the customer is
+		// allowed to renew, so the product must reopen for them.
+		expect(
+			subscriptionOccupiesSlot({ paidUntil: addSeconds(NOW, ONE_DAY / 2) }, product, NOW)
+		).toBe(false);
+	});
+
+	it('frees the slot on an expired subscription', () => {
+		expect(subscriptionOccupiesSlot({ paidUntil: subSeconds(NOW, ONE_DAY) }, product, NOW)).toBe(
+			false
+		);
+	});
+
+	it('uses the phase reminder from the snapshot rather than the product offset', () => {
+		// Phase 1 funded the current period (cursor points at the next one to bill) and its
+		// reminder is 10 days, far wider than the product's single day.
+		const subscription = {
+			paidUntil: addSeconds(NOW, 5 * ONE_DAY),
+			pricingScheduleCursor: 2,
+			pricingScheduleSnapshot: {
+				currency: 'EUR' as const,
+				phases: [
+					{
+						value: 1,
+						unit: 'month' as const,
+						priceAmount: 10,
+						reminderValue: 10,
+						reminderUnit: 'day' as const
+					},
+					{
+						value: 1,
+						unit: 'month' as const,
+						priceAmount: 20,
+						reminderValue: 10,
+						reminderUnit: 'day' as const
+					}
+				]
+			}
+		};
+
+		expect(subscriptionOccupiesSlot(subscription, product, NOW)).toBe(false);
+	});
+});

--- a/src/lib/server/maxQuantityPerUser.ts
+++ b/src/lib/server/maxQuantityPerUser.ts
@@ -1,0 +1,109 @@
+import { subSeconds } from 'date-fns';
+import type { ClientSession } from 'mongodb';
+import type { Product } from '$lib/types/Product';
+import type { PaidSubscription } from '$lib/types/PaidSubscription';
+import type { UserIdentifier } from '$lib/types/UserIdentifier';
+import { collections } from './database';
+import { userQuery } from './user';
+import { currentFundingReminderSeconds } from './subscriptions';
+import { MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION, maxQuantityPerUser } from '$lib/types/Product';
+
+export type ProductForUserLimit = Pick<
+	Product,
+	'_id' | 'type' | 'maxQuantityPerUser' | 'subscriptionReminderSeconds'
+>;
+
+/**
+ * Whether a subscription still occupies its holder's single slot.
+ *
+ * A renewal is an order like any other, so counting orders would close a subscription
+ * forever the day it is first renewed. The criterion is the one `createOrder` already
+ * applies: held, and not yet inside its renewal window.
+ */
+export function subscriptionOccupiesSlot(
+	subscription: Pick<
+		PaidSubscription,
+		'paidUntil' | 'pricingScheduleSnapshot' | 'pricingScheduleCursor' | 'cancelledAt'
+	>,
+	product: { subscriptionReminderSeconds?: number },
+	now = new Date()
+): boolean {
+	return (
+		subSeconds(subscription.paidUntil, currentFundingReminderSeconds(subscription, product)) > now
+	);
+}
+
+/**
+ * Units of this product the person already holds or is in the middle of paying for.
+ *
+ * Orders awaiting payment count: without them a customer opens two orders side by side,
+ * pays both, and lands over the cap.
+ */
+export async function quantityAlreadyTakenByUser(
+	product: ProductForUserLimit,
+	user: UserIdentifier,
+	opts?: { session?: ClientSession }
+): Promise<number> {
+	if (product.type === 'subscription') {
+		const existing = await collections.paidSubscriptions.findOne(
+			{ ...userQuery(user), productId: product._id },
+			{ session: opts?.session }
+		);
+
+		if (existing && subscriptionOccupiesSlot(existing, product)) {
+			return MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION;
+		}
+
+		const pending = await collections.orders.countDocuments(
+			{
+				...userQuery(user),
+				'items.product._id': product._id,
+				status: 'pending'
+			},
+			{ limit: 1, session: opts?.session }
+		);
+
+		return pending ? MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION : 0;
+	}
+
+	const [aggregated] = await collections.orders
+		.aggregate<{ total: number }>(
+			[
+				{
+					$match: {
+						...userQuery(user),
+						'items.product._id': product._id,
+						status: { $in: ['pending', 'paid'] }
+					}
+				},
+				{ $unwind: '$items' },
+				{ $match: { 'items.product._id': product._id } },
+				{ $group: { _id: null, total: { $sum: '$items.quantity' } } }
+			],
+			{ session: opts?.session }
+		)
+		.toArray();
+
+	return aggregated?.total ?? 0;
+}
+
+/**
+ * Cap and consumption in one call, for the callers that need to tell the customer where
+ * they stand before they click — the product page CTA, mainly. `remaining` is `undefined`
+ * on an uncapped product.
+ */
+export async function maxQuantityPerUserStatus(
+	product: ProductForUserLimit,
+	user: UserIdentifier,
+	opts?: { session?: ClientSession }
+): Promise<{ max: number; alreadyTaken: number; remaining: number } | undefined> {
+	const max = maxQuantityPerUser(product);
+
+	if (max === undefined) {
+		return undefined;
+	}
+
+	const alreadyTaken = await quantityAlreadyTakenByUser(product, user, opts);
+
+	return { max, alreadyTaken, remaining: Math.max(max - alreadyTaken, 0) };
+}

--- a/src/lib/server/order.test.ts
+++ b/src/lib/server/order.test.ts
@@ -280,4 +280,35 @@ describe('order', () => {
 		expect(order?.items[0].discountPercentage).toBe(100);
 		expect(order?.currencySnapshot.main.totalPrice.amount).toBe(0);
 	});
+
+	it('should refuse a second subscription order while a first one awaits payment', async () => {
+		const params = {
+			locale: 'en' as const,
+			user: {
+				sessionId: 'test-session-id'
+			},
+			notifications: {
+				paymentStatus: {
+					npub: 'test-npub'
+				}
+			},
+			userVatCountry: 'FR' as const,
+			shippingAddress: null
+		};
+
+		await createOrder(
+			[{ product: TEST_SUBSCRIPTION_PRODUCT, quantity: 1 }],
+			'point-of-sale',
+			params
+		);
+
+		await expect(
+			createOrder([{ product: TEST_SUBSCRIPTION_PRODUCT, quantity: 1 }], 'point-of-sale', params)
+		).rejects.toMatchObject({
+			status: 400,
+			body: {
+				message: expect.stringContaining('You already have a pending order for this product')
+			}
+		});
+	});
 });

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -1087,7 +1087,7 @@ export async function createOrder(
 				{
 					...userQuery(params.user),
 					'items.product._id': product._id,
-					'payment.status': 'pending'
+					status: 'pending'
 				},
 				{ limit: 1 }
 			)

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -115,7 +115,9 @@
 		"vatRate": "MwSt.-Satz für {country}",
 		"vatSellerCountry": "Das Land ist das Land des Verkäufers.",
 		"maxQuantityReached": "Maximale Menge pro Bestellung erreicht ({max})",
+		"maxQuantityPerUserReached": "Sie haben die maximal bestellbare Menge für dieses Produkt erreicht.",
 		"error": {
+			"MAX_PER_USER": "Sie haben die maximal bestellbare Menge für dieses Produkt erreicht.",
 			"BOOKING_SAME_DAY_DISABLED": "Buchungen für heute sind für dieses Produkt nicht verfügbar.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Buchungen für heute sind nach {maxHour} nicht mehr möglich."
 		}
@@ -989,6 +991,7 @@
 		"nameYourPrice": "Nennen Sie Ihren Preis ({currency})",
 		"notForSale": "Dieses Produkt steht nicht zum Verkauf",
 		"outOfStock": "Nicht auf Lager",
+		"maxQuantityPerUserReached": "Sie haben die maximal bestellbare Menge für dieses Produkt erreicht.",
 		"preorderText": "Dies ist eine Vorbestellung, Ihr Produkt wird am {date} verfügbar sein",
 		"pricePlaceholder": "Preis",
 		"seeInCabinet": "In Meinem Schrank ansehen",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -115,7 +115,9 @@
 		"vatRate": "VAT rate for {country}",
 		"vatSellerCountry": "The country is the seller's country.",
 		"maxQuantityReached": "Maximum quantity per order reached ({max})",
+		"maxQuantityPerUserReached": "You have reached the maximum you can order for this product.",
 		"error": {
+			"MAX_PER_USER": "You have reached the maximum you can order for this product.",
 			"BOOKING_SAME_DAY_DISABLED": "Bookings for today are not available for this product.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Bookings for today are no longer possible past {maxHour}."
 		}
@@ -989,6 +991,7 @@
 		"nameYourPrice": "Name your price ({currency})",
 		"notForSale": "This product is not available for sale",
 		"outOfStock": "Out of stock",
+		"maxQuantityPerUserReached": "You have reached the maximum you can order for this product.",
 		"preorderText": "This is a preorder, your product will be available on {date}",
 		"pricePlaceholder": "Price",
 		"seeInCabinet": "See in MyCabinet",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -115,7 +115,9 @@
 		"vatRate": "Tasa de IVA para {country}",
 		"vatSellerCountry": "El país es el del vendedor.",
 		"maxQuantityReached": "Cantidad máxima por pedido alcanzada ({max})",
+		"maxQuantityPerUserReached": "Has alcanzado el máximo que puedes pedir de este producto.",
 		"error": {
+			"MAX_PER_USER": "Has alcanzado el máximo que puedes pedir de este producto.",
 			"BOOKING_SAME_DAY_DISABLED": "Las reservas para hoy no están disponibles para este producto.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Las reservas para hoy ya no son posibles después de las {maxHour}."
 		}
@@ -989,6 +991,7 @@
 		"nameYourPrice": "Pon tu precio ({currency})",
 		"notForSale": "Este producto no está en venta",
 		"outOfStock": "Agotado",
+		"maxQuantityPerUserReached": "Has alcanzado el máximo que puedes pedir de este producto.",
 		"preorderText": "Esta es una preorden, el producto estará disponible el {date}",
 		"pricePlaceholder": "Precio",
 		"seeInCabinet": "Ver en el cabinet",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -115,7 +115,9 @@
 		"vatRate": "Taux de TVA : {country}",
 		"vatSellerCountry": "La TVA est celle du pays du vendeur.",
 		"maxQuantityReached": "Quantité maximale par commande atteinte ({max})",
+		"maxQuantityPerUserReached": "Vous avez atteint le maximum commandable pour ce produit.",
 		"error": {
+			"MAX_PER_USER": "Vous avez atteint le maximum commandable pour ce produit.",
 			"BOOKING_SAME_DAY_DISABLED": "Les réservations pour aujourd'hui ne sont pas disponibles pour ce produit.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Les réservations pour aujourd'hui ne sont plus possibles passé {maxHour}."
 		}
@@ -989,6 +991,7 @@
 		"nameYourPrice": "Choisissez votre prix ({currency})",
 		"notForSale": "Ce produit n'est pas disponible à la vente par cette plateforme, merci de nous contacter",
 		"outOfStock": "En rupture de stock, merci de nous contacter",
+		"maxQuantityPerUserReached": "Vous avez atteint le maximum commandable pour ce produit.",
 		"preorderText": "En précommande, disponible le {date}",
 		"pricePlaceholder": "Prix",
 		"seeInCabinet": "Voir dans MonCabinet",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -115,7 +115,9 @@
 		"vatRate": "IVA per {country}",
 		"vatSellerCountry": "Il paese è quello del venditore.",
 		"maxQuantityReached": "Quantità massima per ordine raggiunta ({max})",
+		"maxQuantityPerUserReached": "Hai raggiunto il massimo ordinabile per questo prodotto.",
 		"error": {
+			"MAX_PER_USER": "Hai raggiunto il massimo ordinabile per questo prodotto.",
 			"BOOKING_SAME_DAY_DISABLED": "Le prenotazioni per oggi non sono disponibili per questo prodotto.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Le prenotazioni per oggi non sono più possibili dopo le {maxHour}."
 		}
@@ -989,6 +991,7 @@
 		"nameYourPrice": "Indica il tuo prezzo ({currency})",
 		"notForSale": "Questo prodotto non è disponibile alla vendita",
 		"outOfStock": "Esaurito",
+		"maxQuantityPerUserReached": "Hai raggiunto il massimo ordinabile per questo prodotto.",
 		"preorderText": "Questo è un preordine, il tuo prodotto sarà disponibile il  {date}",
 		"pricePlaceholder": "Prezzo",
 		"seeInCabinet": "Vedi in MyCabinet",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -115,7 +115,9 @@
 		"vatRate": "Btw-tarief voor {country}",
 		"vatSellerCountry": "Het land is het land van de verkoper.",
 		"maxQuantityReached": "Maximale hoeveelheid per bestelling bereikt ({max})",
+		"maxQuantityPerUserReached": "U hebt het maximum bereikt dat u van dit product kunt bestellen.",
 		"error": {
+			"MAX_PER_USER": "U hebt het maximum bereikt dat u van dit product kunt bestellen.",
 			"BOOKING_SAME_DAY_DISABLED": "Boekingen voor vandaag zijn niet beschikbaar voor dit product.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Boekingen voor vandaag zijn niet meer mogelijk na {maxHour}."
 		}
@@ -989,6 +991,7 @@
 		"nameYourPrice": "Geef uw prijs een naam ({currency})",
 		"notForSale": "Dit product is niet te koop",
 		"outOfStock": "Geen voorraad meer",
+		"maxQuantityPerUserReached": "U hebt het maximum bereikt dat u van dit product kunt bestellen.",
 		"preorderText": "Dit is een voorbestelling. Uw product is beschikbaar op {date}",
 		"pricePlaceholder": "Prijs",
 		"seeInCabinet": "Zie in MijnKabinet",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -115,7 +115,9 @@
 		"vatRate": "Taxa de IVA para {country}",
 		"vatSellerCountry": "O país é o país do vendedor.",
 		"maxQuantityReached": "Quantidade máxima por encomenda atingida ({max})",
+		"maxQuantityPerUserReached": "Atingiu o máximo que pode encomendar deste produto.",
 		"error": {
+			"MAX_PER_USER": "Atingiu o máximo que pode encomendar deste produto.",
 			"BOOKING_SAME_DAY_DISABLED": "As reservas para hoje não estão disponíveis para este produto.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "As reservas para hoje já não são possíveis após as {maxHour}."
 		}
@@ -989,6 +991,7 @@
 		"nameYourPrice": "Dê o seu preço ({currency})",
 		"notForSale": "Este produto não está disponível para venda",
 		"outOfStock": "Esgotado",
+		"maxQuantityPerUserReached": "Atingiu o máximo que pode encomendar deste produto.",
 		"preorderText": "Isto é uma pré-encomenda, o seu produto estará disponível em {date}",
 		"pricePlaceholder": "Preço",
 		"seeInCabinet": "Ver no Meu Armário",

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -51,6 +51,12 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 	};
 	vatProfileId?: ObjectId;
 	maxQuantityPerOrder?: number;
+	/**
+	 * Cap on how many units the same person may take across their whole history, not per
+	 * order. Left unset, the product is uncapped. Subscriptions ignore the stored value:
+	 * they are capped at one per person by a rule that predates this property.
+	 */
+	maxQuantityPerUser?: number;
 	type: 'subscription' | 'resource' | 'donation';
 	subscriptionDuration?: SubscriptionDuration;
 	subscriptionReminderSeconds?: number;
@@ -180,6 +186,28 @@ export const MAX_SHORT_DESCRIPTION_LIMIT = 160;
 export const MAX_DESCRIPTION_LIMIT = 10000;
 
 export const DEFAULT_MAX_QUANTITY_PER_ORDER = 10;
+
+/**
+ * A subscription has been capped at one per person and per product since long before
+ * `maxQuantityPerUser` existed, by the guard in `createOrder`. The property does not loosen
+ * that rule: on a subscription it is fixed here, shown read-only in the admin form, and any
+ * value stored on the document is ignored.
+ */
+export const MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION = 1;
+
+/**
+ * How many units of a product the same person may take in total, across their whole
+ * history — `undefined` when the product is uncapped.
+ */
+export function maxQuantityPerUser(
+	product: Pick<Product, 'type' | 'maxQuantityPerUser'>
+): number | undefined {
+	if (product.type === 'subscription') {
+		return MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION;
+	}
+	return product.maxQuantityPerUser;
+}
+
 export const POS_PRODUCT_PAGINATION = 10;
 export const PRODUCT_PAGINATION_LIMIT = 25;
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -228,6 +228,7 @@ export const actions: Actions = {
 						applyDeliveryFeesOnlyOnce: parsed.applyDeliveryFeesOnlyOnce,
 						requireSpecificDeliveryFee: parsed.requireSpecificDeliveryFee,
 						...(parsed.maxQuantityPerOrder && { maxQuantityPerOrder: parsed.maxQuantityPerOrder }),
+						...(parsed.maxQuantityPerUser && { maxQuantityPerUser: parsed.maxQuantityPerUser }),
 						...(parsed.stock !== undefined && {
 							stock: {
 								total: parsed.stock,
@@ -315,6 +316,7 @@ export const actions: Actions = {
 						...(parsed.stock === undefined && { stock: '' }),
 						...(!parsed.stockReferenceProductId && { stockReference: '' }),
 						...(!parsed.maxQuantityPerOrder && { maxQuantityPerOrder: '' }),
+						...(!parsed.maxQuantityPerUser && { maxQuantityPerUser: '' }),
 						...(!parsed.depositPercentage && { deposit: '' }),
 						...(!parsed.vatProfileId && { vatProfileId: '' }),
 						...(!parsed.subscriptionDuration && { subscriptionDuration: '' }),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -219,6 +219,9 @@ export const actions: Actions = {
 							...(parsed.maxQuantityPerOrder && {
 								maxQuantityPerOrder: parsed.maxQuantityPerOrder
 							}),
+							...(parsed.maxQuantityPerUser && {
+								maxQuantityPerUser: parsed.maxQuantityPerUser
+							}),
 							...(parsed.restrictPaymentMethods && {
 								paymentMethods: parsed.paymentMethods ?? []
 							}),
@@ -431,6 +434,9 @@ export const actions: Actions = {
 					}),
 					...(parsed.maxQuantityPerOrder && {
 						maxQuantityPerOrder: parsed.maxQuantityPerOrder
+					}),
+					...(parsed.maxQuantityPerUser && {
+						maxQuantityPerUser: parsed.maxQuantityPerUser
 					}),
 					displayShortDescription: parsed.displayShortDescription,
 					actionSettings: {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -164,6 +164,12 @@ export const productBaseSchema = () => ({
 		.transform((val) => val || undefined)
 		.optional(),
 	maxQuantityPerOrder: z.number({ coerce: true }).int().min(1).optional(),
+	maxQuantityPerUser: z
+		.string()
+		.trim()
+		.transform((val) => (val ? Number(val) : undefined))
+		.pipe(z.number().int().min(1).optional())
+		.optional(),
 	eshopVisible: z.boolean({ coerce: true }).default(false),
 	retailVisible: z.boolean({ coerce: true }).default(false),
 	nostrVisible: z.boolean({ coerce: true }).default(false),

--- a/src/routes/(app)/cart/+page.server.ts
+++ b/src/routes/(app)/cart/+page.server.ts
@@ -91,6 +91,13 @@ function mapAddError(slug: string, body: AddErrorBody, product: ProductBadge | n
 				...(body.params && { params: body.params }),
 				product
 			};
+		case 'MAX_PER_USER':
+			return {
+				slug,
+				key: 'cart.maxQuantityPerUserReached',
+				...(body.params && { params: body.params }),
+				product
+			};
 		default:
 			return { slug, key: 'cartFromUrl.errors.reasonGeneric', product };
 	}

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -3,6 +3,7 @@ import { cmsFromContent } from '$lib/server/cms';
 import { collections } from '$lib/server/database';
 import { applyResolvedStock, resolveStockProduct } from '$lib/server/product';
 import { resolveSubscriptionDuration } from '$lib/server/subscriptions';
+import { maxQuantityPerUserStatus } from '$lib/server/maxQuantityPerUser';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { adminPrefix as getAdminPrefix } from '$lib/server/admin';
 import { userIdentifier, userQuery } from '$lib/server/user';
@@ -96,6 +97,8 @@ async function fetchProduct(
 	| 'free'
 	| 'standalone'
 	| 'maxQuantityPerOrder'
+	| 'maxQuantityPerUser'
+	| 'subscriptionReminderSeconds'
 	| 'stock'
 	| 'actionSettings'
 	| 'contentBefore'
@@ -142,6 +145,8 @@ async function fetchProduct(
 				free: 1,
 				standalone: 1,
 				maxQuantityPerOrder: 1,
+				maxQuantityPerUser: 1,
+				subscriptionReminderSeconds: 1,
 				stock: 1,
 				actionSettings: 1,
 				contentBefore: {
@@ -232,13 +237,15 @@ export const load = async ({ params, parent, locals }) => {
 		product.stock = resolved.stock;
 	}
 
-	const [pictures, userSubscriptions, schedule, scheduleEvents, parentData] = await Promise.all([
-		fetchProductPictures(productId),
-		fetchUserSubscriptions(userIdentifier(locals)),
-		product.bookingSpec ? fetchProductSchedule(productId) : null,
-		product.bookingSpec ? fetchProductScheduleEvents(productId) : [],
-		parent()
-	]);
+	const [pictures, userSubscriptions, schedule, scheduleEvents, parentData, perUserLimit] =
+		await Promise.all([
+			fetchProductPictures(productId),
+			fetchUserSubscriptions(userIdentifier(locals)),
+			product.bookingSpec ? fetchProductSchedule(productId) : null,
+			product.bookingSpec ? fetchProductScheduleEvents(productId) : [],
+			parent(),
+			maxQuantityPerUserStatus(product, userIdentifier(locals))
+		]);
 	const totalFreeProducts = sum(
 		userSubscriptions.map((s) => s.freeProductsById?.[product._id]?.available ?? 0)
 	);
@@ -291,6 +298,20 @@ export const load = async ({ params, parent, locals }) => {
 		...(product.contentAfter && {
 			productCMSAfter: cmsFromContent({ desktopContent: product.contentAfter }, locals)
 		}),
+		// What the cart already holds counts too, so the CTA goes flat on the unit that would
+		// have been refused rather than one click later.
+		maxPerUser: perUserLimit && {
+			max: perUserLimit.max,
+			remaining: Math.max(
+				perUserLimit.remaining -
+					sum(
+						parentData.cart.items
+							.filter((item) => item.product._id === productId)
+							.map((item) => item.quantity)
+					),
+				0
+			)
+		},
 		showCheckoutButton: runtimeConfig.checkoutButtonOnProductPage,
 		priceHistoryEnabled: runtimeConfig.priceHistoryEnabled,
 		websiteShortDescription: product.shortDescription,

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -217,10 +217,15 @@
 
 	$: isPreorder = isPreorderFn(data.product.availableDate, data.product.preorder);
 
+	// Kept out of `amountAvailable`: reaching one's personal cap is not being out of stock, and
+	// the two say different things to the customer.
+	$: maxPerUserReached = !!data.maxPerUser && data.maxPerUser.remaining <= 0;
+
 	$: amountAvailable = Math.max(
 		Math.min(
 			data.product.stock?.available ?? Infinity,
-			data.product.maxQuantityPerOrder || DEFAULT_MAX_QUANTITY_PER_ORDER
+			data.product.maxQuantityPerOrder || DEFAULT_MAX_QUANTITY_PER_ORDER,
+			data.maxPerUser?.remaining ?? Infinity
 		),
 		0
 	);
@@ -1183,7 +1188,14 @@
 									{t('ageWarning.agreement')}
 								</label>
 							{/if}
-							{#if amountAvailable === 0}
+							{#if maxPerUserReached}
+								<p class="text-red-500">
+									{t('product.maxQuantityPerUserReached')}
+								</p>
+								<button class="btn body-cta body-mainCTA" disabled>
+									{t(`product.cta.${verb}`)}
+								</button>
+							{:else if amountAvailable === 0}
 								<p class="text-red-500">
 									<span class="font-bold">{t('product.outOfStock')}</span>
 									<br />


### PR DESCRIPTION
…756)

A product could already cap how many units go into a single order. Nothing capped how many units the same person could buy across several orders: they ordered three, came back, ordered three more.

Products now carry a "Maximum quantity for an unique user" setting, next to the per-order cap in the admin form. Left empty, nothing changes. Filled in, a customer who has already reached that many units is refused when they add the product to their cart, and the product page shows them why with the buy button greyed out instead of letting them click and fail later.

Who counts as the same person is what the shop already knows about them: their account, their contact e-mail and its secondary addresses, their npub, their SSO identity, or their browser session. No account is needed for the cap to hold. Orders still awaiting payment count towards it, so opening two orders side by side and paying both does not get anyone over the limit.

Subscriptions were the one place where be-BOP already limited a purchase to one per person, and they keep that limit unchanged. What they gain is the same front behaviour as everything else: a customer who already holds an active subscription, or who has an unpaid order for one, now sees it on the product page and is turned away at add to cart, rather than reaching the payment step and hitting a bare error page in English. The message is translated in all seven languages.

Every way into the cart goes through the same refusal: the product page, the product widgets, a pre-configured cart or share link, and the point-of-sale "add by alias".

Fixes #2756