### PR TITLE
🚀🤖 S37 demo release

### DIFF
--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -155,7 +155,8 @@ function computeVatForItem(
 		vatProfiles: params.vatProfiles,
 		bebopCountry: params.bebopCountry,
 		userCountry: params.userCountry,
-		vatSingleCountry: params.vatSingleCountry
+		vatSingleCountry: params.vatSingleCountry,
+		vatExempted: params.vatExempted
 	});
 	const freeUnits = params.freeUnits ?? 0;
 	const { amount: amountToBill, currency, usedFreeUnits } = priceToBillForItem(item, { freeUnits });
@@ -275,6 +276,7 @@ function computeDeliveryFeesHt(params: {
 	bebopCountry: CountryAlpha2 | undefined;
 	userCountry: CountryAlpha2 | undefined;
 	vatSingleCountry: boolean;
+	vatExempted?: boolean;
 	vatProfiles: Array<{
 		_id: string | ObjectId;
 		rates: Partial<Record<CountryAlpha2, number>>;
@@ -288,7 +290,8 @@ function computeDeliveryFeesHt(params: {
 		vatProfiles: params.vatProfiles,
 		bebopCountry: params.bebopCountry,
 		userCountry: params.userCountry,
-		vatSingleCountry: params.vatSingleCountry
+		vatSingleCountry: params.vatSingleCountry,
+		vatExempted: params.vatExempted
 	});
 	return {
 		amount: extractVat(params.deliveryFees.amount, rate),
@@ -382,6 +385,7 @@ export function computePriceInfo(
 		bebopCountry: params.bebopCountry,
 		userCountry: params.userCountry,
 		vatSingleCountry: params.vatSingleCountry,
+		vatExempted: params.vatExempted,
 		vatProfiles: params.vatProfiles
 	});
 

--- a/src/lib/cartErrorKey.ts
+++ b/src/lib/cartErrorKey.ts
@@ -1,0 +1,45 @@
+import type { CartErrorCode } from '$lib/server/cart';
+
+// Re-exported so client code can name a cart error code without reaching into a server module.
+export type { CartErrorCode };
+
+/**
+ * The translation key for each refusal the cart can raise.
+ *
+ * There is one table, and every surface reads it: the product page, the cart, the shared-cart
+ * popup. The messages carried by the errors themselves are an English last resort meant for
+ * NostR and API clients, and they used to reach the screen whenever a surface had no case for
+ * a code — which was most of them.
+ */
+export function cartErrorKey(code: CartErrorCode): string {
+	switch (code) {
+		case 'NOT_FOR_SALE':
+			return 'product.notForSale';
+		case 'OUT_OF_STOCK':
+			return 'product.outOfStock';
+		case 'MAX_ITEMS_REACHED':
+			return 'cart.reachedMaxPerLine';
+		case 'MAX_PER_ORDER':
+			return 'cart.maxQuantityReached';
+		case 'VARIATION_INVALID':
+			return 'cartFromUrl.errors.reasonVariationRequired';
+		case 'BOOKING_INFO_REQUIRED':
+			return 'cartFromUrl.errors.reasonBookingRequired';
+		case 'BOOKING_SAME_DAY_DISABLED':
+		case 'BOOKING_SAME_DAY_CUTOFF_PASSED':
+			return `cart.error.${code}`;
+		case 'LOGIN_REQUIRED':
+		case 'NOT_WHITELISTED':
+		case 'MAX_PER_USER':
+			return `saleLock.${code}`;
+		case 'NOT_PWYW':
+		case 'NOT_PREORDER':
+		case 'STANDALONE_QTY_ONE':
+		case 'SUBSCRIPTION_CUSTOM_PRICE':
+		case 'MAX_PRICE_EXCEEDED':
+			return `cart.error.${code}`;
+		default:
+			code satisfies never;
+			return 'cartFromUrl.errors.reasonGeneric';
+	}
+}

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -174,7 +174,8 @@
 		vatProfiles,
 		bebopCountry: $page.data.vatCountry,
 		userCountry: $page.data.vatCountry,
-		vatSingleCountry: true
+		vatSingleCountry: true,
+		vatExempted: $page.data.vatExempted
 	});
 	$: vatProfileLabel =
 		vatProfiles.find((p) => p._id === vatProfileId)?.name ?? 'No custom VAT profile';

--- a/src/lib/components/ProductForm.svelte
+++ b/src/lib/components/ProductForm.svelte
@@ -8,6 +8,7 @@
 	import {
 		DEFAULT_MAX_QUANTITY_PER_ORDER,
 		MAX_NAME_LIMIT,
+		MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION,
 		MAX_SHORT_DESCRIPTION_LIMIT,
 		type Product
 	} from '$lib/types/Product';
@@ -52,6 +53,8 @@
 	const { t } = useI18n();
 
 	export let tags: Pick<Tag, '_id' | 'name'>[];
+	export let subscriptionProducts: { _id: string; name: string }[] = [];
+
 	export let isNew = false;
 	export let duplicateFromId: string | undefined = undefined;
 	export let sold = 0;
@@ -89,6 +92,7 @@
 		hideDiscountExpiration: false,
 		stock: undefined,
 		maxQuantityPerOrder: DEFAULT_MAX_QUANTITY_PER_ORDER,
+		requiresAuthentication: false,
 		actionSettings: defaultActionSettings,
 		createdAt: new Date(),
 		updatedAt: new Date(),
@@ -103,6 +107,20 @@
 		hasSellDisclaimer: false,
 		hideFromSEO: false
 	};
+
+	let maxQuantityPerUser: number | string = product.maxQuantityPerUser ?? '';
+	let requiresAuthentication = !!product.requiresAuthentication;
+	let hasWhitelist = !!product.whitelist;
+
+	// A per-person cap only means something once we know who the person is. Ticking it here
+	// mirrors what the server does on save, so the admin sees the real state of the option.
+	// A per-person cap is meaningless until we know who the person is, so it forces the
+	// authentication lock — here and again on save, the way variations force `standalone`.
+	$: authForcedByCap =
+		maxQuantityPerUser !== '' && maxQuantityPerUser !== null && maxQuantityPerUser !== undefined;
+	$: if (authForcedByCap) {
+		requiresAuthentication = true;
+	}
 
 	let paymentMethods = product.paymentMethods || [...availablePaymentMethods];
 	let restrictPaymentMethods = !!product.paymentMethods;
@@ -1400,6 +1418,28 @@
 							value={product.maxQuantityPerOrder || DEFAULT_MAX_QUANTITY_PER_ORDER}
 						/>
 					</label>
+
+					<label class="form-label">
+						Maximum quantity for an unique user
+						<input
+							class="form-input"
+							type="number"
+							name="maxQuantityPerUser"
+							placeholder="No limit"
+							step="1"
+							min="1"
+							bind:value={maxQuantityPerUser}
+						/>
+						<span class="text-sm text-gray-600">
+							Across all their orders, not per order. Leave empty for no limit. Orders awaiting
+							payment count towards it, and filling it in requires the customer to be authenticated.
+						</span>
+					</label>
+				{:else}
+					<p class="text-sm text-gray-600">
+						Maximum quantity for an unique user: {MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION} — a subscription
+						is limited to one per person and per product.
+					</p>
 				{/if}
 			</div>
 			<input type="hidden" name="changedDate" value={changedDate} />
@@ -1775,6 +1815,108 @@
 						bind:retailBasket={product.actionSettings.retail.canBeAddedToBasket}
 						bind:nostrBasket={product.actionSettings.nostr.canBeAddedToBasket}
 					/>
