### PR TITLE
🆕🤖 Filter orders on the custom checkout fields they collected (#2772)

### DIFF
--- a/src/lib/server/checkoutFields.ts
+++ b/src/lib/server/checkoutFields.ts
@@ -10,6 +10,17 @@ import type {
 } from '$lib/types/CheckoutFieldConfig';
 import type { CollectedCheckoutField } from '$lib/types/Order';
 
+/**
+ * Every checkout field the shop has defined, disabled ones included.
+ *
+ * Disabling a field stops it being asked at checkout; it does not erase the answers already
+ * collected. A screen that searches past orders therefore needs the whole list, or the orders
+ * carrying a retired field become unreachable.
+ */
+export function loadAllCheckoutFields() {
+	return collections.checkoutFieldConfigs.find({}).sort({ sortOrder: 1 }).toArray();
+}
+
 export function loadEnabledCheckoutFields() {
 	return collections.checkoutFieldConfigs
 		.find({ disabled: { $ne: true } })

--- a/src/lib/translations/de.json
+++ b/src/lib/translations/de.json
@@ -40,6 +40,12 @@
 				"noReference": "-- Keine Referenz (eigenen Lagerbestand verwenden) --",
 				"warning": "⚠️ Dieses Produkt verweist auf den Lagerbestand eines anderen Produkts. Lagerbestandsänderungen wirken sich auf das referenzierte Produkt aus."
 			}
+		},
+		"order": {
+			"customFieldFilterLabel": "Benutzerdefiniertes Checkout-Feld",
+			"customFieldValueLabel": "Feldwert",
+			"customFieldValuePlaceholder": "den zu filternden Wert eingeben",
+			"customFieldDisabled": "deaktiviert"
 		}
 	},
 	"ageWarning": {
@@ -1004,11 +1010,26 @@
 			"then": "dann"
 		},
 		"pricingScheduleUnit": {
-			"hour": { "one": "Stunde", "other": "Stunden" },
-			"day": { "one": "Tag", "other": "Tage" },
-			"week": { "one": "Woche", "other": "Wochen" },
-			"month": { "one": "Monat", "other": "Monate" },
-			"year": { "one": "Jahr", "other": "Jahre" }
+			"hour": {
+				"one": "Stunde",
+				"other": "Stunden"
+			},
+			"day": {
+				"one": "Tag",
+				"other": "Tage"
+			},
+			"week": {
+				"one": "Woche",
+				"other": "Wochen"
+			},
+			"month": {
+				"one": "Monat",
+				"other": "Monate"
+			},
+			"year": {
+				"one": "Jahr",
+				"other": "Jahre"
+			}
 		},
 		"type": {
 			"deposit": "Auf Anzahlung",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -40,6 +40,12 @@
 				"noReference": "-- No reference (use own stock) --",
 				"warning": "⚠️ This product references another product's stock. Stock changes will affect the referenced product."
 			}
+		},
+		"order": {
+			"customFieldFilterLabel": "Custom checkout field",
+			"customFieldValueLabel": "Field value",
+			"customFieldValuePlaceholder": "type the value to filter on",
+			"customFieldDisabled": "disabled"
 		}
 	},
 	"ageWarning": {
@@ -1004,11 +1010,26 @@
 			"then": "then"
 		},
 		"pricingScheduleUnit": {
-			"hour": { "one": "hour", "other": "hours" },
-			"day": { "one": "day", "other": "days" },
-			"week": { "one": "week", "other": "weeks" },
-			"month": { "one": "month", "other": "months" },
-			"year": { "one": "year", "other": "years" }
+			"hour": {
+				"one": "hour",
+				"other": "hours"
+			},
+			"day": {
+				"one": "day",
+				"other": "days"
+			},
+			"week": {
+				"one": "week",
+				"other": "weeks"
+			},
+			"month": {
+				"one": "month",
+				"other": "months"
+			},
+			"year": {
+				"one": "year",
+				"other": "years"
+			}
 		},
 		"type": {
 			"deposit": "On deposit",

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -40,6 +40,12 @@
 				"noReference": "-- Sin referencia (usar stock propio) --",
 				"warning": "⚠️ Este producto referencia el stock de otro producto. Los cambios de stock afectarán al producto referenciado."
 			}