+				</div>
+
+				<div>
+					<h4 class="text-lg font-medium text-gray-900 mb-3">Who can order</h4>
+					<div class="space-y-4">
+						<label class="checkbox-label">
+							<input
+								class="form-checkbox"
+								type="checkbox"
+								name="requiresAuthentication"
+								bind:checked={requiresAuthentication}
+								disabled={authForcedByCap}
+							/>
+							Customer must be authenticated to order this product
+						</label>
+						{#if authForcedByCap}
+							<p class="text-sm text-gray-600">
+								Required, and locked, because this product has a "Maximum quantity for an unique
+								user" set in Inventory &amp; Stock. Clear that field to unlock this option.
+							</p>
+						{/if}
+
+						<label class="checkbox-label">
+							<input
+								class="form-checkbox"
+								type="checkbox"
+								name="hasWhitelist"
+								bind:checked={hasWhitelist}
+							/>
+							Restrict who can order this product
+						</label>
+
+						{#if hasWhitelist}
+							<p class="text-sm text-gray-600">
+								Anyone matching at least one of the sources below can order the product. Everyone
+								else sees the product page, with the order and add-to-cart buttons disabled. Leaving
+								every source empty closes the product to everyone.
+							</p>
+
+							<label class="form-label">
+								Allowed e-mail addresses
+								<textarea
+									class="form-input"
+									name="whitelistEmails"
+									rows="4"
+									placeholder="One e-mail address per line"
+									value={product.whitelist?.emails?.join('\n') ?? ''}
+								/>
+							</label>
+
+							<label class="form-label">
+								Allowed npubs
+								<textarea
+									class="form-input"
+									name="whitelistNpubs"
+									rows="4"
+									placeholder="One npub per line"
+									value={product.whitelist?.npubs?.join('\n') ?? ''}
+								/>
+							</label>
+
+							<!-- svelte-ignore a11y-label-has-associated-control -->
+							<label class="form-label">
+								Allow the active subscribers of
+								<MultiSelect
+									--sms-options-bg="var(--body-mainPlan-backgroundColor)"
+									name="whitelistSubscriptionProductIds"
+									options={subscriptionProducts.map((subscriptionProduct) => ({
+										value: subscriptionProduct._id,
+										label: subscriptionProduct.name
+									}))}
+									selected={product.whitelist?.subscriptionProductIds?.map((productId) => ({
+										value: productId,
+										label:
+											subscriptionProducts.find(
+												(subscriptionProduct) => subscriptionProduct._id === productId
+											)?.name ?? productId
+									})) ?? []}
+								/>
+							</label>
+
+							<label class="checkbox-label">
+								<input
+									class="form-checkbox"
+									type="checkbox"
+									name="whitelistAllowEmployees"
+									checked={product.whitelist?.allowEmployees ?? false}
+								/>
+								Allow every employee, whatever their role
+							</label>
+
+							<label class="checkbox-label">
+								<input
+									class="form-checkbox"
+									type="checkbox"
+									name="whitelistAllowPosOverride"
+									checked={product.whitelist?.allowPosOverride ?? false}
+								/>
+								Let a point-of-sale employee add it for a customer who is not whitelisted
+							</label>
+						{/if}
+					</div>
 				</div>
 			</div>
 		</details>

--- a/src/lib/components/ProductWidget.svelte
+++ b/src/lib/components/ProductWidget.svelte
@@ -22,7 +22,11 @@
 	export { className as class };
 	export let displayOption = 'img-0';
 	$: canAddToCart =
-		canBuy && (!product.availableDate || product.availableDate <= new Date() || !!product.preorder);
+		canBuy &&
+		!product.saleLocked &&
+		(!product.availableDate || product.availableDate <= new Date() || !!product.preorder);
+	// Locked for this visitor: the CTA takes them to the product page, where the reason is.
+	$: saleLockedHref = product.saleLocked ? `/product/${product._id}` : undefined;
 	const widgets = {
 		'img-0': {
 			component: ProductWidgetVariation0
@@ -69,6 +73,7 @@
 		{pictures}
 		{hasDigitalFiles}
 		{canAddToCart}
+		{saleLockedHref}
 		{externalUrl}
 		class={className}
 	/>

--- a/src/lib/components/ProductWidget/ProductWidgetProduct.ts
+++ b/src/lib/components/ProductWidget/ProductWidgetProduct.ts
@@ -17,4 +17,10 @@ export type ProductWidgetProduct = Pick<
 	| 'payWhatYouWant'
 	| 'bookingSpec'
 	| 'hasVariations'
->;
+> & {
+	/**
+	 * Set by `annotateProductsWithSaleLocks` on listings. When true the widget CTA becomes a
+	 * link to the product page, which is where the reason is spelled out.
+	 */
+	saleLocked?: boolean;
+};

--- a/src/lib/components/ProductWidget/ProductWidgetVariation0.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation0.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let saleLockedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -89,6 +90,10 @@
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>
+		{:else if saleLockedHref}
+			<a href={saleLockedHref} class="btn cartPreview-mainCTA">
+				{t('product.cta.view')}
+			</a>
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation1.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation1.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let saleLockedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -90,6 +91,10 @@
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>
+		{:else if saleLockedHref}
+			<a href={saleLockedHref} class="btn cartPreview-mainCTA">
+				{t('product.cta.view')}
+			</a>
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation2.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation2.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let saleLockedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -93,6 +94,10 @@
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>
+		{:else if saleLockedHref}
+			<a href={saleLockedHref} class="btn cartPreview-mainCTA">
+				{t('product.cta.view')}
+			</a>
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation3.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation3.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let saleLockedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -75,6 +76,10 @@
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>
+		{:else if saleLockedHref}
+			<a href={saleLockedHref} class="btn cartPreview-mainCTA">
+				{t('product.cta.view')}
+			</a>
 		{/if}
 	</div>
 	<div class="flex flex-col">

--- a/src/lib/components/ProductWidget/ProductWidgetVariation4.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation4.svelte
@@ -11,6 +11,7 @@
 	export let product: ProductWidgetProduct;
 	export let hasDigitalFiles: boolean;
 	export let canAddToCart: boolean;
+	export let saleLockedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let className = '';
@@ -84,6 +85,10 @@
 			<div class="flex flex-row items-end justify-end">
 				<AddToCart {product} picture={pictures[0]} class="btn cartPreview-mainCTA" />
 			</div>
+		{:else if saleLockedHref}
+			<a href={saleLockedHref} class="btn cartPreview-mainCTA">
+				{t('product.cta.view')}
+			</a>
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/ProductWidget/ProductWidgetVariation5.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation5.svelte
@@ -13,6 +13,7 @@
 	export let product: ProductWidgetProduct;
 	export let pictures: Picture[] | [];
 	export let canAddToCart: boolean;
+	export let saleLockedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 	let pictureId = 0;
 
@@ -61,6 +62,10 @@
 						/>
 					</div>
 				</div>
+			{:else if saleLockedHref}
+				<a href={saleLockedHref} class="btn cartPreview-mainCTA">
+					{t('product.cta.view')}
+				</a>
 			{/if}
 		</div>
 

--- a/src/lib/components/ProductWidget/ProductWidgetVariation6.svelte
+++ b/src/lib/components/ProductWidget/ProductWidgetVariation6.svelte
@@ -13,6 +13,7 @@
 	export let product: ProductWidgetProduct;
 	export let pictures: Picture[] | [];
 	export let canAddToCart: boolean;
+	export let saleLockedHref: string | undefined = undefined;
 	export let externalUrl: string | undefined = undefined;
 
 	let pictureId = 0;
@@ -89,6 +90,10 @@
 						/>
 					</div>
 				</div>
+			{:else if saleLockedHref}
+				<a href={saleLockedHref} class="btn cartPreview-mainCTA">
+					{t('product.cta.view')}
+				</a>
 			{/if}
 		</div>
 	</div>

--- a/src/lib/server/cart.ts
+++ b/src/lib/server/cart.ts
@@ -8,7 +8,11 @@ import {
 } from '$lib/types/Product';
 import { error } from '@sveltejs/kit';
 import { runtimeConfig } from './runtime-config';
-import { amountOfStockReserved, refreshAvailableStockInDb } from './product';
+import {
+	amountOfStockReserved,
+	refreshAvailableStockInDb,
+	resolveAvailableAmounts
+} from './product';
 import type { Cart } from '$lib/types/Cart';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import { userQuery } from './user';
@@ -19,6 +23,13 @@ import type { Currency } from '$lib/types/Currency';
 import { toCurrency } from '$lib/utils/toCurrency';
 import { sum } from '$lib/utils/sum';
 import { deepEquals } from '$lib/utils/deep-equals';
+import {
+	evaluateSaleLocks,
+	saleLockMessage,
+	SALE_LOCK_CODES,
+	type ProductWithSaleLocks,
+	type SaleLock
+} from './saleLock';
 
 export const CART_ERROR_CODES = [
 	'NOT_FOR_SALE',
@@ -33,7 +44,8 @@ export const CART_ERROR_CODES = [
 	'OUT_OF_STOCK',
 	'STANDALONE_QTY_ONE',
 	'VARIATION_INVALID',
-	'MAX_PER_ORDER'
+	'MAX_PER_ORDER',
+	...SALE_LOCK_CODES
 ] as const;
 export type CartErrorCode = (typeof CART_ERROR_CODES)[number];
 
@@ -259,6 +271,30 @@ export async function addToCartInDb(
 	const totalQuantityInCart = () =>
 		sum(cart.items.filter((item) => item.productId === product._id).map((item) => item.quantity));
 
+	// Sale locks, refused at the door. Every way into the cart lands here — the product page,
+	// a pre-configured cart link, the point-of-sale alias field, NostR — so none of them needs
+	// its own copy of the rules. Evaluated once the cart is known, because a per-person cap
+	// counts what already sits in it on top of what was already ordered.
+	const lockOnAdd = (
+		await evaluateSaleLocks([product], params.user, {
+			mode: params.mode,
+			// A subscription line is clamped to one unit whatever was asked, but a subscription is
+			// standalone: a second add makes a second line rather than merging. So what the cart
+			// already holds has to count, or the same subscription piles up in one order.
+			extraQuantityByProductId: {
+				[product._id]: product.type === 'subscription' ? 1 : quantity
+			},
+			quantityInCartByProductId: { [product._id]: totalQuantityInCart() },
+			availableByProductId: await resolveAvailableAmounts([product], params.user)
+		})
+	).get(product._id);
+	if (lockOnAdd?.length) {
+		// One code and its params travel on the error — the first reason, which is the most
+		// actionable. The message carries every reason; the pages read the evaluator directly
+		// and show them all.
+		cartError(lockOnAdd[0].code, saleLockMessage(lockOnAdd, product.name), lockOnAdd[0].params);
+	}
+
 	const availableAmount = await computeAvailableAmount(product, cart);
 
 	if (availableAmount <= 0) {
@@ -452,13 +488,43 @@ async function computeAvailableAmount(product: Product, cart: Cart): Promise<num
 export async function checkCartItems(
 	items: Array<{
 		quantity: number;
-		product: Pick<Product, 'stock' | '_id' | 'name' | 'maxQuantityPerOrder' | 'stockReference'>;
+		product: Pick<Product, 'stock' | '_id' | 'name' | 'maxQuantityPerOrder' | 'stockReference'> &
+			ProductWithSaleLocks;
 	}>,
 	opts?: {
 		user?: UserIdentifier;
 	}
 ) {
 	const products = items.map((item) => item.product);
+
+	// Sale locks, re-asked here and not only on the way in: a cart filled before the shop owner
+	// drew a list up, or before a subscription lapsed, would otherwise still check out. This
+	// function is what the cart page, the checkout page and order creation all call, so the
+	// three give the same answer.
+	//
+	// Additive: the stock, per-order and cart-size rules below are untouched and still apply.
+	if (opts?.user) {
+		const quantityInCart: Record<string, number> = {};
+		for (const item of items) {
+			quantityInCart[item.product._id] = (quantityInCart[item.product._id] ?? 0) + item.quantity;
+		}
+		const locks = await evaluateSaleLocks(products, opts.user, {
+			mode: opts.user.userHasPosOptions ? 'pos' : 'eshop',
+			// What sits in the cart is what is about to be ordered, so it counts towards a
+			// per-person cap alongside what was ordered before.
+			extraQuantityByProductId: quantityInCart,
+			availableByProductId: await resolveAvailableAmounts(products, opts.user)
+		});
+		const firstLocked = products.find((product) => locks.has(product._id));
+		if (firstLocked) {
+			const productLocks = locks.get(firstLocked._id) as SaleLock[];
+			cartError(productLocks[0].code, saleLockMessage(productLocks, firstLocked.name), {
+				...productLocks[0].params,
+				products: firstLocked.name
+			});
+		}
+	}
+
 	const productById = Object.fromEntries(products.map((product) => [product._id, product]));
 
 	// be careful, there can be multiple lines for the same product due to product.standalone

--- a/src/lib/server/cms.ts
+++ b/src/lib/server/cms.ts
@@ -9,6 +9,8 @@ import { trimSuffix } from '$lib/utils/trimSuffix';
 import { JSDOM } from 'jsdom';
 import DOMPurify from 'dompurify';
 import { collections } from './database';
+import { annotateProductsWithSaleLocks } from './saleLock';
+import { userIdentifier } from './user';
 import { ALLOW_JS_INJECTION } from '$lib/server/env-config';
 import type { Specification } from '$lib/types/Specification';
 import type { Tag } from '$lib/types/Tag';
@@ -591,6 +593,10 @@ export async function cmsFromContent(
 						Pick<
 							Product,
 							| '_id'
+							| 'requiresAuthentication'
+							| 'whitelist'
+							| 'maxQuantityPerUser'
+							| 'subscriptionReminderSeconds'
 							| 'price'
 							| 'name'
 							| 'shortDescription'
@@ -633,7 +639,11 @@ export async function cmsFromContent(
 						hasSellDisclaimer: 1,
 						payWhatYouWant: 1,
 						bookingSpec: 1,
-						hasVariations: 1
+						hasVariations: 1,
+						requiresAuthentication: 1,
+						whitelist: 1,
+						maxQuantityPerUser: 1,
+						subscriptionReminderSeconds: 1
 					})
 					.toArray()
 			: [],
@@ -805,11 +815,18 @@ export async function cmsFromContent(
 
 	const scheduleEventsById = groupBy(scheduleEvents, (event) => event.scheduleId);
 
+	// Listings must not offer straight to the cart what the cart would refuse. One evaluation
+	// for the whole page, none at all when no product on it carries a lock.
+	const productsWithSaleLocks = await annotateProductsWithSaleLocks(
+		products,
+		userIdentifier(locals)
+	);
+
 	return {
 		tokens,
 		challenges,
 		sliders,
-		products,
+		products: productsWithSaleLocks,
 		externalProducts,
 		tags,
 		specifications,

--- a/src/lib/server/cms.ts
+++ b/src/lib/server/cms.ts
@@ -854,6 +854,7 @@ async function buildSearchlistViews(searchlistSlugs: string[], locals: App.Local
 		bebopCountry: runtimeConfig.vatCountry,
 		userCountry: locals.countryCode,
 		vatSingleCountry: runtimeConfig.vatSingleCountry,
+		vatExempted: runtimeConfig.vatExempted,
 		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
 	};
 

--- a/src/lib/server/discount.test.ts
+++ b/src/lib/server/discount.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isPublicZeroCriteriaDiscount, publicDiscountPriceSnapshot } from './discount';
+import {
+	evaluateDiscountConditions,
+	isPublicZeroCriteriaDiscount,
+	publicDiscountPriceSnapshot
+} from './discount';
+import type { DiscountContext } from './discount';
 import type { Discount } from '$lib/types/Discount';
 
 /** Minimal valid public percentage discount; override any field per test. */
@@ -89,5 +94,80 @@ describe('publicDiscountPriceSnapshot', () => {
 			wholeCatalog: false,
 			productIds: ['p1', 'p2']
 		});
+	});
+});
+
+/** Cart context with no conditions met beyond what a test sets. */
+function context(overrides: Partial<DiscountContext> = {}): DiscountContext {
+	return {
+		userSubscriptionIds: [],
+		userContactAddresses: [],
+		cartItems: [],
+		isLoggedIn: false,
+		...overrides
+	};
+}
+
+describe('evaluateDiscountConditions — required subscription', () => {
+	const membership = discount({ subscriptionIds: ['membership'] });
+
+	it('passes when the subscription is already active', () => {
+		expect(
+			evaluateDiscountConditions(membership, context({ userSubscriptionIds: ['membership'] }))
+		).toBe(true);
+	});
+
+	it('fails when the customer has no such subscription', () => {
+		expect(evaluateDiscountConditions(membership, context())).toBe(false);
+	});
+
+	// #2718: without the opt-in, a subscription sitting in the cart is not a subscription the
+	// customer holds — an existing members-only discount must keep meaning paid-up members.
+	it('ignores the subscription sitting in the cart by default', () => {
+		expect(
+			evaluateDiscountConditions(
+				membership,
+				context({ cartItems: [{ productId: 'membership', quantity: 1 }] })
+			)
+		).toBe(false);
+	});
+
+	it('accepts the subscription sitting in the cart once the shop opts in', () => {
+		expect(
+			evaluateDiscountConditions(
+				discount({ subscriptionIds: ['membership'], acceptSubscriptionInCart: true }),
+				context({ cartItems: [{ productId: 'membership', quantity: 1 }] })
+			)
+		).toBe(true);
+	});
+
+	it('still fails with the opt-in when neither the cart nor the customer carries it', () => {
+		expect(
+			evaluateDiscountConditions(
+				discount({ subscriptionIds: ['membership'], acceptSubscriptionInCart: true }),
+				context({ cartItems: [{ productId: 'something-else', quantity: 1 }] })
+			)
+		).toBe(false);
+	});
+});
+
+describe('evaluateDiscountConditions — required product combinations', () => {
+	// #2718: combinations gate the discount and are matched against the cart, so a subscription
+	// works there like any other line once the admin form lets it be picked.
+	const combo = discount({
+		productCombinations: [{ products: [{ productId: 'membership', quantity: 1 }] }]
+	});
+
+	it('matches a subscription listed in a required combination', () => {
+		expect(
+			evaluateDiscountConditions(
+				combo,
+				context({ cartItems: [{ productId: 'membership', quantity: 1 }] })
+			)
+		).toBe(true);
+	});
+
+	it('does not match when the combination is absent from the cart', () => {
+		expect(evaluateDiscountConditions(combo, context())).toBe(false);
 	});
 });

--- a/src/lib/server/discount.ts
+++ b/src/lib/server/discount.ts
@@ -47,11 +47,19 @@ export async function getActivePercentageDiscounts(): Promise<Discount[]> {
  * Each non-empty condition must pass. Empty/undefined = "true" (no filter).
  */
 export function evaluateDiscountConditions(discount: Discount, ctx: DiscountContext): boolean {
-	if (
-		discount.subscriptionIds?.length &&
-		!discount.subscriptionIds.some((id) => ctx.userSubscriptionIds.includes(id))
-	) {
-		return false;
+	if (discount.subscriptionIds?.length) {
+		const hasActiveSubscription = discount.subscriptionIds.some((id) =>
+			ctx.userSubscriptionIds.includes(id)
+		);
+		// Buying the subscription right now counts, when the shop allows it: otherwise a new
+		// customer has to order the membership, come back logged in, and order again (#2718).
+		const isSubscribingNow =
+			!!discount.acceptSubscriptionInCart &&
+			discount.subscriptionIds.some((id) => ctx.cartItems.some((item) => item.productId === id));
+
+		if (!hasActiveSubscription && !isSubscribingNow) {
+			return false;
+		}
 	}
 
 	if (discount.promoCode && discount.promoCode.toLowerCase() !== ctx.promoCode?.toLowerCase()) {

--- a/src/lib/server/product.ts
+++ b/src/lib/server/product.ts
@@ -349,3 +349,38 @@ export function cleanVariationLabels(variationLabels?: {
 
 	return { names, values };
 }
+
+/**
+ * How many units of each product are still sellable, this visitor's own reservations excluded.
+ *
+ * One rule, one place. The product page used to read the cached `stock.available`, which counts
+ * everyone's reservations including the visitor's own, while the cart computed it live and
+ * excluded them — so a page could announce a rupture the cart would have accepted. Both now
+ * ask this.
+ *
+ * A product without stock is unlimited and simply absent from the result.
+ */
+export async function resolveAvailableAmounts(
+	products: Array<{
+		_id: string;
+		stock?: { available: number; total: number; reserved: number };
+		stockReference?: { productId: string };
+	}>,
+	user: UserIdentifier | undefined,
+	session?: ClientSession
+): Promise<Record<string, number>> {
+	const available: Record<string, number> = {};
+
+	for (const product of products) {
+		if (!product.stock) {
+			continue;
+		}
+		const reserved = await amountOfStockReserved(product.stockReference?.productId || product._id, {
+			...(user && { exclude: user }),
+			session
+		});
+		available[product._id] = Math.max(product.stock.total - reserved, 0);
+	}
+
+	return available;
+}

--- a/src/lib/server/saleLock.test.ts
+++ b/src/lib/server/saleLock.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { addSeconds, subSeconds } from 'date-fns';
+import { CUSTOMER_ROLE_ID } from '$lib/types/User';
+import {
+	MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION,
+	maxQuantityPerUser,
+	requiresAuthenticationToOrder
+} from '$lib/types/Product';
+import {
+	buildProductWhitelist,
+	hasSaleLocks,
+	isEmployee,
+	matchesWhitelist,
+	subscriptionOccupiesSlot
+} from './saleLock';
+
+const ONE_DAY = 24 * 3600;
+const NOW = new Date('2026-09-07T12:00:00Z');
+
+const WHITELIST = {
+	emails: ['Alice@Example.com'],
+	npubs: ['npub1alice'],
+	subscriptionProductIds: ['gold'],
+	allowEmployees: false,
+	allowPosOverride: false
+};
+
+describe('isEmployee', () => {
+	it('is false for an anonymous visitor and for a customer role', () => {
+		expect(isEmployee(undefined)).toBe(false);
+		expect(isEmployee({ sessionId: 'anon' })).toBe(false);
+		expect(isEmployee({ sessionId: 'anon', userRoleId: CUSTOMER_ROLE_ID })).toBe(false);
+	});
+
+	it('is true for any other role', () => {
+		expect(isEmployee({ sessionId: 'anon', userRoleId: 'employee' })).toBe(true);
+	});
+});
+
+describe('matchesWhitelist', () => {
+	it('matches a listed e-mail whatever its case', () => {
+		expect(matchesWhitelist(WHITELIST, { email: 'alice@example.com' }, [])).toBe(true);
+	});
+
+	it('matches a listed npub', () => {
+		expect(matchesWhitelist(WHITELIST, { npub: 'npub1alice' }, [])).toBe(true);
+	});
+
+	it('matches an active subscriber without listing them by hand', () => {
+		expect(matchesWhitelist(WHITELIST, { sessionId: 'anon' }, ['gold'])).toBe(true);
+	});
+
+	it('turns nobody away who matches none of the sources', () => {
+		expect(matchesWhitelist(WHITELIST, { email: 'bob@example.com' }, ['silver'])).toBe(false);
+	});
+
+	it('lets employees in only when the option says so', () => {
+		const employee = { sessionId: 'anon', userRoleId: 'employee' };
+		expect(matchesWhitelist(WHITELIST, employee, [])).toBe(false);
+		expect(matchesWhitelist({ ...WHITELIST, allowEmployees: true }, employee, [])).toBe(true);
+	});
+
+	it('closes the product when every source is empty — an empty guest list', () => {
+		const empty = {
+			emails: [],
+			npubs: [],
+			subscriptionProductIds: [],
+			allowEmployees: false,
+			allowPosOverride: false
+		};
+		expect(matchesWhitelist(empty, { email: 'alice@example.com' }, ['gold'])).toBe(false);
+	});
+});
+
+describe('buildProductWhitelist', () => {
+	const fields = {
+		hasWhitelist: true,
+		whitelistEmails: ' alice@example.com \n\n bob@example.com ',
+		whitelistNpubs: '',
+		whitelistSubscriptionProductIds: ['gold', ''],
+		whitelistAllowEmployees: true,
+		whitelistAllowPosOverride: false
+	};
+
+	it('is undefined when the option is off, leaving the product open', () => {
+		expect(buildProductWhitelist({ ...fields, hasWhitelist: false })).toBeUndefined();
+	});
+
+	it('trims the text areas and drops blank lines', () => {
+		expect(buildProductWhitelist(fields)).toEqual({
+			emails: ['alice@example.com', 'bob@example.com'],
+			npubs: [],
+			subscriptionProductIds: ['gold'],
+			allowEmployees: true,
+			allowPosOverride: false
+		});
+	});
+});
+
+describe('maxQuantityPerUser', () => {
+	it('is undefined on an uncapped product', () => {
+		expect(maxQuantityPerUser({ type: 'resource' })).toBeUndefined();
+	});
+
+	it('is the stored value on a regular product', () => {
+		expect(maxQuantityPerUser({ type: 'resource', maxQuantityPerUser: 3 })).toBe(3);
+	});
+
+	it('is one on a subscription, whatever the document says', () => {
+		expect(maxQuantityPerUser({ type: 'subscription', maxQuantityPerUser: 5 })).toBe(
+			MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION
+		);
+	});
+});
+
+describe('requiresAuthenticationToOrder', () => {
+	it('follows the option on its own', () => {
+		expect(requiresAuthenticationToOrder({})).toBe(false);
+		expect(requiresAuthenticationToOrder({ requiresAuthentication: true })).toBe(true);
+	});
+
+	it('is turned on by a per-person cap, which is meaningless without an identity', () => {
+		expect(requiresAuthenticationToOrder({ maxQuantityPerUser: 2 })).toBe(true);
+	});
+
+	it('is not turned on by the implicit one-per-person rule of subscriptions', () => {
+		// The rule reads the stored field, which a subscription leaves unset.
+		expect(requiresAuthenticationToOrder({})).toBe(false);
+	});
+});
+
+describe('subscriptionOccupiesSlot', () => {
+	const product = { subscriptionReminderSeconds: ONE_DAY };
+
+	it('holds the slot while the subscription runs and renewal is not open yet', () => {
+		expect(
+			subscriptionOccupiesSlot({ paidUntil: addSeconds(NOW, 30 * ONE_DAY) }, product, NOW)
+		).toBe(true);
+	});
+
+	it('frees the slot once inside the renewal window, so renewals go through', () => {
+		expect(
+			subscriptionOccupiesSlot({ paidUntil: addSeconds(NOW, ONE_DAY / 2) }, product, NOW)
+		).toBe(false);
+	});
+
+	it('frees the slot on an expired subscription', () => {
+		expect(subscriptionOccupiesSlot({ paidUntil: subSeconds(NOW, ONE_DAY) }, product, NOW)).toBe(
+			false
+		);
+	});
+});
+
+describe('hasSaleLocks', () => {
+	it('is false on a plain product, which is what lets listings skip every query', () => {
+		expect(hasSaleLocks({ _id: 'p', name: 'P', type: 'resource' })).toBe(false);
+	});
+
+	it('is true for each of the three locks', () => {
+		expect(
+			hasSaleLocks({ _id: 'p', name: 'P', type: 'resource', requiresAuthentication: true })
+		).toBe(true);
+		expect(hasSaleLocks({ _id: 'p', name: 'P', type: 'resource', whitelist: WHITELIST })).toBe(
+			true
+		);
+		expect(hasSaleLocks({ _id: 'p', name: 'P', type: 'resource', maxQuantityPerUser: 2 })).toBe(
+			true
+		);
+	});
+
+	it('is true on every subscription — one per person predates the property', () => {
+		expect(hasSaleLocks({ _id: 'p', name: 'P', type: 'subscription' })).toBe(true);
+	});
+});

--- a/src/lib/server/saleLock.ts
+++ b/src/lib/server/saleLock.ts
@@ -1,0 +1,541 @@
+import { subSeconds } from 'date-fns';
+import type { ClientSession } from 'mongodb';
+import type { PaidSubscription } from '$lib/types/PaidSubscription';
+import type { Product } from '$lib/types/Product';
+import {
+	DEFAULT_MAX_QUANTITY_PER_ORDER,
+	MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION,
+	maxQuantityPerUser,
+	requiresAuthenticationToOrder
+} from '$lib/types/Product';
+import type { UserIdentifier } from '$lib/types/UserIdentifier';
+import { CUSTOMER_ROLE_ID } from '$lib/types/User';
+import { collections } from './database';
+import { collectUserAddresses, isAuthenticated } from './discount';
+import { currentFundingReminderSeconds } from './subscriptions';
+import { userQuery } from './user';
+
+/**
+ * A sale lock is a per-product rule that answers one question: may *this* customer buy *this*
+ * product right now? Three rules share the mechanism — they differ only in what they check and
+ * in what the customer is told.
+ *
+ * Every rule is enforced in the same three places, and nowhere else:
+ *   - `addToCartInDb`, so the product never enters the cart;
+ *   - `checkCartItems`, which the cart page, the checkout page and order creation all call;
+ *   - the front, which asks for the same verdict to grey a CTA out before it is clicked.
+ *
+ * Adding a fourth rule means adding a case below and a translation. It must not mean touching
+ * the cart, the checkout or the order again.
+ */
+export const SALE_LOCK_CODES = [
+	'LOGIN_REQUIRED',
+	'NOT_WHITELISTED',
+	'MAX_PER_USER',
+	'MAX_PER_ORDER',
+	'OUT_OF_STOCK'
+] as const;
+export type SaleLockCode = (typeof SALE_LOCK_CODES)[number];
+
+export type SaleLock = {
+	code: SaleLockCode;
+	/** Interpolated into `saleLock.<code>` on the front. */
+	params?: Record<string, string | number>;
+};
+
+/**
+ * Whether a thrown error is a sale lock. Every route that can put a product in a cart uses
+ * this to send the customer to a page that explains the refusal, instead of letting a 400
+ * error page do it in English.
+ */
+export function isSaleLockError(err: unknown): boolean {
+	const code =
+		typeof err === 'object' && err && 'body' in err
+			? (err as { body?: { code?: string } }).body?.code
+			: undefined;
+	return !!code && (SALE_LOCK_CODES as readonly string[]).includes(code);
+}
+
+/**
+ * Fallback wording, for the callers that have no translation at hand — NostR, a raw API
+ * client. Every surface a customer actually reads goes through `saleLock.<code>` instead.
+ */
+export function saleLockMessage(locks: SaleLock[], productName: string): string {
+	return locks.map((lock) => saleLockReason(lock, productName)).join(' ');
+}
+
+function saleLockReason(lock: SaleLock, productName: string): string {
+	switch (lock.code) {
+		case 'LOGIN_REQUIRED':
+			return `You need to be logged in to order: ${productName}`;
+		case 'NOT_WHITELISTED':
+			return `This product is reserved for selected customers: ${productName}`;
+		case 'MAX_PER_USER':
+			return `You have reached the maximum you can order for: ${productName}`;
+		case 'MAX_PER_ORDER':
+			return `You can only order ${lock.params?.max} of this product: ${productName}`;
+		case 'OUT_OF_STOCK':
+			return `Out of stock: ${productName}`;
+		default:
+			lock.code satisfies never;
+			return productName;
+	}
+}
+
+/**
+ * Turns the admin form fields into the stored whitelist, or undefined when the product is
+ * left open to everyone. The two text areas hold one address per line.
+ */
+export function buildProductWhitelist(fields: {
+	hasWhitelist: boolean;
+	whitelistEmails: string;
+	whitelistNpubs: string;
+	whitelistSubscriptionProductIds: string[];
+	whitelistAllowEmployees: boolean;
+	whitelistAllowPosOverride: boolean;
+}): Product['whitelist'] {
+	if (!fields.hasWhitelist) {
+		return undefined;
+	}
+
+	const splitLines = (value: string) =>
+		value
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean);
+
+	return {
+		emails: splitLines(fields.whitelistEmails),
+		npubs: splitLines(fields.whitelistNpubs),
+		subscriptionProductIds: fields.whitelistSubscriptionProductIds.filter(Boolean),
+		allowEmployees: fields.whitelistAllowEmployees,
+		allowPosOverride: fields.whitelistAllowPosOverride
+	};
+}
+
+export type ProductWithSaleLocks = Pick<
+	Product,
+	| '_id'
+	| 'name'
+	| 'type'
+	| 'requiresAuthentication'
+	| 'whitelist'
+	| 'maxQuantityPerUser'
+	| 'subscriptionReminderSeconds'
+	| 'maxQuantityPerOrder'
+	| 'stock'
+	| 'stockReference'
+>;
+
+export type SaleLockContext = {
+	/** How the product is being added. The counter gets exemptions a customer does not. */
+	mode?: 'eshop' | 'nostr' | 'pos';
+	/** Units of each product about to be added, on top of what the cart already holds. */
+	extraQuantityByProductId?: Record<string, number>;
+	/** Units of each product the cart already holds. Counts against the per-order cap. */
+	quantityInCartByProductId?: Record<string, number>;
+	/**
+	 * Units of each product still sellable, this visitor's own reservations excluded — see
+	 * `resolveAvailableAmounts`. Absent means the caller has nothing to say about stock.
+	 */
+	availableByProductId?: Record<string, number>;
+	session?: ClientSession;
+};
+
+/**
+ * An employee, whatever their role. At the counter the session belongs to the seller and not
+ * to the buyer, so rules that describe *the buyer* cannot be read from it.
+ */
+export function isEmployee(user: UserIdentifier | undefined): boolean {
+	return !!user?.userRoleId && user.userRoleId !== CUSTOMER_ROLE_ID;
+}
+
+/**
+ * Whether a stored identity is the same *identified* person — account, contact address, npub
+ * or SSO. The browser session deliberately does not count: see `identifiedUserQuery`.
+ */
+function matchesIdentifiedUser(stored: UserIdentifier, user: UserIdentifier | undefined): boolean {
+	if (!user) {
+		return false;
+	}
+	const addresses = new Set(collectUserAddresses(user).map(normalizeAddress));
+	return !!(
+		(user.userId && stored.userId === user.userId) ||
+		(stored.email && addresses.has(normalizeAddress(stored.email))) ||
+		(stored.npub && addresses.has(normalizeAddress(stored.npub))) ||
+		stored.ssoIds?.some((ssoId) => user.ssoIds?.includes(ssoId))
+	);
+}
+
+function normalizeAddress(address: string): string {
+	return address.trim().toLowerCase();
+}
+
+/**
+ * Whether a whitelist lets a user through. Pure: the caller passes the subscriptions the user
+ * holds, so a page that already loaded them does not query twice.
+ *
+ * The sources are a union — matching a single one is enough. A whitelist that is switched on
+ * with every source empty lets nobody through, which is what an empty guest list means.
+ */
+export function matchesWhitelist(
+	whitelist: NonNullable<Product['whitelist']>,
+	user: UserIdentifier | undefined,
+	activeSubscriptionProductIds: string[]
+): boolean {
+	if (whitelist.allowEmployees && isEmployee(user)) {
+		return true;
+	}
+
+	const listed = new Set(
+		[...whitelist.emails, ...whitelist.npubs].map(normalizeAddress).filter(Boolean)
+	);
+	if (
+		listed.size &&
+		collectUserAddresses(user)
+			.map(normalizeAddress)
+			.some((address) => listed.has(address))
+	) {
+		return true;
+	}
+
+	return whitelist.subscriptionProductIds.some((productId) =>
+		activeSubscriptionProductIds.includes(productId)
+	);
+}
+
+/**
+ * Whether a subscription still occupies its holder's single slot.
+ *
+ * A renewal is an order like any other, so counting orders would close a subscription forever
+ * the day it is first renewed. The criterion is the one `createOrder` already applies: held,
+ * and not yet inside its renewal window.
+ */
+export function subscriptionOccupiesSlot(
+	subscription: Pick<
+		PaidSubscription,
+		'paidUntil' | 'pricingScheduleSnapshot' | 'pricingScheduleCursor' | 'cancelledAt'
+	>,
+	product: { subscriptionReminderSeconds?: number },
+	now = new Date()
+): boolean {
+	return (
+		subSeconds(subscription.paidUntil, currentFundingReminderSeconds(subscription, product)) > now
+	);
+}
+
+/** True when at least one rule could possibly apply — lets callers skip every query. */
+export function hasSaleLocks(product: ProductWithSaleLocks): boolean {
+	return (
+		requiresAuthenticationToOrder(product) ||
+		!!product.whitelist ||
+		maxQuantityPerUser(product) !== undefined
+	);
+}
+
+/**
+ * The verdict for each product, by product id. A product absent from the map may be bought.
+ *
+ * Every query is made once for the whole batch, and only when some product needs it: a cart of
+ * ordinary products costs nothing.
+ */
+export async function evaluateSaleLocks(
+	products: ProductWithSaleLocks[],
+	user: UserIdentifier | undefined,
+	context?: SaleLockContext
+): Promise<Map<string, SaleLock[]>> {
+	const locks = new Map<string, SaleLock[]>();
+	// Every product is evaluated: stock and the per-order cap apply to all of them, and it is
+	// having them answered elsewhere that made the customer's experience depend on which rule
+	// happened to fire first.
+	const locked = products;
+
+	if (!locked.length) {
+		return locks;
+	}
+
+	const session = context?.session;
+	const employee = isEmployee(user);
+
+	// The counter sells to a walk-in customer under the seller's own session, so rules that
+	// read the buyer's identity would read the seller's and are skipped there. Being an
+	// employee is not enough on its own: on the e-shop an employee buys for themselves and is
+	// a customer like any other. The whitelist keeps its own per-product answer to this.
+	const sellerSession = context?.mode === 'pos';
+
+	const needsSubscriptions = locked.some(
+		(product) =>
+			product.whitelist?.subscriptionProductIds.length ||
+			(product.type === 'subscription' && maxQuantityPerUser(product) !== undefined)
+	);
+	const subscriptions =
+		needsSubscriptions && user
+			? await collections.paidSubscriptions
+					.find({ ...userQuery(user), paidUntil: { $gt: new Date() } }, { session })
+					.toArray()
+			: [];
+
+	// Two different questions, two different identities. Whether a subscription already
+	// occupies someone's single slot is a refusal, and the browser session counts for it — that
+	// is how an anonymous buyer is stopped from taking a second one. Whether a subscription
+	// lets someone through a whitelist is a grant, and a session that once served a subscriber
+	// must not carry that right to whoever holds the browser next.
+	const activeSubscriptionProductIds = subscriptions
+		.filter((subscription) => matchesIdentifiedUser(subscription.user, user))
+		.map((subscription) => subscription.productId);
+
+	const cappedIds = locked
+		.filter(
+			(product) => product.type !== 'subscription' && maxQuantityPerUser(product) !== undefined
+		)
+		.map((product) => product._id);
+	const takenByProductId = new Map<string, number>();
+	if (cappedIds.length && user && !sellerSession) {
+		const rows = await collections.orders
+			.aggregate<{ _id: string; total: number }>(
+				[
+					{
+						$match: {
+							...userQuery(user),
+							'items.product._id': { $in: cappedIds },
+							status: { $in: ['pending', 'paid'] }
+						}
+					},
+					{ $unwind: '$items' },
+					{ $match: { 'items.product._id': { $in: cappedIds } } },
+					{ $group: { _id: '$items.product._id', total: { $sum: '$items.quantity' } } }
+				],
+				{ session }
+			)
+			.toArray();
+		for (const row of rows) {
+			takenByProductId.set(row._id, row.total);
+		}
+	}
+
+	// Only reached when a subscription product carries a cap, which is always: a subscription is
+	// one per person by a rule that predates all of this.
+	const subscriptionIds = locked
+		.filter((product) => product.type === 'subscription')
+		.map((product) => product._id);
+	const pendingSubscriptionOrderIds = new Set<string>();
+	if (subscriptionIds.length && user && !sellerSession) {
+		const rows = await collections.orders
+			.aggregate<{ _id: string }>(
+				[
+					{
+						$match: {
+							...userQuery(user),
+							'items.product._id': { $in: subscriptionIds },
+							status: 'pending'
+						}
+					},
+					{ $unwind: '$items' },
+					{ $match: { 'items.product._id': { $in: subscriptionIds } } },
+					{ $group: { _id: '$items.product._id' } }
+				],
+				{ session }
+			)
+			.toArray();
+		for (const row of rows) {
+			pendingSubscriptionOrderIds.add(row._id);
+		}
+	}
+
+	for (const product of locked) {
+		const productLocks = locksFor(product, user, {
+			employee,
+			sellerSession,
+			mode: context?.mode,
+			activeSubscriptionProductIds,
+			subscriptions,
+			takenByProductId,
+			pendingSubscriptionOrderIds,
+			extraQuantity: context?.extraQuantityByProductId?.[product._id] ?? 0,
+			quantityInCart: context?.quantityInCartByProductId?.[product._id] ?? 0,
+			available: context?.availableByProductId?.[product._id]
+		});
+		if (productLocks.length) {
+			locks.set(product._id, productLocks);
+		}
+	}
+
+	return locks;
+}
+
+/**
+ * Every reason this customer may not buy this product, not just the first — a product can
+ * carry all three locks at once and the customer deserves to know all of them.
+ *
+ * One exception: while nobody is identified, the other two rules have nothing to read. Telling
+ * an anonymous visitor they are "not on the list" would be a guess, and possibly a wrong one —
+ * they may well be on it once logged in. So `LOGIN_REQUIRED` stands alone.
+ */
+function locksFor(
+	product: ProductWithSaleLocks,
+	user: UserIdentifier | undefined,
+	ctx: {
+		employee: boolean;
+		sellerSession: boolean;
+		mode?: 'eshop' | 'nostr' | 'pos';
+		activeSubscriptionProductIds: string[];
+		subscriptions: PaidSubscription[];
+		takenByProductId: Map<string, number>;
+		pendingSubscriptionOrderIds: Set<string>;
+		extraQuantity: number;
+		quantityInCart: number;
+		available: number | undefined;
+	}
+): SaleLock[] {
+	if (requiresAuthenticationToOrder(product) && !ctx.employee && !isAuthenticated(user)) {
+		return [{ code: 'LOGIN_REQUIRED' }];
+	}
+
+	const found: SaleLock[] = [];
+
+	if (product.whitelist) {
+		const posOverride = ctx.mode === 'pos' && product.whitelist.allowPosOverride;
+		if (
+			!posOverride &&
+			!matchesWhitelist(product.whitelist, user, ctx.activeSubscriptionProductIds)
+		) {
+			found.push({ code: 'NOT_WHITELISTED' });
+		}
+	}
+
+	// What this person is asking for: what already sits in their cart, plus what they are adding.
+	const wanted = ctx.quantityInCart + ctx.extraQuantity;
+
+	const max = maxQuantityPerUser(product);
+	if (max !== undefined && !ctx.sellerSession) {
+		const taken =
+			product.type === 'subscription'
+				? subscriptionUnitsHeld(product, ctx.subscriptions, ctx.pendingSubscriptionOrderIds)
+				: ctx.takenByProductId.get(product._id) ?? 0;
+
+		// The cart counts. Leaving it out let a cart already sitting on the cap look allowed, and
+		// the page then blamed the stock for a refusal that had nothing to do with it.
+		if (taken + wanted > max) {
+			found.push({ code: 'MAX_PER_USER', params: { max } });
+		}
+	}
+
+	// Rules that predate the sale locks, answered here so there is one list of reasons and one
+	// way of being told, whoever the customer is and whichever rule bites first.
+
+	// Nothing left to reserve is its own answer. Wanting more than is left is not: the cap the
+	// customer runs into is whichever of stock and per-order limit is lower, and it has always
+	// been reported as MAX_PER_ORDER carrying that figure. Kept as it was.
+	if (ctx.available !== undefined && ctx.available <= 0) {
+		found.push({ code: 'OUT_OF_STOCK' });
+		return found;
+	}
+
+	const maxPerOrder = Math.min(
+		product.maxQuantityPerOrder || DEFAULT_MAX_QUANTITY_PER_ORDER,
+		ctx.available ?? Infinity
+	);
+	if (wanted > maxPerOrder) {
+		found.push({ code: 'MAX_PER_ORDER', params: { max: maxPerOrder } });
+	}
+
+	return found;
+}
+
+function subscriptionUnitsHeld(
+	product: ProductWithSaleLocks,
+	subscriptions: PaidSubscription[],
+	pendingSubscriptionOrderIds: Set<string>
+): number {
+	const held = subscriptions.find((subscription) => subscription.productId === product._id);
+	if (held && subscriptionOccupiesSlot(held, product)) {
+		return 1;
+	}
+	return pendingSubscriptionOrderIds.has(product._id) ? 1 : 0;
+}
+
+/**
+ * Flags each product a listing must not offer straight to the cart — CMS product widgets, tag
+ * widgets, search lists. The queries are made once for the whole page, and not at all when no
+ * product on it carries a lock.
+ */
+export async function annotateProductsWithSaleLocks<T extends ProductWithSaleLocks>(
+	products: T[],
+	user: UserIdentifier | undefined
+): Promise<Array<T & { saleLocked: boolean }>> {
+	if (!products.some(hasSaleLocks)) {
+		return products.map((product) => ({ ...product, saleLocked: false }));
+	}
+
+	const locks = await evaluateSaleLocks(products, user);
+	return products.map((product) => ({ ...product, saleLocked: locks.has(product._id) }));
+}
+
+/**
+ * Units of a product this person may still take, or undefined when it is uncapped.
+ *
+ * The quantity picker asks for this: offering a number the cart is bound to refuse turns a
+ * plain limit into a broken button.
+ */
+export async function remainingForUser(
+	product: ProductWithSaleLocks,
+	user: UserIdentifier | undefined,
+	session?: ClientSession
+): Promise<number | undefined> {
+	const max = maxQuantityPerUser(product);
+	if (max === undefined || !user) {
+		return undefined;
+	}
+
+	return Math.max(max - (await quantityTakenByUser(product, user, session)), 0);
+}
+
+/**
+ * Units of a product this person already holds or is in the middle of paying for.
+ *
+ * A subscription is not counted in orders: a renewal is an order, and counting those would
+ * close it for good at the first one. It is held, or it is not — the same criterion order
+ * creation applies.
+ */
+async function quantityTakenByUser(
+	product: ProductWithSaleLocks,
+	user: UserIdentifier,
+	session?: ClientSession
+): Promise<number> {
+	if (product.type === 'subscription') {
+		const [held, pending] = await Promise.all([
+			collections.paidSubscriptions.findOne(
+				{ ...userQuery(user), productId: product._id, paidUntil: { $gt: new Date() } },
+				{ session }
+			),
+			collections.orders.countDocuments(
+				{ ...userQuery(user), 'items.product._id': product._id, status: 'pending' },
+				{ limit: 1, session }
+			)
+		]);
+		if (held && subscriptionOccupiesSlot(held, product)) {
+			return MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION;
+		}
+		return pending ? MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION : 0;
+	}
+
+	const [row] = await collections.orders
+		.aggregate<{ total: number }>(
+			[
+				{
+					$match: {
+						...userQuery(user),
+						'items.product._id': product._id,
+						status: { $in: ['pending', 'paid'] }
+					}
+				},
+				{ $unwind: '$items' },
+				{ $match: { 'items.product._id': product._id } },
+				{ $group: { _id: null, total: { $sum: '$items.quantity' } } }
+			],
+			{ session }
+		)
+		.toArray();
+
+	return row?.total ?? 0;
+}

--- a/src/lib/server/searchlist.ts
+++ b/src/lib/server/searchlist.ts
@@ -193,6 +193,7 @@ export type VatContext = {
 	bebopCountry: CountryAlpha2 | undefined;
 	userCountry: CountryAlpha2 | undefined;
 	vatSingleCountry: boolean;
+	vatExempted: boolean;
 	displayVatIncluded: boolean;
 };
 
@@ -256,7 +257,8 @@ export async function searchProducts(
 					vatProfiles: vat.vatProfiles,
 					bebopCountry: vat.bebopCountry,
 					userCountry: vat.userCountry,
-					vatSingleCountry: vat.vatSingleCountry
+					vatSingleCountry: vat.vatSingleCountry,
+					vatExempted: vat.vatExempted
 				});
 				const branches = vat.vatProfiles.map((vp) => ({
 					case: { $eq: ['$vatProfileId', new ObjectId(vp._id)] },
@@ -267,7 +269,8 @@ export async function searchProducts(
 							vatProfiles: vat.vatProfiles,
 							bebopCountry: vat.bebopCountry,
 							userCountry: vat.userCountry,
-							vatSingleCountry: vat.vatSingleCountry
+							vatSingleCountry: vat.vatSingleCountry,
+							vatExempted: vat.vatExempted
 						}) /
 							100
 				}));

--- a/src/lib/server/subscriptions.ts
+++ b/src/lib/server/subscriptions.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/types/SubscriptionDuration';
 import { collections } from './database';
 import { runtimeConfig } from './runtime-config';
-import { userQuery } from './user';
+import { identifiedUserQuery } from './user';
 
 /** Shared resolver so order renewal and customer display never compute the fallback differently. */
 export function resolveSubscriptionDuration(product: {
@@ -64,7 +64,7 @@ export async function freeProductsForUser(
 	}
 	const existingSubscriptions = await collections.paidSubscriptions
 		.find({
-			...userQuery(user),
+			...identifiedUserQuery(user),
 			$or: products.map((productId) => ({
 				[`freeProductsById.${productId}.available`]: { $gt: 0 }
 			})),

--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -72,6 +72,21 @@ export function userIdentifier(locals: App.Locals): UserIdentifier {
 	};
 }
 
+/**
+ * The same person, minus the browser session.
+ *
+ * `userQuery` matches on the session id too, which is what lets an anonymous visitor keep
+ * their own cart and orders. That is right for recognising someone's belongings, and wrong for
+ * granting them anything: a session that once served a subscriber keeps matching that
+ * subscription after they log out, or after somebody else logs in on the same browser — and
+ * the subscriber discount followed the session instead of the person.
+ *
+ * So: `userQuery` to find what is yours, this one to decide what you are entitled to.
+ */
+export function identifiedUserQuery(user: UserIdentifier) {
+	return userQuery({ ...user, sessionId: undefined });
+}
+
 export function userQuery(user: UserIdentifier) {
 	const emails = [...(user.email ? [user.email] : []), ...(user.secondaryEmails ?? [])];
 	const ret = {

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -116,6 +116,11 @@
 		"vatSellerCountry": "Das Land ist das Land des Verkäufers.",
 		"maxQuantityReached": "Maximale Menge pro Bestellung erreicht ({max})",
 		"error": {
+			"NOT_PWYW": "Dieses Produkt akzeptiert keinen frei wählbaren Preis.",
+			"NOT_PREORDER": "Dieses Produkt ist noch nicht als Vorbestellung verfügbar.",
+			"STANDALONE_QTY_ONE": "Sie können nur ein Exemplar dieses Produkts auf einmal bestellen.",
+			"SUBSCRIPTION_CUSTOM_PRICE": "Ein Abonnement kann nicht zu einem frei wählbaren Preis gekauft werden.",
+			"MAX_PRICE_EXCEEDED": "Der eingegebene Preis liegt über dem Maximum von {max} {currency}.",
 			"BOOKING_SAME_DAY_DISABLED": "Buchungen für heute sind für dieses Produkt nicht verfügbar.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Buchungen für heute sind nach {maxHour} nicht mehr möglich."
 		}
@@ -1197,5 +1202,11 @@
 		"errorLabelRequired": "Jede Zahlungsmethode benötigt eine Bezeichnung.",
 		"removeConfirm": "Diese Methode entfernen?",
 		"cancel": "Abbrechen"
+	},
+	"saleLock": {
+		"LOGIN_REQUIRED": "Sie müssen angemeldet sein, um dieses Produkt zu bestellen.",
+		"NOT_WHITELISTED": "Dieses Produkt ist ausgewählten Kunden vorbehalten.",
+		"MAX_PER_USER": "Sie haben die maximal bestellbare Menge für dieses Produkt erreicht.",
+		"login": "Anmelden"
 	}
 }

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -116,6 +116,11 @@
 		"vatSellerCountry": "The country is the seller's country.",
 		"maxQuantityReached": "Maximum quantity per order reached ({max})",
 		"error": {
+			"NOT_PWYW": "This product does not accept a custom price.",
+			"NOT_PREORDER": "This product is not available for pre-order yet.",
+			"STANDALONE_QTY_ONE": "You can only order one of this product at a time.",
+			"SUBSCRIPTION_CUSTOM_PRICE": "A subscription cannot be bought at a custom price.",
+			"MAX_PRICE_EXCEEDED": "The price you entered is above the maximum of {max} {currency}.",
 			"BOOKING_SAME_DAY_DISABLED": "Bookings for today are not available for this product.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Bookings for today are no longer possible past {maxHour}."
 		}
@@ -1197,5 +1202,11 @@
 		"errorLabelRequired": "Every payment method needs a label.",
 		"removeConfirm": "Remove this method?",
 		"cancel": "Cancel"
+	},
+	"saleLock": {
+		"LOGIN_REQUIRED": "You need to be logged in to order this product.",
+		"NOT_WHITELISTED": "This product is reserved for selected customers.",
+		"MAX_PER_USER": "You have reached the maximum you can order for this product.",
+		"login": "Log in"
 	}
 }

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -116,6 +116,11 @@
 		"vatSellerCountry": "El país es el del vendedor.",
 		"maxQuantityReached": "Cantidad máxima por pedido alcanzada ({max})",
 		"error": {
+			"NOT_PWYW": "Este producto no acepta un precio libre.",
+			"NOT_PREORDER": "Este producto aún no está disponible en preventa.",
+			"STANDALONE_QTY_ONE": "Solo puedes pedir una unidad de este producto a la vez.",
+			"SUBSCRIPTION_CUSTOM_PRICE": "Una suscripción no puede comprarse a precio libre.",
+			"MAX_PRICE_EXCEEDED": "El precio introducido supera el máximo de {max} {currency}.",
 			"BOOKING_SAME_DAY_DISABLED": "Las reservas para hoy no están disponibles para este producto.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Las reservas para hoy ya no son posibles después de las {maxHour}."
 		}
@@ -1197,5 +1202,11 @@
 		"errorLabelRequired": "Cada método de pago necesita una etiqueta.",
 		"removeConfirm": "¿Eliminar este método?",
 		"cancel": "Cancelar"
+	},
+	"saleLock": {
+		"LOGIN_REQUIRED": "Debes iniciar sesión para pedir este producto.",
+		"NOT_WHITELISTED": "Este producto está reservado a determinados clientes.",
+		"MAX_PER_USER": "Has alcanzado el máximo que puedes pedir de este producto.",
+		"login": "Iniciar sesión"
 	}
 }

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -116,6 +116,11 @@
 		"vatSellerCountry": "La TVA est celle du pays du vendeur.",
 		"maxQuantityReached": "Quantité maximale par commande atteinte ({max})",
 		"error": {
+			"NOT_PWYW": "Ce produit n’accepte pas de prix libre.",
+			"NOT_PREORDER": "Ce produit n’est pas encore disponible en précommande.",
+			"STANDALONE_QTY_ONE": "Vous ne pouvez commander qu’un seul exemplaire de ce produit à la fois.",
+			"SUBSCRIPTION_CUSTOM_PRICE": "Un abonnement ne peut pas être acheté à prix libre.",
+			"MAX_PRICE_EXCEEDED": "Le prix saisi dépasse le maximum de {max} {currency}.",
 			"BOOKING_SAME_DAY_DISABLED": "Les réservations pour aujourd'hui ne sont pas disponibles pour ce produit.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Les réservations pour aujourd'hui ne sont plus possibles passé {maxHour}."
 		}
@@ -1197,5 +1202,11 @@
 		"errorLabelRequired": "Chaque moyen de paiement doit avoir un libellé.",
 		"removeConfirm": "Supprimer ce moyen ?",
 		"cancel": "Annuler"
+	},
+	"saleLock": {
+		"LOGIN_REQUIRED": "Vous devez être connecté pour commander ce produit.",
+		"NOT_WHITELISTED": "Ce produit est réservé à certains clients.",
+		"MAX_PER_USER": "Vous avez atteint le maximum commandable pour ce produit.",
+		"login": "Se connecter"
 	}
 }

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -116,6 +116,11 @@
 		"vatSellerCountry": "Il paese è quello del venditore.",
 		"maxQuantityReached": "Quantità massima per ordine raggiunta ({max})",
 		"error": {
+			"NOT_PWYW": "Questo prodotto non accetta un prezzo libero.",
+			"NOT_PREORDER": "Questo prodotto non è ancora disponibile in preordine.",
+			"STANDALONE_QTY_ONE": "Puoi ordinare una sola unità di questo prodotto alla volta.",
+			"SUBSCRIPTION_CUSTOM_PRICE": "Un abbonamento non può essere acquistato a prezzo libero.",
+			"MAX_PRICE_EXCEEDED": "Il prezzo inserito supera il massimo di {max} {currency}.",
 			"BOOKING_SAME_DAY_DISABLED": "Le prenotazioni per oggi non sono disponibili per questo prodotto.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Le prenotazioni per oggi non sono più possibili dopo le {maxHour}."
 		}
@@ -1197,5 +1202,11 @@
 		"errorLabelRequired": "Ogni metodo di pagamento necessita di un'etichetta.",
 		"removeConfirm": "Rimuovere questo metodo?",
 		"cancel": "Annulla"
+	},
+	"saleLock": {
+		"LOGIN_REQUIRED": "Devi accedere per ordinare questo prodotto.",
+		"NOT_WHITELISTED": "Questo prodotto è riservato a determinati clienti.",
+		"MAX_PER_USER": "Hai raggiunto il massimo ordinabile per questo prodotto.",
+		"login": "Accedi"
 	}
 }

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -116,6 +116,11 @@
 		"vatSellerCountry": "Het land is het land van de verkoper.",
 		"maxQuantityReached": "Maximale hoeveelheid per bestelling bereikt ({max})",
 		"error": {
+			"NOT_PWYW": "Dit product accepteert geen vrije prijs.",
+			"NOT_PREORDER": "Dit product is nog niet beschikbaar voor pre-order.",
+			"STANDALONE_QTY_ONE": "U kunt slechts één exemplaar van dit product tegelijk bestellen.",
+			"SUBSCRIPTION_CUSTOM_PRICE": "Een abonnement kan niet tegen een vrije prijs worden gekocht.",
+			"MAX_PRICE_EXCEEDED": "De ingevoerde prijs ligt boven het maximum van {max} {currency}.",
 			"BOOKING_SAME_DAY_DISABLED": "Boekingen voor vandaag zijn niet beschikbaar voor dit product.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "Boekingen voor vandaag zijn niet meer mogelijk na {maxHour}."
 		}
@@ -1197,5 +1202,11 @@
 		"errorLabelRequired": "Elke betaalmethode heeft een label nodig.",
 		"removeConfirm": "Deze methode verwijderen?",
 		"cancel": "Annuleren"
+	},
+	"saleLock": {
+		"LOGIN_REQUIRED": "U moet ingelogd zijn om dit product te bestellen.",
+		"NOT_WHITELISTED": "Dit product is voorbehouden aan bepaalde klanten.",
+		"MAX_PER_USER": "U hebt het maximum bereikt dat u van dit product kunt bestellen.",
+		"login": "Inloggen"
 	}
 }

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -116,6 +116,11 @@
 		"vatSellerCountry": "O país é o país do vendedor.",
 		"maxQuantityReached": "Quantidade máxima por encomenda atingida ({max})",
 		"error": {
+			"NOT_PWYW": "Este produto não aceita um preço livre.",
+			"NOT_PREORDER": "Este produto ainda não está disponível em pré-encomenda.",
+			"STANDALONE_QTY_ONE": "Só pode encomendar uma unidade deste produto de cada vez.",
+			"SUBSCRIPTION_CUSTOM_PRICE": "Uma subscrição não pode ser comprada a preço livre.",
+			"MAX_PRICE_EXCEEDED": "O preço introduzido excede o máximo de {max} {currency}.",
 			"BOOKING_SAME_DAY_DISABLED": "As reservas para hoje não estão disponíveis para este produto.",
 			"BOOKING_SAME_DAY_CUTOFF_PASSED": "As reservas para hoje já não são possíveis após as {maxHour}."
 		}