+		},
+		"order": {
+			"customFieldFilterLabel": "Campo de checkout personalizado",
+			"customFieldValueLabel": "Valor del campo",
+			"customFieldValuePlaceholder": "escribe el valor a filtrar",
+			"customFieldDisabled": "desactivado"
 		}
 	},
 	"ageWarning": {
@@ -1004,11 +1010,26 @@
 			"then": "luego"
 		},
 		"pricingScheduleUnit": {
-			"hour": { "one": "hora", "other": "horas" },
-			"day": { "one": "día", "other": "días" },
-			"week": { "one": "semana", "other": "semanas" },
-			"month": { "one": "mes", "other": "meses" },
-			"year": { "one": "año", "other": "años" }
+			"hour": {
+				"one": "hora",
+				"other": "horas"
+			},
+			"day": {
+				"one": "día",
+				"other": "días"
+			},
+			"week": {
+				"one": "semana",
+				"other": "semanas"
+			},
+			"month": {
+				"one": "mes",
+				"other": "meses"
+			},
+			"year": {
+				"one": "año",
+				"other": "años"
+			}
 		},
 		"type": {
 			"deposit": "En depósito",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -40,6 +40,12 @@
 				"noReference": "-- Pas de référence (utiliser le stock propre) --",
 				"warning": "⚠️ Ce produit référence le stock d'un autre produit. Les modifications de stock affecteront le produit référencé."
 			}
+		},
+		"order": {
+			"customFieldFilterLabel": "Champ de checkout personnalisé",
+			"customFieldValueLabel": "Valeur du champ",
+			"customFieldValuePlaceholder": "saisissez la valeur à filtrer",
+			"customFieldDisabled": "désactivé"
 		}
 	},
 	"ageWarning": {
@@ -1004,11 +1010,26 @@
 			"then": "puis"
 		},
 		"pricingScheduleUnit": {
-			"hour": { "one": "heure", "other": "heures" },
-			"day": { "one": "jour", "other": "jours" },
-			"week": { "one": "semaine", "other": "semaines" },
-			"month": { "one": "mois", "other": "mois" },
-			"year": { "one": "an", "other": "ans" }
+			"hour": {
+				"one": "heure",
+				"other": "heures"
+			},
+			"day": {
+				"one": "jour",
+				"other": "jours"
+			},
+			"week": {
+				"one": "semaine",
+				"other": "semaines"
+			},
+			"month": {
+				"one": "mois",
+				"other": "mois"
+			},
+			"year": {
+				"one": "an",
+				"other": "ans"
+			}
 		},
 		"type": {
 			"deposit": "Sur acompte",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -40,6 +40,12 @@
 				"noReference": "-- Nessun riferimento (usa stock proprio) --",
 				"warning": "⚠️ Questo prodotto fa riferimento allo stock di un altro prodotto. Le modifiche allo stock influenzeranno il prodotto di riferimento."
 			}
+		},
+		"order": {
+			"customFieldFilterLabel": "Campo di checkout personalizzato",
+			"customFieldValueLabel": "Valore del campo",
+			"customFieldValuePlaceholder": "digita il valore da filtrare",
+			"customFieldDisabled": "disattivato"
 		}
 	},
 	"ageWarning": {
@@ -1004,11 +1010,26 @@
 			"then": "poi"
 		},
 		"pricingScheduleUnit": {
-			"hour": { "one": "ora", "other": "ore" },
-			"day": { "one": "giorno", "other": "giorni" },
-			"week": { "one": "settimana", "other": "settimane" },
-			"month": { "one": "mese", "other": "mesi" },
-			"year": { "one": "anno", "other": "anni" }
+			"hour": {
+				"one": "ora",
+				"other": "ore"
+			},
+			"day": {
+				"one": "giorno",
+				"other": "giorni"
+			},
+			"week": {
+				"one": "settimana",
+				"other": "settimane"
+			},
+			"month": {
+				"one": "mese",
+				"other": "mesi"
+			},
+			"year": {
+				"one": "anno",
+				"other": "anni"
+			}
 		},
 		"type": {
 			"deposit": "In deposito",

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -40,6 +40,12 @@
 				"noReference": "-- Geen verwijzing (gebruik eigen voorraad) --",
 				"warning": "⚠️ Dit product verwijst naar de voorraad van een ander product. Voorraadwijzigingen zullen het gerefereerde product beïnvloeden."
 			}