@@ -1197,5 +1202,11 @@
 		"errorLabelRequired": "Cada método de pagamento precisa de um rótulo.",
 		"removeConfirm": "Remover este método?",
 		"cancel": "Cancelar"
+	},
+	"saleLock": {
+		"LOGIN_REQUIRED": "Tem de iniciar sessão para encomendar este produto.",
+		"NOT_WHITELISTED": "Este produto está reservado a determinados clientes.",
+		"MAX_PER_USER": "Atingiu o máximo que pode encomendar deste produto.",
+		"login": "Iniciar sessão"
 	}
 }

--- a/src/lib/types/Discount.ts
+++ b/src/lib/types/Discount.ts
@@ -14,6 +14,15 @@ export type Discount = Timestamps & {
 	name: string;
 	/** If set, user must have at least one of these active subscriptions */
 	subscriptionIds?: string[];
+	/**
+	 * Accept a `subscriptionIds` subscription sitting in the cart as if it were already active,
+	 * so a customer can subscribe and buy the discounted product in one order (#2718).
+	 *
+	 * Off unless the shop turns it on: a membership discount that already exists means "paid-up
+	 * members only", and flipping that for every shop at once would start applying discounts on
+	 * a membership nobody has paid for yet.
+	 */
+	acceptSubscriptionInCart?: boolean;
 	/** Promo code (case-insensitive match). Percentage mode only */
 	promoCode?: string;
 	/** Sales channels where this discount applies */

--- a/src/lib/types/Product.ts
+++ b/src/lib/types/Product.ts
@@ -51,6 +51,28 @@ export interface Product extends Timestamps, ProductTranslatableFields {
 	};
 	vatProfileId?: ObjectId;
 	maxQuantityPerOrder?: number;
+	/**
+	 * Sale locks — see `$lib/server/saleLock`. Each one, on its own, forbids some customers
+	 * from buying the product; all three are enforced at the same points.
+	 */
+	/** The customer must have an identified session — e-mail, nostr or SSO — to order. */
+	requiresAuthentication?: boolean;
+	/** Only the customers this list lets through may order. Absent means open to everyone. */
+	whitelist?: {
+		emails: string[];
+		npubs: string[];
+		/** Anyone holding an active subscription to one of these products is let through. */
+		subscriptionProductIds: string[];
+		allowEmployees: boolean;
+		/** Lets the counter ring the product up for a customer who is not on the list. */
+		allowPosOverride: boolean;
+	};
+	/**
+	 * How many units the same person may take across their whole history, not per order.
+	 * Unset leaves the product uncapped. Subscriptions ignore the stored value: they are
+	 * capped at one per person by a rule that predates this property.
+	 */
+	maxQuantityPerUser?: number;
 	type: 'subscription' | 'resource' | 'donation';
 	subscriptionDuration?: SubscriptionDuration;
 	subscriptionReminderSeconds?: number;
@@ -180,6 +202,38 @@ export const MAX_SHORT_DESCRIPTION_LIMIT = 160;
 export const MAX_DESCRIPTION_LIMIT = 10000;
 
 export const DEFAULT_MAX_QUANTITY_PER_ORDER = 10;
+
+/**
+ * A subscription has been capped at one per person and per product since long before
+ * `maxQuantityPerUser` existed, by the guard in `createOrder`. The property does not loosen
+ * that rule: on a subscription it is fixed here, shown read-only in the admin form, and any
+ * value stored on the document is ignored.
+ */
+export const MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION = 1;
+
+/**
+ * How many units of a product the same person may take in total, across their whole
+ * history — `undefined` when the product is uncapped.
+ */
+export function maxQuantityPerUser(
+	product: Pick<Product, 'type' | 'maxQuantityPerUser'>
+): number | undefined {
+	if (product.type === 'subscription') {
+		return MAX_QUANTITY_PER_USER_FOR_SUBSCRIPTION;
+	}
+	return product.maxQuantityPerUser;
+}
+
+/**
+ * Filling in a per-person cap only means something once we know who the person is, so it
+ * turns the authentication lock on by itself — in the admin form and again on save, the way
+ * variations force `standalone`.
+ */
+export function requiresAuthenticationToOrder(
+	product: Pick<Product, 'maxQuantityPerUser' | 'requiresAuthentication'>
+): boolean {
+	return !!product.requiresAuthentication || product.maxQuantityPerUser !== undefined;
+}
 export const POS_PRODUCT_PAGINATION = 10;
 export const PRODUCT_PAGINATION_LIMIT = 25;
 

--- a/src/lib/utils/vat.test.ts
+++ b/src/lib/utils/vat.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { computeVatRate } from './vat';
+
+const CH_PROFILE = { _id: 'profile-ch', rates: { CH: 2.6 } } as const;
+
+describe('computeVatRate', () => {
+	it('falls back to the country rate when no profile is set', () => {
+		expect(
+			computeVatRate({
+				productVatProfileId: undefined,
+				vatProfiles: [],
+				bebopCountry: 'CH',
+				userCountry: 'CH',
+				vatSingleCountry: true
+			})
+		).toBeGreaterThan(0);
+	});
+
+	it('prefers the profile rate over the country rate', () => {
+		expect(
+			computeVatRate({
+				productVatProfileId: CH_PROFILE._id,
+				vatProfiles: [CH_PROFILE],
+				bebopCountry: 'CH',
+				userCountry: 'CH',
+				vatSingleCountry: true
+			})
+		).toBe(2.6);
+	});
+
+	// #2649: a shop that turned VAT off was still shown the country rate, and a price entered
+	// VAT-included was divided by a tax it does not charge. The exemption wins over everything,
+	// so any fee routed through here — a product, delivery, whatever comes next — inherits it.
+	describe('when the shop is VAT exempt', () => {
+		it('returns zero instead of the country rate', () => {
+			expect(
+				computeVatRate({
+					productVatProfileId: undefined,
+					vatProfiles: [],
+					bebopCountry: 'CH',
+					userCountry: 'CH',
+					vatSingleCountry: true,
+					vatExempted: true
+				})
+			).toBe(0);
+		});
+
+		it('returns zero even when a custom profile carries a rate', () => {
+			expect(
+				computeVatRate({
+					productVatProfileId: CH_PROFILE._id,
+					vatProfiles: [CH_PROFILE],
+					bebopCountry: 'CH',
+					userCountry: 'CH',
+					vatSingleCountry: true,
+					vatExempted: true
+				})
+			).toBe(0);
+		});
+
+		it('returns zero whatever the customer country', () => {
+			expect(
+				computeVatRate({
+					productVatProfileId: undefined,
+					vatProfiles: [],
+					bebopCountry: 'CH',
+					userCountry: 'FR',
+					vatSingleCountry: false,
+					vatExempted: true
+				})
+			).toBe(0);
+		});
+	});
+});

--- a/src/lib/utils/vat.ts
+++ b/src/lib/utils/vat.ts
@@ -4,6 +4,13 @@ import type { ObjectId } from 'mongodb';
 
 /**
  * Computes the VAT rate for a product considering custom VAT profiles
+ *
+ * Every rate the shop shows or bills goes through here — a product, a delivery fee, and
+ * whatever fee is added next. That is deliberate: the shop-wide exemption is settled once,
+ * at the top of this function, so a new kind of fee inherits it without anyone remembering to
+ * ask. Before that, "Disable VAT for my be-BOP" was honoured when the order was priced but not
+ * when a rate was shown, and a shop entering a VAT-included price had it divided by a tax it
+ * does not charge (#2649).
  */
 export function computeVatRate(params: {
 	productVatProfileId: string | ObjectId | undefined;
@@ -14,7 +21,13 @@ export function computeVatRate(params: {
 	bebopCountry: CountryAlpha2 | undefined;
 	userCountry: CountryAlpha2 | undefined;
 	vatSingleCountry: boolean;
+	/** "Disable VAT for my be-BOP". Nothing is taxed, whatever the country or profile says. */
+	vatExempted?: boolean;
 }): number {
+	if (params.vatExempted) {
+		return 0;
+	}
+
 	const country = params.vatSingleCountry
 		? params.bebopCountry
 		: params.userCountry ?? params.bebopCountry;

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -8,7 +8,7 @@ import { pojo } from '$lib/server/pojo.js';
 import { runtimeConfig } from '$lib/server/runtime-config';
 import { freeProductsForUser, resolveSubscriptionDuration } from '$lib/server/subscriptions';
 import type { DigitalFile } from '$lib/types/DigitalFile';
-import { userQuery } from '$lib/server/user.js';
+import { identifiedUserQuery } from '$lib/server/user.js';
 import { userIdentifier } from '$lib/server/user.js';
 import type { CMSPage } from '$lib/types/CmsPage.js';
 import type { Product } from '$lib/types/Product';
@@ -131,6 +131,10 @@ export async function load(params) {
 							| 'maxQuantityPerOrder'
 							| 'stock'
 							| 'stockReference'
+							| 'requiresAuthentication'
+							| 'whitelist'
+							| 'maxQuantityPerUser'
+							| 'subscriptionReminderSeconds'
 							| 'isTicket'
 							| 'vatProfileId'
 							| 'paymentMethods'
@@ -158,6 +162,10 @@ export async function load(params) {
 						maxQuantityPerOrder: 1,
 						stock: 1,
 						stockReference: 1,
+						requiresAuthentication: 1,
+						whitelist: 1,
+						maxQuantityPerUser: 1,
+						subscriptionReminderSeconds: 1,
 						vatProfileId: 1,
 						paymentMethods: 1,
 						'bookingSpec.slotMinutes': 1,
@@ -186,7 +194,7 @@ export async function load(params) {
 		cart.items.length ? await picturesForProducts(cart.items.map((it) => it.productId)) : [],
 		cart.items.length
 			? collections.paidSubscriptions
-					.find({ ...userQuery(user), paidUntil: { $gt: new Date() } })
+					.find({ ...identifiedUserQuery(user), paidUntil: { $gt: new Date() } })
 					.toArray()
 			: []
 	]);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/delivery/+page.svelte
@@ -18,7 +18,8 @@
 		vatProfiles: data.vatProfiles,
 		bebopCountry: data.vatCountry,
 		userCountry: data.vatCountry,
-		vatSingleCountry: true
+		vatSingleCountry: true,
+		vatExempted: data.vatExempted
 	});
 </script>
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.server.ts
@@ -70,6 +70,7 @@ export const actions = {
 		const base = z.object({
 			name: z.string().min(1).max(MAX_NAME_LIMIT),
 			subscriptionIds: z.string().array(), // was .min(1), now optional
+			acceptSubscriptionInCart: z.boolean({ coerce: true }).default(false),
 			productIds: z.string().array(),
 			wholeCatalog: z.boolean({ coerce: true }).default(false),
 			beginsAt: z.date({ coerce: true }),
@@ -92,6 +93,7 @@ export const actions = {
 			subscriptionIds: JSON.parse(String(formData.get('subscriptionIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),
+			acceptSubscriptionInCart: formData.get('acceptSubscriptionInCart'),
 			productIds: JSON.parse(String(formData.get('productIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/[id]/+page.svelte
@@ -17,6 +17,10 @@
 	let endsAtElement: HTMLInputElement;
 	let availableProductList = data.products;
 	let subscriptions = data.subscriptions;
+	// Required combinations gate the discount, they are not what gets discounted — so a
+	// subscription belongs here even though it can never be the discounted product itself.
+	// That is what lets a customer subscribe and buy in the same order (#2718).
+	$: combinationProductList = [...availableProductList, ...subscriptions];
 	let wholeCatalog = data.discount.wholeCatalog;
 	let mode = data.discount.mode;
 	let productFree: string[] = [];
@@ -181,6 +185,20 @@
 		/>
 	</label>
 
+	<label class="form-label flex flex-row items-center gap-2">
+		<input
+			class="form-checkbox"
+			type="checkbox"
+			name="acceptSubscriptionInCart"
+			checked={data.discount.acceptSubscriptionInCart}
+		/>
+		Accept the subscription when it is in the cart, not only when it is already active
+	</label>
+	<p class="text-sm text-gray-600 -mt-2">
+		Lets a new customer subscribe and buy the discounted product in the same order, instead of
+		ordering the subscription, coming back logged in, and ordering again.
+	</p>
+
 	{#if mode === 'percentage'}
 		<label class="form-label">
 			Required code (optional)
@@ -262,7 +280,7 @@
 							{product}
 							{comboIdx}
 							{prodIdx}
-							{availableProductList}
+							availableProductList={combinationProductList}
 							on:change={() => (combinations = combinations)}
 							on:remove={() => {
 								combo.products = combo.products.filter((_, idx) => idx !== prodIdx);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.server.ts
@@ -52,6 +52,7 @@ export const actions: Actions = {
 		const base = z.object({
 			name: z.string().min(1).max(MAX_NAME_LIMIT),
 			subscriptionIds: z.string().array(), // was .min(1), now optional
+			acceptSubscriptionInCart: z.boolean({ coerce: true }).default(false),
 			productIds: z.string().array(),
 			wholeCatalog: z.boolean({ coerce: true }).default(false),
 			beginsAt: z.date({ coerce: true }),
@@ -75,6 +76,7 @@ export const actions: Actions = {
 			subscriptionIds: JSON.parse(String(formData.get('subscriptionIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),
+			acceptSubscriptionInCart: formData.get('acceptSubscriptionInCart'),
 			productIds: JSON.parse(String(formData.get('productIds') ?? '[]')).map(
 				(x: { value: string }) => x.value
 			),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/discount/new/+page.svelte
@@ -17,6 +17,10 @@
 	let endsAtElement: HTMLInputElement;
 	let availableProductList = data.products;
 	let subscriptions = data.subscriptions;
+	// Required combinations gate the discount, they are not what gets discounted — so a
+	// subscription belongs here even though it can never be the discounted product itself.
+	// That is what lets a customer subscribe and buy in the same order (#2718).
+	$: combinationProductList = [...availableProductList, ...subscriptions];
 	let wholeCatalog = false;
 	let mode = 'percentage';
 	let productFreeLine = 2;
@@ -133,6 +137,15 @@
 		/>
 	</label>
 
+	<label class="form-label flex flex-row items-center gap-2">
+		<input class="form-checkbox" type="checkbox" name="acceptSubscriptionInCart" />
+		Accept the subscription when it is in the cart, not only when it is already active
+	</label>
+	<p class="text-sm text-gray-600 -mt-2">
+		Lets a new customer subscribe and buy the discounted product in the same order, instead of
+		ordering the subscription, coming back logged in, and ordering again.
+	</p>
+
 	{#if mode === 'percentage'}
 		<label class="form-label">
 			Required code (optional)
@@ -202,7 +215,7 @@
 							{product}
 							{comboIdx}
 							{prodIdx}
-							{availableProductList}
+							availableProductList={combinationProductList}
 							on:change={() => (combinations = combinations)}
 							on:remove={() => {
 								combo.products = combo.products.filter((_, idx) => idx !== prodIdx);

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.server.ts
@@ -1,4 +1,6 @@
 import { collections } from '$lib/server/database';
+import { buildProductWhitelist } from '$lib/server/saleLock';
+import { requiresAuthenticationToOrder } from '$lib/types/Product';
 import { error, redirect } from '@sveltejs/kit';
 import type { Actions } from './$types';
 import { z } from 'zod';
@@ -31,6 +33,12 @@ import type { Picture } from '$lib/types/Picture';
 import { logAccountingEvent, employeeFromLocals } from '$lib/server/accounting-log';
 
 export const load = async ({ params }) => {
+	const subscriptionProducts = await collections.products
+		.find({ type: 'subscription' })
+		.project<{ _id: string; name: string }>({ _id: 1, name: 1 })
+		.sort({ name: 1 })
+		.toArray();
+
 	const pictures = await collections.pictures
 		.find({ productId: params.id })
 		.sort({ order: 1, createdAt: 1 })
@@ -81,6 +89,7 @@ export const load = async ({ params }) => {
 		digitalFiles,
 		tags,
 		productsWithStock,
+		subscriptionProducts,
 		reserved,
 		sold,
 		scanned,
@@ -98,6 +107,10 @@ export const actions: Actions = {
 			set(json, key, value);
 		}
 		json.paymentMethods = formData.getAll('paymentMethods')?.map(String);
+		// MultiSelect posts a JSON array of {value,label}, like the product tag picker.
+		json.whitelistSubscriptionProductIds = JSON.parse(
+			String(formData.get('whitelistSubscriptionProductIds') || '[]')
+		).map((x: { value: string }) => x.value);
 
 		const product = await collections.products.findOne({ _id: params.id });
 
@@ -198,6 +211,11 @@ export const actions: Actions = {
 					$set: {
 						name: parsed.name,
 						isTicket: parsed.isTicket,
+						// Sale locks. A per-person cap only means something once we know who the person is, so
+						// filling it in turns the authentication lock on, the way variations force `standalone`.
+						requiresAuthentication: requiresAuthenticationToOrder(parsed),
+						...(parsed.maxQuantityPerUser && { maxQuantityPerUser: parsed.maxQuantityPerUser }),
+						...(buildProductWhitelist(parsed) && { whitelist: buildProductWhitelist(parsed) }),
 						alias: parsed.alias ? [params.id, parsed.alias] : [params.id],
 						description: parsed.description,
 						shortDescription: parsed.shortDescription,
@@ -315,6 +333,10 @@ export const actions: Actions = {
 						...(parsed.stock === undefined && { stock: '' }),
 						...(!parsed.stockReferenceProductId && { stockReference: '' }),
 						...(!parsed.maxQuantityPerOrder && { maxQuantityPerOrder: '' }),
+						// Sale locks. Emptying a field has to remove it, not leave the old value in
+						// place: without these the cap and the whitelist could be set but never cleared.
+						...(!parsed.maxQuantityPerUser && { maxQuantityPerUser: '' }),
+						...(!buildProductWhitelist(parsed) && { whitelist: '' }),
 						...(!parsed.depositPercentage && { deposit: '' }),
 						...(!parsed.vatProfileId && { vatProfileId: '' }),
 						...(!parsed.subscriptionDuration && { subscriptionDuration: '' }),

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/[id]/+page.svelte
@@ -37,6 +37,7 @@
 	globalDeliveryFees={data.deliveryFees}
 	product={data.product}
 	tags={data.tags}
+	subscriptionProducts={data.subscriptionProducts ?? []}
 	productsWithStock={data.productsWithStock}
 	adminPrefix={data.adminPrefix}
 	reserved={data.reserved}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.server.ts
@@ -1,4 +1,6 @@
 import { collections, withTransaction } from '$lib/server/database';
+import { buildProductWhitelist } from '$lib/server/saleLock';
+import { requiresAuthenticationToOrder } from '$lib/types/Product';
 import { generatePicture } from '$lib/server/picture';
 import {
 	getProductsWithStock,
@@ -35,6 +37,12 @@ import { defaultSchedule, productToScheduleId } from '$lib/types/Schedule';
 import { logProductCreationEvents } from '$lib/server/accounting-log';
 
 export const load = async ({ url }) => {
+	const subscriptionProducts = await collections.products
+		.find({ type: 'subscription' })
+		.project<{ _id: string; name: string }>({ _id: 1, name: 1 })
+		.sort({ name: 1 })
+		.toArray();
+
 	const productId = url.searchParams.get('duplicate_from');
 	const tags = await collections.tags
 		.find({})
@@ -62,13 +70,15 @@ export const load = async ({ url }) => {
 				digitalFiles,
 				tags,
 				productsWithStock,
+				subscriptionProducts,
 				currency: runtimeConfig.priceReferenceCurrency
 			};
 		}
 	}
 	return {
 		tags,
-		productsWithStock
+		productsWithStock,
+		subscriptionProducts
 	};
 };
 
@@ -81,6 +91,10 @@ export const actions: Actions = {
 			set(json, key, value);
 		}
 		json.paymentMethods = formData.getAll('paymentMethods')?.map(String);
+		// MultiSelect posts a JSON array of {value,label}, like the product tag picker.
+		json.whitelistSubscriptionProductIds = JSON.parse(
+			String(formData.get('whitelistSubscriptionProductIds') || '[]')
+		).map((x: { value: string }) => x.value);
 
 		const parsed = z
 			.object({
@@ -174,6 +188,11 @@ export const actions: Actions = {
 							shortDescription: parsed.shortDescription.replaceAll('\r', ''),
 							name: parsed.name,
 							isTicket: parsed.isTicket,
+							// Sale locks. A per-person cap only means something once we know who the person is, so
+							// filling it in turns the authentication lock on, the way variations force `standalone`.
+							requiresAuthentication: requiresAuthenticationToOrder(parsed),
+							...(parsed.maxQuantityPerUser && { maxQuantityPerUser: parsed.maxQuantityPerUser }),
+							...(buildProductWhitelist(parsed) && { whitelist: buildProductWhitelist(parsed) }),
 							price: computePriceForStorage(priceAmount, parsed.priceCurrency),
 							hideDiscountExpiration: parsed.hideDiscountExpiration,
 							type: parsed.type,
@@ -332,6 +351,10 @@ export const actions: Actions = {
 			set(json, key, value);
 		}
 		json.paymentMethods = formData.getAll('paymentMethods')?.map(String);
+		// MultiSelect posts a JSON array of {value,label}, like the product tag picker.
+		json.whitelistSubscriptionProductIds = JSON.parse(
+			String(formData.get('whitelistSubscriptionProductIds') || '[]')
+		).map((x: { value: string }) => x.value);
 
 		const { duplicateFromId } = z
 			.object({ duplicateFromId: z.string() })
@@ -398,6 +421,11 @@ export const actions: Actions = {
 					shortDescription: parsed.shortDescription.replaceAll('\r', ''),
 					name: parsed.name,
 					isTicket: parsed.isTicket,
+					// Sale locks. A per-person cap only means something once we know who the person is, so
+					// filling it in turns the authentication lock on, the way variations force `standalone`.
+					requiresAuthentication: requiresAuthenticationToOrder(parsed),
+					...(parsed.maxQuantityPerUser && { maxQuantityPerUser: parsed.maxQuantityPerUser }),
+					...(buildProductWhitelist(parsed) && { whitelist: buildProductWhitelist(parsed) }),
 					price: computePriceForStorage(parseFloat(parsed.priceAmount), parsed.priceCurrency),
 					type: product.type,
 					availableDate: parsed.availableDate || undefined,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/new/+page.svelte
@@ -18,6 +18,7 @@
 	isNew
 	duplicateFromId={data.product?._id}
 	tags={data.tags}
+	subscriptionProducts={data.subscriptionProducts ?? []}
 	productsWithStock={data.productsWithStock}
 	product={data.product ?? undefined}
 	defaultActionSettings={data.productActionSettings}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/product/product-schema.ts
@@ -164,6 +164,20 @@ export const productBaseSchema = () => ({
 		.transform((val) => val || undefined)
 		.optional(),
 	maxQuantityPerOrder: z.number({ coerce: true }).int().min(1).optional(),
+	// Sale locks — see `$lib/server/saleLock`.
+	maxQuantityPerUser: z
+		.string()
+		.trim()
+		.transform((val) => (val ? Number(val) : undefined))
+		.pipe(z.number().int().min(1).optional())
+		.optional(),
+	requiresAuthentication: z.boolean({ coerce: true }).default(false),
+	hasWhitelist: z.boolean({ coerce: true }).default(false),
+	whitelistEmails: z.string().default(''),
+	whitelistNpubs: z.string().default(''),
+	whitelistSubscriptionProductIds: z.string().array().default([]),
+	whitelistAllowEmployees: z.boolean({ coerce: true }).default(false),
+	whitelistAllowPosOverride: z.boolean({ coerce: true }).default(false),
 	eshopVisible: z.boolean({ coerce: true }).default(false),
 	retailVisible: z.boolean({ coerce: true }).default(false),
 	nostrVisible: z.boolean({ coerce: true }).default(false),

--- a/src/routes/(app)/cart/+page.server.ts
+++ b/src/routes/(app)/cart/+page.server.ts
@@ -9,6 +9,8 @@ import { cmsFromContent } from '$lib/server/cms';
 import { collections, withTransaction } from '$lib/server/database';
 import { findActivePromoDiscount, hasAnyActivePromoDiscount } from '$lib/server/discount';
 import { picturesForProducts } from '$lib/server/picture';
+import { evaluateSaleLocks, SALE_LOCK_CODES } from '$lib/server/saleLock';
+import { cartErrorKey } from '$lib/cartErrorKey';
 import { applyResolvedStock, refreshAvailableStockInDb } from '$lib/server/product.js';
 import { rateLimit } from '$lib/server/rateLimit';
 import { runtimeConfig } from '$lib/server/runtime-config.js';
@@ -73,27 +75,15 @@ function isEmployeeFromLocals(locals: App.Locals): boolean {
 }
 
 function mapAddError(slug: string, body: AddErrorBody, product: ProductBadge | null): AddError {
-	switch (body.code) {
-		case 'NOT_FOR_SALE':
-			return { slug, key: 'product.notForSale', product };
-		case 'OUT_OF_STOCK':
-			return { slug, key: 'product.outOfStock', product };
-		case 'MAX_ITEMS_REACHED':
-			return { slug, key: 'cart.reachedMaxPerLine', product };
-		case 'VARIATION_INVALID':
-			return { slug, key: 'cartFromUrl.errors.reasonVariationRequired', product };
-		case 'BOOKING_INFO_REQUIRED':
-			return { slug, key: 'cartFromUrl.errors.reasonBookingRequired', product };
-		case 'MAX_PER_ORDER':
-			return {
-				slug,
-				key: 'cart.maxQuantityReached',
-				...(body.params && { params: body.params }),
-				product
-			};
-		default:
-			return { slug, key: 'cartFromUrl.errors.reasonGeneric', product };
+	if (!body.code) {
+		return { slug, key: 'cartFromUrl.errors.reasonGeneric', product };
 	}
+	return {
+		slug,
+		key: cartErrorKey(body.code),
+		...(body.params && { params: body.params }),
+		product
+	};
 }
 
 async function resolveProductsBySlug(
@@ -254,20 +244,47 @@ export async function load({ parent, locals, url }) {
 		}))
 	);
 
+	const saleLocks = [
+		...(
+			await evaluateSaleLocks(
+				parentData.cart.items.map((item) => item.product),
+				userIdentifier(locals),
+				{
+					mode: locals.user?.hasPosOptions ? 'pos' : 'eshop',
+					extraQuantityByProductId: parentData.cart.items.reduce<Record<string, number>>(
+						(acc, item) => ({
+							...acc,
+							[item.product._id]: (acc[item.product._id] ?? 0) + item.quantity
+						}),
+						{}
+					)
+				}
+			)
+		).entries()
+	].map(([productId, productLocks]) => ({
+		locks: productLocks,
+		name:
+			parentData.cart.items.find((item) => item.product._id === productId)?.product.name ??
+			productId
+	}));
+
+	let errorMessage: string | undefined;
+
 	if (parentData.cart) {
 		try {
 			await checkCartItems(cartItemsWithResolvedStock, { user: userIdentifier(locals) });
 		} catch (err) {
-			if (
-				typeof err === 'object' &&
-				err &&
-				'body' in err &&
-				typeof err.body === 'object' &&
-				err.body &&
-				'message' in err.body &&
-				typeof err.body.message === 'string'
-			) {
-				return { errorMessage: err.body.message };
+			const body =
+				typeof err === 'object' && err && 'body' in err
+					? (err as { body?: AddErrorBody }).body
+					: undefined;
+			// Only a sale lock is dropped here, because the banner already carries it and in a
+			// better form. Everything else — stock, per-order cap, cart size — is shown
+			// alongside: several rules can block the same checkout, and the customer needs to
+			// read all of them, not the first one we happened to raise.
+			const isSaleLock = !!body?.code && (SALE_LOCK_CODES as readonly string[]).includes(body.code);
+			if (!isSaleLock && typeof body?.message === 'string') {
+				errorMessage = body.message;
 			}
 		}
 	}
@@ -365,6 +382,8 @@ export async function load({ parent, locals, url }) {
 			items: cartItemsWithResolvedStock
 		},
 		hasPromoDiscounts,
+		saleLocks,
+		...(errorMessage && { errorMessage }),
 		appliedPromoCode: cartInDb?.promoCode,
 		allowCartFromUrl: runtimeConfig.allowCartFromUrl,
 		...(cartFromUrl && { cartFromUrl }),

--- a/src/routes/(app)/cart/+page.svelte
+++ b/src/routes/(app)/cart/+page.svelte
@@ -12,6 +12,7 @@
 	import IconInfo from '$lib/components/icons/IconInfo.svelte';
 	import IconTrash from '$lib/components/icons/IconTrash.svelte';
 	import { useI18n } from '$lib/i18n';
+	import { cartErrorKey } from '$lib/cartErrorKey';
 	import { computeDeliveryFees } from '$lib/cart';
 	import { isAlpha2CountryCode } from '$lib/types/Country.js';
 	import { UNDERLYING_CURRENCY } from '$lib/types/Currency.js';
@@ -161,6 +162,25 @@
 					</label>
 				</div>
 			</form>
+		{/if}
+		{#if data.saleLocks?.length}
+			<div class="border border-red-500 rounded p-4 flex flex-col gap-2">
+				{#each data.saleLocks as { locks, name }}
+					{#each locks as lock}
+						<p class="text-red-500">
+							{name} — {t(cartErrorKey(lock.code), lock.params ?? {})}
+						</p>
+					{/each}
+				{/each}
+				{#if data.saleLocks.some( ({ locks }) => locks.some((lock) => lock.code === 'LOGIN_REQUIRED') )}
+					<a
+						href="/login"
+						target="_blank"
+						rel="noopener"
+						class="btn body-cta body-mainCTA self-start">{t('saleLock.login')}</a
+					>
+				{/if}
+			</div>
 		{/if}
 		{#if errorMessage && !errorProductId}
 			<p class="text-red-500">{errorMessage}</p>
@@ -588,7 +608,7 @@
 			<form action="/checkout" class="flex justify-end">
 				<button
 					class="btn body-cta body-mainCTA"
-					disabled={!physicalCartCanBeOrdered}
+					disabled={!physicalCartCanBeOrdered || !!data.saleLocks?.length}
 					type="submit"
 				>
 					{t('cart.cta.checkout')}

--- a/src/routes/(app)/cart/[id]/+page.server.ts
+++ b/src/routes/(app)/cart/[id]/+page.server.ts
@@ -1,4 +1,5 @@
 import { addToCartInDb, findItemInCart, getCartFromDb, removeFromCartInDb } from '$lib/server/cart';
+import { isSaleLockError } from '$lib/server/saleLock';
 import { collections, withTransaction } from '$lib/server/database';
 import { loadProductWithResolvedStock, refreshAvailableStockInDb } from '$lib/server/product.js';
 import { userIdentifier, userQuery } from '$lib/server/user.js';
@@ -69,13 +70,20 @@ export const actions = {
 			})
 			.parse(Object.fromEntries(formData));
 
-		await addToCartInDb(product, quantity + 1, {
-			user: userIdentifier(locals),
-			mode: 'eshop',
-			totalQuantity: true,
-			deposit,
-			lineId
-		});
+		try {
+			await addToCartInDb(product, quantity + 1, {
+				user: userIdentifier(locals),
+				mode: 'eshop',
+				totalQuantity: true,
+				deposit,
+				lineId
+			});
+		} catch (err) {
+			// A sale lock is not an error page: the cart says why, in the customer's language.
+			if (!isSaleLockError(err)) {
+				throw err;
+			}
+		}
 
 		throw redirect(303, request.headers.get('referer') || '/cart');
 	},
@@ -154,13 +162,19 @@ export const actions = {
 				cart
 			});
 		} else {
-			await addToCartInDb(product, quantity, {
-				user: userIdentifier(locals),
-				mode,
-				lineId,
-				totalQuantity: true,
-				cart
-			});
+			try {
+				await addToCartInDb(product, quantity, {
+					user: userIdentifier(locals),
+					mode,
+					lineId,
+					totalQuantity: true,
+					cart
+				});
+			} catch (err) {
+				if (!isSaleLockError(err)) {
+					throw err;
+				}
+			}
 		}
 
 		throw redirect(303, request.headers.get('referer') || '/cart');

--- a/src/routes/(app)/checkout/+page.server.ts
+++ b/src/routes/(app)/checkout/+page.server.ts
@@ -10,9 +10,14 @@ import {
 } from '$lib/server/orders';
 import { isEmailConfigured } from '$lib/server/email';
 import { runtimeConfig } from '$lib/server/runtime-config';
-import { checkCartItems, getCartFromDb } from '$lib/server/cart.js';
+import {
+	CART_ERROR_CODES,
+	checkCartItems,
+	getCartFromDb,
+	type CartErrorCode
+} from '$lib/server/cart.js';
 import { applyResolvedStock } from '$lib/server/product.js';
-import { userIdentifier, userQuery } from '$lib/server/user.js';
+import { identifiedUserQuery, userIdentifier, userQuery } from '$lib/server/user.js';
 import { CUSTOMER_ROLE_ID } from '$lib/types/User.js';
 import {
 	collectUserAddresses,
@@ -118,7 +123,7 @@ export async function load({ parent, locals }) {
 	// Precompute auto discount per payment method so the frontend can switch live
 	const activeDiscounts = await getActivePercentageDiscounts();
 	const paidSubs = await collections.paidSubscriptions
-		.find({ ...userQuery(userIdentifier(locals)), paidUntil: { $gt: new Date() } })
+		.find({ ...identifiedUserQuery(userIdentifier(locals)), paidUntil: { $gt: new Date() } })
 		.toArray();
 	const user = userIdentifier(locals);
 	const discountItemsForEval = cartItemsWithResolvedStock.map((i) => ({
@@ -670,6 +675,16 @@ export const actions = {
 				);
 			});
 		} catch (err) {
+			// A typed cart error means the cart itself is no longer orderable. The cart page says
+			// why, in the customer's own language, and keeps their cart intact; a raw 400 page
+			// says nothing and loses them.
+			const cartErrorBody =
+				typeof err === 'object' && err && 'body' in err
+					? (err as { body?: { code?: string } }).body
+					: undefined;
+			if (cartErrorBody?.code && CART_ERROR_CODES.includes(cartErrorBody.code as CartErrorCode)) {
+				throw redirect(303, '/cart');
+			}
 			if (err instanceof PaymentGenerationError) {
 				console.error('PaymentGenerationError on /checkout:', err.method, err.reason);
 				await notifySuperAdminPaymentFailure({

--- a/src/routes/(app)/checkout/+page.svelte
+++ b/src/routes/(app)/checkout/+page.svelte
@@ -157,7 +157,8 @@
 		vatProfiles: data.vatProfiles,
 		bebopCountry: data.vatCountry,
 		userCountry: isDigital ? digitalCountry : country,
-		vatSingleCountry: data.vatSingleCountry
+		vatSingleCountry: data.vatSingleCountry,
+		vatExempted: data.vatExempted
 	});
 	$: deliveryFeesToDisplay = data.deliveryFees.vatIncludedReference
 		? extractVat(deliveryFeesToBill, deliveryFeesVatRate)

--- a/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
+++ b/src/routes/(app)/pos/touch/tab/[orderTabSlug]/+page.svelte
@@ -103,7 +103,8 @@
 			vatProfiles: data.vatProfiles,
 			bebopCountry: data.vatCountry,
 			userCountry: data.countryCode,
-			vatSingleCountry: data.vatSingleCountry
+			vatSingleCountry: data.vatSingleCountry,
+			vatExempted: data.vatExempted
 		});
 		return toCurrency(
 			data.currencies.main,

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -262,7 +262,8 @@ export const load = async ({ params, parent, locals }) => {
 		vatProfiles: parentData.vatProfiles,
 		bebopCountry: runtimeConfig.vatCountry,
 		userCountry: locals.countryCode,
-		vatSingleCountry: runtimeConfig.vatSingleCountry
+		vatSingleCountry: runtimeConfig.vatSingleCountry,
+		vatExempted: runtimeConfig.vatExempted
 	});
 
 	return {
@@ -373,7 +374,8 @@ async function addToCart({ params, request, locals }: RequestEvent) {
 			vatProfiles,
 			bebopCountry: runtimeConfig.vatCountry,
 			userCountry: locals.countryCode,
-			vatSingleCountry: runtimeConfig.vatSingleCountry
+			vatSingleCountry: runtimeConfig.vatSingleCountry,
+			vatExempted: runtimeConfig.vatExempted
 		});
 
 		// Extract VAT: entered price is WITH VAT, we need to store WITHOUT VAT

--- a/src/routes/(app)/product/[id]/+page.server.ts
+++ b/src/routes/(app)/product/[id]/+page.server.ts
@@ -1,11 +1,16 @@
 import { addToCartInDb } from '$lib/server/cart';
 import { cmsFromContent } from '$lib/server/cms';
 import { collections } from '$lib/server/database';
-import { applyResolvedStock, resolveStockProduct } from '$lib/server/product';
+import {
+	applyResolvedStock,
+	resolveAvailableAmounts,
+	resolveStockProduct
+} from '$lib/server/product';
 import { resolveSubscriptionDuration } from '$lib/server/subscriptions';
 import { runtimeConfig } from '$lib/server/runtime-config';
+import { evaluateSaleLocks, isSaleLockError, remainingForUser } from '$lib/server/saleLock';
 import { adminPrefix as getAdminPrefix } from '$lib/server/admin';
-import { userIdentifier, userQuery } from '$lib/server/user';
+import { identifiedUserQuery, userIdentifier } from '$lib/server/user';
 import { CURRENCIES, parsePriceAmount } from '$lib/types/Currency';
 import { DEFAULT_MAX_QUANTITY_PER_ORDER, type Product } from '$lib/types/Product';
 import { computeVatRate, extractVat } from '$lib/utils/vat';
@@ -14,7 +19,7 @@ import { set } from '$lib/utils/set';
 import { sum } from '$lib/utils/sum';
 import type { UserIdentifier } from '$lib/types/UserIdentifier';
 import type { RequestEvent } from './$types';
-import { error, redirect } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import { subDays, parseISO, isValid } from 'date-fns';
 import type { JsonObject } from 'type-fest';
 import { z } from 'zod';
@@ -115,6 +120,10 @@ async function fetchProduct(
 	| 'bookingSpec'
 	| 'vatProfileId'
 	| 'stockReference'
+	| 'requiresAuthentication'
+	| 'whitelist'
+	| 'maxQuantityPerUser'
+	| 'subscriptionReminderSeconds'
 	| 'tagIds'
 	| 'subscriptionDuration'
 	| 'pricingSchedule'
@@ -170,6 +179,10 @@ async function fetchProduct(
 				bookingSpec: 1,
 				vatProfileId: 1,
 				stockReference: 1,
+				requiresAuthentication: 1,
+				whitelist: 1,
+				maxQuantityPerUser: 1,
+				subscriptionReminderSeconds: 1,
 				tagIds: 1,
 				subscriptionDuration: 1,
 				pricingSchedule: 1,
@@ -186,7 +199,7 @@ async function fetchProductPictures(productId: string) {
 async function fetchUserSubscriptions(userIdentifier: UserIdentifier) {
 	return collections.paidSubscriptions
 		.find({
-			...userQuery(userIdentifier),
+			...identifiedUserQuery(userIdentifier),
 			paidUntil: { $gt: new Date() }
 		})
 		.toArray();
@@ -291,6 +304,32 @@ export const load = async ({ params, parent, locals }) => {
 		...(product.contentAfter && {
 			productCMSAfter: cmsFromContent({ desktopContent: product.contentAfter }, locals)
 		}),
+		// Same verdict the cart and the order will give, asked before the click so the CTA can
+		// go flat instead of failing after it.
+		// Asked as "may they take one more?", which is the question the CTA answers. Without the
+		// extra unit a customer sitting exactly on their cap reads nothing, and only finds out by
+		// clicking — what the cart already holds counts towards it too.
+		// Asked as "may they take one more?", which is the question the CTA answers. Every
+		// reason comes back the same way — login, whitelist, per-person cap, per-order cap,
+		// stock — so the page states them all before the click instead of letting whichever
+		// one happens to fire first surface after it.
+		saleLocks:
+			(
+				await evaluateSaleLocks([product], userIdentifier(locals), {
+					extraQuantityByProductId: { [productId]: 1 },
+					quantityInCartByProductId: {
+						[productId]: sum(
+							parentData.cart.items
+								.filter((item) => item.product._id === productId)
+								.map((item) => item.quantity)
+						)
+					},
+					availableByProductId: await resolveAvailableAmounts([product], userIdentifier(locals))
+				})
+			).get(product._id) ?? [],
+		// How many more units this person may take, so the quantity picker cannot offer a number
+		// the cart will refuse. Undefined on an uncapped product.
+		maxPerUserRemaining: await remainingForUser(product, userIdentifier(locals)),
 		showCheckoutButton: runtimeConfig.checkoutButtonOnProductPage,
 		priceHistoryEnabled: runtimeConfig.priceHistoryEnabled,
 		websiteShortDescription: product.shortDescription,
@@ -399,15 +438,49 @@ async function addToCart({ params, request, locals }: RequestEvent) {
 	});
 }
 
+/**
+ * A sale lock is not an error page. Send the customer back to the product page, which
+ * recomputes the same verdict on load and states it there, with the CTA already greyed out —
+ * the way they would have seen it had they landed on the page a moment later. Everything
+ * else keeps bubbling up as it did.
+ */
+/**
+ * A refusal is answered, not redirected.
+ *
+ * Redirecting looked tidy and was a lie: under `use:enhance` a redirect is not an error, so the
+ * page took its success path and announced a product it had not added. `fail` gives the form a
+ * typed failure it can state, and leaves the no-JS path on the product page rather than on a
+ * bare 400.
+ */
+async function addToCartOrExplain(params: RequestEvent) {
+	try {
+		await addToCart(params);
+		return null;
+	} catch (err) {
+		if (!isSaleLockError(err)) {
+			throw err;
+		}
+		const body = (err as { body?: { code?: string; params?: Record<string, string | number> } })
+			.body;
+		return fail(400, { saleLock: { code: body?.code, params: body?.params ?? {} } });
+	}
+}
+
 export const actions = {
 	buy: async (params) => {
-		await addToCart(params);
+		const refused = await addToCartOrExplain(params);
+		if (refused) {
+			return refused;
+		}
 
 		throw redirect(303, '/checkout');
 	},
 
 	addToCart: async (params) => {
-		await addToCart(params);
+		const refused = await addToCartOrExplain(params);
+		if (refused) {
+			return refused;
+		}
 
 		throw redirect(303, params.request.headers.get('referer') || '/cart');
 	}

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -649,23 +649,30 @@
 								{vatRate}%)
 								<span class="text-gray-400 text-xs ml-1">{showExclTax ? '▲' : '▼'}</span></span
 							>
-							<div class="flex items-center gap-2">
-								<PriceTag
-									currency={data.product.price.currency}
-									class={data.discount?.mode === 'percentage'
-										? 'text-xl lg:text-2xl line-through text-gray-400'
-										: 'text-2xl lg:text-3xl'}
-									short={!!data.discount}
-									amount={unitPriceWithVat}
-									main
-								/>
-								{#if data.discount?.mode === 'percentage'}
-									{#if data.discount.showBadge !== false}
+							<!-- The struck price takes its own line: on a long amount it, the badge and the
+							     real price ran off the side of the card together. -->
+							<div class="flex flex-wrap items-center gap-2">
+								<div
+									class="flex items-center gap-2"
+									class:w-full={data.discount?.mode === 'percentage'}
+								>
+									<PriceTag
+										currency={data.product.price.currency}
+										class={data.discount?.mode === 'percentage'
+											? 'text-xl lg:text-2xl line-through text-gray-400'
+											: 'text-2xl lg:text-3xl'}
+										short={!!data.discount}
+										amount={unitPriceWithVat}
+										main
+									/>
+									{#if data.discount?.mode === 'percentage' && data.discount.showBadge !== false}
 										<span
 											class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
 											>-{data.discount.percentage}%</span
 										>
 									{/if}
+								</div>
+								{#if data.discount?.mode === 'percentage'}
 									<PriceTag
 										currency={data.product.price.currency}
 										class="text-2xl lg:text-3xl"
@@ -704,23 +711,30 @@
 							<span class="text-sm mt-1"
 								>{t('product.vatExcludedEstimate')} ({t('cart.vat')} {vatRate}%)</span
 							>
-							<div class="flex items-center gap-2">
-								<PriceTag
-									currency={data.product.price.currency}
-									class={data.discount?.mode === 'percentage'
-										? 'text-base line-through text-gray-400'
-										: 'text-lg'}
-									short={!!data.discount}
-									amount={unitPrice}
-									main
-								/>
-								{#if data.discount?.mode === 'percentage'}
-									{#if data.discount.showBadge !== false}
+							<!-- The struck price takes its own line: on a long amount it, the badge and the
+							     real price ran off the side of the card together. -->
+							<div class="flex flex-wrap items-center gap-2">
+								<div
+									class="flex items-center gap-2"
+									class:w-full={data.discount?.mode === 'percentage'}
+								>
+									<PriceTag
+										currency={data.product.price.currency}
+										class={data.discount?.mode === 'percentage'
+											? 'text-base line-through text-gray-400'
+											: 'text-lg'}
+										short={!!data.discount}
+										amount={unitPrice}
+										main
+									/>
+									{#if data.discount?.mode === 'percentage' && data.discount.showBadge !== false}
 										<span
 											class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
 											>-{data.discount.percentage}%</span
 										>
 									{/if}
+								</div>
+								{#if data.discount?.mode === 'percentage'}
 									<PriceTag
 										currency={data.product.price.currency}
 										class="text-lg"
@@ -742,21 +756,27 @@
 					{@const showStrikeThrough =
 						data.discount?.mode === 'percentage' && data.discount.showBadge !== false}
 					<div class="flex flex-col gap-1 lg:items-start">
-						<div class="flex items-baseline gap-3">
-							<PriceTag
-								currency={data.product.price.currency}
-								class="text-2xl lg:text-4xl truncate max-w-full {showStrikeThrough
-									? 'line-through text-gray-400'
-									: ''}"
-								short={showStrikeThrough}
-								amount={unitPrice}
-								main
-							/>
+						<!-- Same reason as above: the struck price gets its own line rather than sharing
+						     one with the badge and the real price. -->
+						<div class="flex flex-wrap items-baseline gap-3">
+							<div class="flex items-baseline gap-3" class:w-full={showStrikeThrough}>
+								<PriceTag
+									currency={data.product.price.currency}
+									class="text-2xl lg:text-4xl truncate max-w-full {showStrikeThrough
+										? 'line-through text-gray-400'
+										: ''}"
+									short={showStrikeThrough}
+									amount={unitPrice}
+									main
+								/>
+								{#if showStrikeThrough}
+									<span
+										class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+										>-{data.discount?.mode === 'percentage' ? data.discount.percentage : 0}%</span
+									>
+								{/if}
+							</div>
 							{#if showStrikeThrough}
-								<span
-									class="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
-									>-{data.discount?.mode === 'percentage' ? data.discount.percentage : 0}%</span
-								>
 								<PriceTag
 									currency={data.product.price.currency}
 									class="text-2xl lg:text-4xl truncate max-w-full"

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -641,14 +641,19 @@
 						<!-- svelte-ignore a11y-click-events-have-key-events -->
 						<!-- svelte-ignore a11y-no-static-element-interactions -->
 						<div
-							class="flex flex-col gap-1 cursor-pointer"
-							on:click={() => (showExclTax = !showExclTax)}
+							class="flex flex-col gap-1"
+							class:cursor-pointer={!data.vatExempted}
+							on:click={() => (showExclTax = !data.vatExempted && !showExclTax)}
 						>
-							<span class="text-sm"
-								>{t('product.vatIncluded')} ({t('cart.vat')}
-								{vatRate}%)
-								<span class="text-gray-400 text-xs ml-1">{showExclTax ? '▲' : '▼'}</span></span
-							>
+							<!-- A shop with VAT turned off has nothing to say about it: no rate, no caption,
+							     and no toggle to a breakdown that would be empty. -->
+							{#if !data.vatExempted}
+								<span class="text-sm"
+									>{t('product.vatIncluded')} ({t('cart.vat')}
+									{vatRate}%)
+									<span class="text-gray-400 text-xs ml-1">{showExclTax ? '▲' : '▼'}</span></span
+								>
+							{/if}
 							<div class="flex items-center gap-2">
 								<PriceTag
 									currency={data.product.price.currency}
@@ -699,7 +704,7 @@
 							/>
 						</div>
 
-						{#if showExclTax}
+						{#if showExclTax && !data.vatExempted}
 							<hr class="border-gray-400 mt-2 w-full" />
 							<span class="text-sm mt-1"
 								>{t('product.vatExcludedEstimate')} ({t('cart.vat')} {vatRate}%)</span
@@ -788,7 +793,9 @@
 							secondary
 							class="text-base"
 						/>
-						<span class="font-semibold text-sm">{t('product.vatExcluded')}</span>
+						{#if !data.vatExempted}
+							<span class="font-semibold text-sm">{t('product.vatExcluded')}</span>
+						{/if}
 					</div>
 				{/if}
 

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -8,7 +8,7 @@
 	import { applyAction, enhance } from '$app/forms';
 	import IconInfo from '$lib/components/icons/IconInfo.svelte';
 	import { productAddedToCart } from '$lib/stores/productAddedToCart';
-	import { invalidate } from '$app/navigation';
+	import { invalidate, invalidateAll } from '$app/navigation';
 	import { UrlDependency } from '$lib/types/UrlDependency';
 	import {
 		DEFAULT_MAX_QUANTITY_PER_ORDER,
@@ -31,6 +31,7 @@
 		subMinutes
 	} from 'date-fns';
 	import { useI18n } from '$lib/i18n';
+	import { cartErrorKey } from '$lib/cartErrorKey';
 	import CmsDesign from '$lib/components/CmsDesign.svelte';
 	import {
 		FRACTION_DIGITS_PER_CURRENCY,
@@ -217,10 +218,20 @@
 
 	$: isPreorder = isPreorderFn(data.product.availableDate, data.product.preorder);
 
+	// The server answers every reason the product cannot be added — login, whitelist, per-person
+	// cap, per-order cap, stock — in one list. The page states that list; it no longer holds a
+	// second copy of any of those rules.
+	$: quantityAlreadyInCart = data.cart.items
+		.filter((item) => item.product._id === data.product._id)
+		.reduce((total, item) => total + item.quantity, 0);
+
 	$: amountAvailable = Math.max(
 		Math.min(
-			data.product.stock?.available ?? Infinity,
-			data.product.maxQuantityPerOrder || DEFAULT_MAX_QUANTITY_PER_ORDER
+			(data.product.stock?.available ?? Infinity) - quantityAlreadyInCart,
+			(data.product.maxQuantityPerOrder || DEFAULT_MAX_QUANTITY_PER_ORDER) - quantityAlreadyInCart,
+			// What this person may still take. Offering more than this made the picker propose a
+			// quantity the cart was bound to refuse.
+			(data.maxPerUserRemaining ?? Infinity) - quantityAlreadyInCart
 		),
 		0
 	);
@@ -918,10 +929,17 @@
 								if (result.type === 'error') {
 									const code = result.error.code;
 									const params = result.error.params ?? {};
-									errorMessage =
-										code && te(`cart.error.${code}`)
-											? t(`cart.error.${code}`, params)
-											: result.error.message;
+									const key = code ? cartErrorKey(code) : undefined;
+									errorMessage = key && te(key) ? t(key, params) : result.error.message;
+									return;
+								}
+
+								// A sale lock comes back as a typed failure. Reloading is enough to state it: the
+								// page asks the evaluator on every load, so the reason appears and the button
+								// greys out on its own. What matters here is not announcing a product that never
+								// entered the cart.
+								if (result.type === 'failure') {
+									await invalidateAll();
 									return;
 								}
 
@@ -1183,7 +1201,24 @@
 									{t('ageWarning.agreement')}
 								</label>
 							{/if}
-							{#if amountAvailable === 0}
+							{#if data.saleLocks?.length}
+								{#each data.saleLocks as lock}
+									<p class="text-red-500">{t(cartErrorKey(lock.code), lock.params ?? {})}</p>
+								{/each}
+								<button class="btn body-cta body-mainCTA" disabled>
+									{t(`product.cta.${verb}`)}
+								</button>
+								{#if data.saleLocks.some((lock) => lock.code === 'LOGIN_REQUIRED')}
+									<a
+										href="/login"
+										target="_blank"
+										rel="noopener"
+										class="btn body-cta body-secondaryCTA text-center"
+									>
+										{t('saleLock.login')}
+									</a>
+								{/if}
+							{:else if amountAvailable === 0}
 								<p class="text-red-500">
 									<span class="font-bold">{t('product.outOfStock')}</span>
 									<br />

--- a/src/routes/(app)/searchlist/[slug]/+page.server.ts
+++ b/src/routes/(app)/searchlist/[slug]/+page.server.ts
@@ -35,6 +35,7 @@ export const load = async ({ params, url, locals }) => {
 		bebopCountry: runtimeConfig.vatCountry,
 		userCountry: locals.countryCode,
 		vatSingleCountry: runtimeConfig.vatSingleCountry,
+		vatExempted: runtimeConfig.vatExempted,
 		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
 	};
 
@@ -97,6 +98,7 @@ export const load = async ({ params, url, locals }) => {
 		totalPages,
 		allowedTags,
 		basePath: `/searchlist/${params.slug}`,
+		vatExempted: runtimeConfig.vatExempted,
 		displayVatIncluded: runtimeConfig.displayVatIncludedInProduct
 	};
 };


### PR DESCRIPTION
Release branch for the S37 demo: `main` plus the three branches below, merged in that order and type-checked together.

**#2748 — Honour "Disable VAT for my be-BOP" everywhere a rate is shown (#2649).** A shop with VAT turned off no longer shows a rate on the product page, in search lists or on the point-of-sale tab.

**#2749 — Let a customer subscribe and buy the discounted product in one order (#2718).** A subscription product can now be one of the required products of a discount combination, so a new customer subscribes and buys the discounted product in the same order instead of subscribing, logging back in, and coming back.

**#2763 — Sales locks: whitelist, per-person cap and authentication (#2143, #2756, #2759).** Three ways to reserve a product to certain customers, built as one mechanism: require the buyer to be logged in, restrict ordering to a whitelist, or cap how many units the same person may take across all their orders. Customers are turned away before they click, on the product page, in widgets and in the cart.

Nothing here changes a shop that uses none of these settings.