+		},
+		"order": {
+			"customFieldFilterLabel": "Aangepast checkout-veld",
+			"customFieldValueLabel": "Veldwaarde",
+			"customFieldValuePlaceholder": "typ de waarde om op te filteren",
+			"customFieldDisabled": "uitgeschakeld"
 		}
 	},
 	"ageWarning": {
@@ -1004,11 +1010,26 @@
 			"then": "dan"
 		},
 		"pricingScheduleUnit": {
-			"hour": { "one": "uur", "other": "uur" },
-			"day": { "one": "dag", "other": "dagen" },
-			"week": { "one": "week", "other": "weken" },
-			"month": { "one": "maand", "other": "maanden" },
-			"year": { "one": "jaar", "other": "jaar" }
+			"hour": {
+				"one": "uur",
+				"other": "uur"
+			},
+			"day": {
+				"one": "dag",
+				"other": "dagen"
+			},
+			"week": {
+				"one": "week",
+				"other": "weken"
+			},
+			"month": {
+				"one": "maand",
+				"other": "maanden"
+			},
+			"year": {
+				"one": "jaar",
+				"other": "jaar"
+			}
 		},
 		"type": {
 			"deposit": "Op borg",

--- a/src/lib/translations/pt.json
+++ b/src/lib/translations/pt.json
@@ -40,6 +40,12 @@
 				"noReference": "-- Sem referência (usar stock próprio) --",
 				"warning": "⚠️ Este produto referencia o stock de outro produto. As alterações de stock afetarão o produto referenciado."
 			}
+		},
+		"order": {
+			"customFieldFilterLabel": "Campo de checkout personalizado",
+			"customFieldValueLabel": "Valor do campo",
+			"customFieldValuePlaceholder": "escreva o valor a filtrar",
+			"customFieldDisabled": "desativado"
 		}
 	},
 	"ageWarning": {
@@ -1004,11 +1010,26 @@
 			"then": "depois"
 		},
 		"pricingScheduleUnit": {
-			"hour": { "one": "hora", "other": "horas" },
-			"day": { "one": "dia", "other": "dias" },
-			"week": { "one": "semana", "other": "semanas" },
-			"month": { "one": "mês", "other": "meses" },
-			"year": { "one": "ano", "other": "anos" }
+			"hour": {
+				"one": "hora",
+				"other": "horas"
+			},
+			"day": {
+				"one": "dia",
+				"other": "dias"
+			},
+			"week": {
+				"one": "semana",
+				"other": "semanas"
+			},
+			"month": {
+				"one": "mês",
+				"other": "meses"
+			},
+			"year": {
+				"one": "ano",
+				"other": "anos"
+			}
 		},
 		"type": {
 			"deposit": "Sob depósito",

--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.server.ts
@@ -1,4 +1,5 @@
 import { collections } from '$lib/server/database';
+import { loadAllCheckoutFields } from '$lib/server/checkoutFields';
 import { paymentMethods } from '$lib/server/payment-methods';
 import { COUNTRY_ALPHA2S } from '$lib/types/Country.js';
 import { type Order, ORDER_PAGINATION_LIMIT } from '$lib/types/Order';
@@ -25,6 +26,15 @@ export async function load({ url, locals }) {
 
 	const searchParams = Object.fromEntries(url.searchParams.entries());
 	const result = querySchema.parse(searchParams);
+
+	// Read before the single-value parse above would flatten them: a filter row is a (slug, value)
+	// pair, and there can be several. Rows are paired by position, and an empty value drops its row
+	// rather than matching every order that carries the field.
+	const customFieldSlugs = url.searchParams.getAll('customFieldSlug');
+	const customFieldValues = url.searchParams.getAll('customFieldValue');
+	const customFieldFilters = customFieldSlugs
+		.map((slug, index) => ({ slug: slug.trim(), value: (customFieldValues[index] ?? '').trim() }))
+		.filter((filter) => filter.slug && filter.value);
 	const {
 		skip,
 		orderNumber,
@@ -64,6 +74,14 @@ export async function load({ url, locals }) {
 	if (label) {
 		query['orderLabelIds'] = label;
 	}
+	if (customFieldFilters.length) {
+		// One $elemMatch per row: two filters must be satisfied by two different entries of the
+		// array, which a flat 'customCheckoutFields.slug' + '.value' pair would not guarantee.
+		query.$and = customFieldFilters.map((filter) => ({
+			customCheckoutFields: { $elemMatch: { slug: filter.slug, value: filter.value } }
+		}));
+	}
+
 	if (employeeAlias === 'System') {
 		query['user.userAlias'] = { $exists: false };
 	} else if (employeeAlias) {
@@ -81,6 +99,7 @@ export async function load({ url, locals }) {
 		.find({})
 		.sort({ sortOrder: 1 })
 		.toArray();
+	const checkoutFields = await loadAllCheckoutFields();
 	const nonCustomers = await collections.users
 		.find({ roleId: { $ne: CUSTOMER_ROLE_ID } })
 		.sort({ _id: 1 })
@@ -114,6 +133,12 @@ export async function load({ url, locals }) {
 			alias: user.alias
 		})),
 		posSubtype,
-		posSubtypes: posSubtypes.map((s) => ({ slug: s.slug, name: s.name }))
+		posSubtypes: posSubtypes.map((s) => ({ slug: s.slug, name: s.name })),
+		checkoutFields: checkoutFields.map((field) => ({
+			slug: field.slug,
+			label: field.label,
+			disabled: !!field.disabled
+		})),
+		customFieldFilters
 	};
 }

--- a/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/order/+page.svelte
@@ -8,6 +8,23 @@
 	let next = 0;
 	let selectedPaymentMethod = $page.url.searchParams.get('paymentMethod') ?? '';
 
+	// One row per custom checkout field to filter on. Restored from the URL so a bookmarked or
+	// shared search comes back with its rows, and never empty: the first row is the invitation.
+	let customFieldFilters: Array<{ slug: string; value: string }> = data.customFieldFilters.length
+		? data.customFieldFilters.map((filter) => ({ ...filter }))
+		: [{ slug: '', value: '' }];
+
+	function addCustomFieldFilter() {
+		customFieldFilters = [...customFieldFilters, { slug: '', value: '' }];
+	}
+
+	function removeCustomFieldFilter(index: number) {
+		customFieldFilters = customFieldFilters.filter((_, i) => i !== index);
+		if (!customFieldFilters.length) {
+			customFieldFilters = [{ slug: '', value: '' }];
+		}
+	}
+
 	const { t, countryName, sortedCountryCodes } = useI18n();
 </script>
 
@@ -114,6 +131,48 @@
 			<a href="/admin/order" class="btn body-mainCTA">🧹</a>
 		</label>
 	</div>
+	{#if data.checkoutFields.length}
+		<div class="flex flex-col gap-2">
+			{#each customFieldFilters as filter, index}
+				<div class="gap-4 flex flex-col md:flex-row md:flex-wrap md:items-end">
+					<label class="form-label w-[15em]">
+						{t('admin.order.customFieldFilterLabel')}
+						<select name="customFieldSlug" class="form-input" bind:value={filter.slug}>
+							<option value="" />
+							{#each data.checkoutFields as field}
+								<option value={field.slug}
+									>{field.label}{field.disabled
+										? ` (${t('admin.order.customFieldDisabled')})`
+										: ''}</option
+								>
+							{/each}
+						</select>
+					</label>
+					<label class="form-label w-[15em]">
+						{t('admin.order.customFieldValueLabel')}
+						<input
+							class="form-input"
+							type="text"
+							name="customFieldValue"
+							bind:value={filter.value}
+							placeholder={t('admin.order.customFieldValuePlaceholder')}
+						/>
+					</label>
+					<label class="form-label w-auto flex flex-row gap-2">
+						<button type="button" class="btn body-mainCTA" on:click={addCustomFieldFilter}>+</button
+						>
+						{#if customFieldFilters.length > 1}
+							<button
+								type="button"
+								class="btn body-secondaryCTA"
+								on:click={() => removeCustomFieldFilter(index)}>-</button
+							>
+						{/if}
+					</label>
+				</div>
+			{/each}
+		</div>
+	{/if}
 	<OrdersList orders={data.orders} adminPrefix={data.adminPrefix} orderLabels={data.labels} />
 	<div class="no-sticky flex gap-2">
 		<input type="hidden" value={next} name="skip" />


### PR DESCRIPTION
The order list could be narrowed by number, product, payment method, country, email, npub, label, seller and payment subtype — but not by what the shop asks its own customers at checkout, so finding the order that carries a given wristband id or table number meant reading the list by hand.

The list now takes as many custom-field filters as needed. Each row picks one of the shop's checkout fields from a dropdown and takes the value to look for, typed rather than picked: the values a field has collected are not proposed. Several rows narrow together, each one matched against its own field.

Fixes #2772
